### PR TITLE
#38815 Allow Service Desk to change an organisation's public sector type

### DIFF
--- a/GenderPayGap.Core/Enums.cs
+++ b/GenderPayGap.Core/Enums.cs
@@ -230,6 +230,8 @@ namespace GenderPayGap.Core
         AdminChangeUserContactPreferences = 6,
         [Display(Name = "Re-send verification email")]
         AdminResendVerificationEmail = 7,
+        [Display(Name = "Change organisation public sector classification")]
+        AdminChangeOrganisationPublicSectorClassification = 8,
     }
 
     public enum HashingAlgorithm

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationSectorController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationSectorController.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Linq;
+using GenderPayGap.Core;
+using GenderPayGap.Core.Interfaces;
+using GenderPayGap.Database;
+using GenderPayGap.Extensions;
+using GenderPayGap.WebUI.Classes;
+using GenderPayGap.WebUI.Models.Admin;
+using GovUkDesignSystem.Parsers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GenderPayGap.WebUI.Controllers.Admin
+{
+    [Authorize(Roles = "GPGadmin")]
+    [Route("admin")]
+    public class AdminOrganisationSectorController : Controller
+    {
+        private readonly IDataRepository dataRepository;
+        private readonly AuditLogger auditLogger;
+
+        public AdminOrganisationSectorController(
+            IDataRepository dataRepository,
+            AuditLogger auditLogger)
+        {
+            this.dataRepository = dataRepository;
+            this.auditLogger = auditLogger;
+        }
+
+        [HttpGet("organisation/{id}/change-public-sector-classification")]
+        public IActionResult ChangePublicSectorClassificationGet(long id)
+        {
+            Organisation organisation = dataRepository.Get<Organisation>(id);
+
+            var viewModel = new AdminChangePublicSectorClassificationViewModel
+            {
+                OrganisationId = organisation.OrganisationId,
+                OrganisationName = organisation.OrganisationName,
+                PublicSectorTypes = dataRepository.GetAll<PublicSectorType>().ToList(),
+                SelectedPublicSectorTypeId = organisation.LatestPublicSectorType?.PublicSectorTypeId
+            };
+
+            return View("ChangePublicSectorClassification", viewModel);
+        }
+
+        [HttpPost("organisation/{id}/change-public-sector-classification")]
+        public IActionResult ChangePublicSectorClassificationPost(long id, AdminChangePublicSectorClassificationViewModel viewModel)
+        {
+            Organisation organisation = dataRepository.Get<Organisation>(id);
+            viewModel.OrganisationId = organisation.OrganisationId;
+            viewModel.OrganisationName = organisation.OrganisationName;
+            viewModel.PublicSectorTypes = dataRepository.GetAll<PublicSectorType>().ToList();
+
+            viewModel.ParseAndValidateParameters(Request, m=> m.Reason);
+
+            if (!viewModel.SelectedPublicSectorTypeId.HasValue)
+            {
+                viewModel.AddErrorFor<AdminChangePublicSectorClassificationViewModel, int?>(
+                    m => m.SelectedPublicSectorTypeId,
+                    "Please select a public sector classification");
+            }
+
+            if (viewModel.HasAnyErrors())
+            {
+                return View("ChangePublicSectorClassification", viewModel);
+            }
+
+            var newPublicSectorType = dataRepository.GetAll<PublicSectorType>()
+                .FirstOrDefault(p => p.PublicSectorTypeId == viewModel.SelectedPublicSectorTypeId.Value);
+            if (newPublicSectorType == null)
+            {
+                throw new ArgumentException($"User selected an invalid PublicSectorType ({viewModel.SelectedPublicSectorTypeId})");
+            }
+
+            AuditChange(viewModel, organisation, newPublicSectorType);
+
+            RetireExistingOrganisationPublicSectorTypesForOrganisation(organisation);
+
+            AddNewOrganisationPublicSectorType(organisation, viewModel.SelectedPublicSectorTypeId.Value);
+
+            dataRepository.SaveChangesAsync().Wait();
+
+            return RedirectToAction("ViewOrganisation", "AdminViewOrganisation", new {id = organisation.OrganisationId});
+        }
+
+        private void AuditChange(
+            AdminChangePublicSectorClassificationViewModel viewModel,
+            Organisation organisation,
+            PublicSectorType newPublicSectorType)
+        {
+            auditLogger.AuditChangeToOrganisation(
+                this,
+                AuditedAction.AdminChangeOrganisationPublicSectorClassification,
+                organisation,
+                new
+                {
+                    OldClassification = organisation.LatestPublicSectorType?.PublicSectorType?.Description,
+                    NewClassification = newPublicSectorType.Description,
+                    Reason = viewModel.Reason
+                });
+        }
+
+        private void RetireExistingOrganisationPublicSectorTypesForOrganisation(Organisation organisation)
+        {
+            var organisationPublicSectorTypes = dataRepository.GetAll<OrganisationPublicSectorType>()
+                .Where(opst => opst.OrganisationId == organisation.OrganisationId)
+                .ToList();
+
+            foreach (OrganisationPublicSectorType organisationPublicSectorType in organisationPublicSectorTypes)
+            {
+                organisationPublicSectorType.Retired = VirtualDateTime.Now;
+            }
+        }
+
+        private void AddNewOrganisationPublicSectorType(Organisation organisation, int publicSectorTypeId)
+        {
+            var newOrganisationPublicSectorType = new OrganisationPublicSectorType
+            {
+                OrganisationId = organisation.OrganisationId,
+                PublicSectorTypeId = publicSectorTypeId,
+                Source = "Service Desk"
+            };
+
+            dataRepository.Insert(newOrganisationPublicSectorType);
+
+            organisation.LatestPublicSectorType = newOrganisationPublicSectorType;
+        }
+
+    }
+}

