### PR TITLE
#38878 On logout, manually expire cookies

### DIFF
--- a/GenderPayGap.IdentityServer4/Controllers/AccountController.cs
+++ b/GenderPayGap.IdentityServer4/Controllers/AccountController.cs
@@ -287,7 +287,17 @@ namespace GenderPayGap.IdentityServer4.Controllers
             if (User?.Identity.IsAuthenticated == true)
             {
                 // delete local authentication cookie
-                await HttpContext.SignOutAsync();
+                var options = new CookieOptions
+                {
+                    HttpOnly = false,
+                    Secure = true,
+                    Path = "/account",
+                    IsEssential = true,
+                    SameSite = SameSiteMode.Strict,
+                    Expires = DateTimeOffset.UnixEpoch
+                };
+                HttpContext.Response.Cookies.Append("idsrv", "", options);
+                HttpContext.Response.Cookies.Append("idsrv.session", "", options);
 
                 // raise the logout event
                 await _events.RaiseAsync(new UserLogoutSuccessEvent(User.GetSubjectId(), User.GetDisplayName()));


### PR DESCRIPTION
Make sure sign-out still works with Chrome's new cookie settings