### PR TITLE
#39257 Speed up Admin Search by caching Organisations and Users in memory

### DIFF
--- a/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
@@ -22,6 +22,8 @@ namespace GenderPayGap.WebUI.Models.Admin
         public double FilteringMilliSeconds { get; set; }
         public double OrderingMilliSeconds { get; set; }
         public double HighlightingMilliSeconds { get; set; }
+        public int SearchCacheUpdatedSecondsAgo { get; set; }
+        public bool UsedCache { get; set; }
 
     }
 

--- a/GenderPayGap.WebUI/Startup.cs
+++ b/GenderPayGap.WebUI/Startup.cs
@@ -159,6 +159,8 @@ namespace GenderPayGap.WebUI
             Global.SubmissionLog = MvcApplication.ContainerIoC.ResolveKeyed<ILogRecordLogger>(Filenames.SubmissionLog);
             Global.SearchLog = MvcApplication.ContainerIoC.ResolveKeyed<ILogRecordLogger>(Filenames.SearchLog);
 
+            AdminSearchService.StartCacheUpdateThread();
+
             // Create the IServiceProvider based on the container.
             return new AutofacServiceProvider(MvcApplication.ContainerIoC);
         }

--- a/GenderPayGap.WebUI/Views/Admin/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/Admin/Search.cshtml
@@ -104,6 +104,12 @@
             Ordering     @(Model.SearchResults.OrderingMilliSeconds)ms
             Highlighting @(Model.SearchResults.HighlightingMilliSeconds)ms
             -->
+            @if (Model.SearchResults.UsedCache)
+            {
+                <p class="govuk-body-s">
+                    Changes made within the last @(Model.SearchResults.SearchCacheUpdatedSecondsAgo) seconds will not be reflected in these results.
+                </p>
+            }
 
             <details class="govuk-details" data-module="govuk-details" open>
                 <summary class="govuk-details__summary">


### PR DESCRIPTION
The search functionality on the admin site is quite slow.
This will become quite irritating during the busy period as the Service Desk need to do lots of searches.
Currently, the search controller loads the full set of organisations and users for each search.
This change periodically loads this data into an efficient in-memory cache.