--- a/GenderPayGap.WebUI/Models/Admin/AdminChangePublicSectorClassificationViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/AdminChangePublicSectorClassificationViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using GenderPayGap.Database;
+using GovUkDesignSystem;
+using GovUkDesignSystem.Attributes.ValidationAttributes;
+
+namespace GenderPayGap.WebUI.Models.Admin
+{
+    public class AdminChangePublicSectorClassificationViewModel : GovUkViewModel
+    {
+        public long OrganisationId { get; set; }
+        public string OrganisationName { get; set; }
+
+        public List<PublicSectorType> PublicSectorTypes { get; set; }
+
+        public int? SelectedPublicSectorTypeId { get; set; }
+
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Please enter a reason for this change")]
+        public string Reason { get; set; }
+    }
+}

--- a/GenderPayGap.WebUI/Views/Admin/ViewOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/Admin/ViewOrganisation.cshtml
@@ -145,17 +145,26 @@
         </tr>
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Sector</th>
-            <td class="govuk-table__cell" colspan="2">
+            <td class="govuk-table__cell">
                 @(Model.SectorType)
-                @if (Model.LatestPublicSectorType?.PublicSectorType?.Description != null)
-                {
-                    <br/>
-                    <span>
-                        (@(Model.LatestPublicSectorType.PublicSectorType.Description))
-                    </span>
-                }
             </td>
+            <td class="govuk-table__cell"></td>
         </tr>
+        @if (Model.SectorType == SectorTypes.Public)
+        {
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">Public sector classification</th>
+                <td class="govuk-table__cell">
+                    @(Model.LatestPublicSectorType?.PublicSectorType?.Description ?? "(none)")
+                </td>
+                <td class="govuk-table__cell">
+                    <a href="@Url.Action("ChangePublicSectorClassificationGet", "AdminOrganisationSector", new {id = Model.OrganisationId})"
+                       class="govuk-link">
+                        Change <span class="govuk-visually-hidden">public sector classification</span>
+                    </a>
+                </td>
+            </tr>
+        }
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">SIC codes</th>
             <td class="govuk-table__cell">

