### PR TITLE
#37486 Fix SendReminderEmail Function

### DIFF
--- a/GenderPayGap.Core/Classes/Logger/CustomLogger.cs
+++ b/GenderPayGap.Core/Classes/Logger/CustomLogger.cs
@@ -35,6 +35,8 @@ namespace GenderPayGap.Core.Classes.Logger
         {
             try
             {
+                // The logger doesn't use JsonConvert but it is doing something similar
+                // We try to convert values to JSON to see if it will throw an exception
                 JsonConvert.SerializeObject(values);
                 return values == null ? message : message + ". Log: {@Values}";
             }

--- a/GenderPayGap.Core/Classes/Logger/CustomLogger.cs
+++ b/GenderPayGap.Core/Classes/Logger/CustomLogger.cs
@@ -1,4 +1,5 @@
-﻿using Serilog;
+﻿using Newtonsoft.Json;
+using Serilog;
 
 namespace GenderPayGap.Core.Classes.Logger
 {
@@ -32,7 +33,16 @@ namespace GenderPayGap.Core.Classes.Logger
 
         private static string GetLogMessage(string message, object values = null)
         {
-            return values == null ? message : message + ". Log: {@Values}";
+            try
+            {
+                JsonConvert.SerializeObject(values);
+                return values == null ? message : message + ". Log: {@Values}";
+            }
+            catch (JsonSerializationException ex)
+            {
+                Error("SERILOG ERROR: Can't serialize values");
+                throw;
+            }
         }
 
     }

--- a/GenderPayGap.WebJob/Functions/Functions.SendReminderEmails.cs
+++ b/GenderPayGap.WebJob/Functions/Functions.SendReminderEmails.cs
@@ -85,7 +85,7 @@ namespace GenderPayGap.WebJob
                     catch (Exception ex)
                     {
                         CustomLogger.Error(
-                            "Failed whilst sending or saving reminder email.",
+                            "Failed whilst sending or saving reminder email",
                             new
                             {
                                 UserId = user.UserId,


### PR DESCRIPTION
The function would start, successfully send the first email to me (valid email), then fall over on the second one which was an invalid email (Notify smoke test address). This would result in only a single result in the DB.

The problem was with our CustomLogger. I was passing a `User` object, which it then tried to convert to JSON, but it would go and get the associated `UserOrganisations` which would in turn go and get the `User`. This caused the program to hang. This also explains why in the Azure logs we would see the function start but never finish.

I've also taken this opportunity to remove some of the other logging and try/catch blocks. Hopefully making the code more readable.