--- a/GenderPayGap.WebUI/Views/AdminOrganisationSector/ChangePublicSectorClassification.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationSector/ChangePublicSectorClassification.cshtml
@@ -1,0 +1,115 @@
+﻿@using GenderPayGap.Database
+@using GenderPayGap.WebUI.Models.Admin
+@using GovUkDesignSystem
+@using GovUkDesignSystem.GovUkDesignSystemComponents
+@model GenderPayGap.WebUI.Models.Admin.AdminChangePublicSectorClassificationViewModel
+
+@{
+    ViewBag.Title = $"Change public-sector classification - {Model.OrganisationName} - Administration - Gender pay gap service";
+    Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
+}
+
+@section BeforeMain {
+    @{
+        var crumbs = new List<CrumbViewModel>
+{
+            new CrumbViewModel
+            {
+                Text = "Admin",
+                Href = Url.Action("Home", "Admin")
+            },
+            new CrumbViewModel
+            {
+                Text = Model.OrganisationName,
+                Href = Url.Action("ViewOrganisation", "AdminViewOrganisation", new {id = Model.OrganisationId})
+            },
+            new CrumbViewModel
+            {
+                Text = "Change public-sector classification"
+            }
+        };
+    }
+
+    @(Html.GovUkBreadcrumbs(new BreadcrumbsViewModel
+    {
+        Crumbs = crumbs
+    }))
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-xl">Administration</span>
+        <h1 class="govuk-heading-xl">
+            Change public-sector classification
+            <br />
+            <span class="govuk-!-font-size-27">
+                for @(Model.OrganisationName)
+            </span>
+        </h1>
+
+        @(Html.GovUkErrorSummary())
+
+        
+        <form method="post" action="@Url.Action("ChangePublicSectorClassificationPost", "AdminOrganisationSector", new {id = Model.OrganisationId})">
+            @(Html.AntiForgeryToken())
+
+            @{
+                string error = Model.GetErrorFor<AdminChangePublicSectorClassificationViewModel, int?>(m => m.SelectedPublicSectorTypeId);
+                ErrorMessageViewModel errorMessageViewModel = error != null ? new ErrorMessageViewModel {Text = error} : null;
+            }
+            @(Html.GovUkRadios(new RadiosViewModel
+            {
+                Name = nameof(AdminChangePublicSectorClassificationViewModel.SelectedPublicSectorTypeId),
+                Fieldset = new FieldsetViewModel
+                {
+                    Legend = new LegendViewModel
+                    {
+                        Html = @<text>
+                                   What type of public sector organisation is @(Model.OrganisationName)?
+                                </text>,
+                        Classes = "govuk-fieldset__legend--m"
+                    }
+                },
+                Items = Model.PublicSectorTypes
+                        .Select(publicSectorType =>
+                        {
+                            string fieldName = nameof(AdminChangePublicSectorClassificationViewModel.SelectedPublicSectorTypeId);
+                            int fieldValue = publicSectorType.PublicSectorTypeId;
+                            string fieldId = $"{fieldName}_{fieldValue}";
+
+                            return (ItemViewModel) new RadioItemViewModel
+                            {
+                                Name = fieldName,
+                                Value = fieldValue.ToString(),
+                                Id = fieldId,
+                                Checked = Model.SelectedPublicSectorTypeId == fieldValue,
+                                Label = new LabelViewModel
+                                {
+                                    Text = publicSectorType.Description,
+                                    For = fieldId
+                                }
+                            };
+                        })
+                        .ToList(),
+                ErrorMessage = errorMessageViewModel
+            }))
+            
+            @(Html.GovUkTextAreaFor(
+                m => m.Reason,
+                labelOptions: new LabelViewModel
+                {
+                    Text = "What is the reason for this change?",
+                    Classes = "govuk-label--m"
+                }
+                ))
+
+            @(Html.GovUkButton(new ButtonViewModel
+            {
+                Text = "Confirm and save",
+                Classes = "govuk-!-margin-right-2 govuk-!-margin-bottom-4"
+            }))
+        </form>
+
+    </div>
+</div>

--- a/GovUkDesignSystem/GovUkHtmlHelperExtensions.cs
+++ b/GovUkDesignSystem/GovUkHtmlHelperExtensions.cs
@@ -209,6 +209,13 @@ namespace GovUkDesignSystem
             return htmlHelper.Partial("/GovUkDesignSystemComponents/PhaseBanner.cshtml", phaseBannerViewModel);
         }
 
+        public static IHtmlContent GovUkRadios(
+            this IHtmlHelper htmlHelper,
+            RadiosViewModel radioItemViewModel)
+        {
+            return htmlHelper.Partial("/GovUkDesignSystemComponents/Radios.cshtml", radioItemViewModel);
+        }
+
         public static IHtmlContent GovUkRadiosFor<TModel, TProperty>(
             this IHtmlHelper<TModel> htmlHelper,
             Expression<Func<TModel, TProperty>> propertyLambdaExpression,


### PR DESCRIPTION
Public sector organisations have a Public Sector Type (classification)
e.g. NHS / University / Academy Trust...
All public sector organisations are supposed to have this but, for some, it's missing.
This allow the Service Desk to add / edit this classification