### PR TITLE
#39333 Stop sending Gov.UK/GDS our Google Analytics data from non-production environments

### DIFF
--- a/GenderPayGap.Core/Global.cs
+++ b/GenderPayGap.Core/Global.cs
@@ -137,6 +137,8 @@ namespace GenderPayGap.Core
 
         public static DateTime ActionHubSwitchOverDate => Config.GetAppSetting("ActionHubSwitchOverDate").ToDateTime();
 
+        public static bool SendGoogleAnalyticsDataToGovUk => Config.GetAppSetting("SendGoogleAnalyticsDataToGovUk").ToBoolean();
+
         public static string AzureInstanceId => Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID");
 
         public static void SetupAppInsights()

--- a/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
@@ -66,7 +66,7 @@
     {
         @:sendGpgPageView();
     }
-    @if (cookieSettings.GoogleAnalyticsGovUk)
+    @if (cookieSettings.GoogleAnalyticsGovUk && Global.SendGoogleAnalyticsDataToGovUk)
     {
         @:sendGovUkPageView();
     }

--- a/GenderPayGap.WebUI/appsettings.PROD.json
+++ b/GenderPayGap.WebUI/appsettings.PROD.json
@@ -7,6 +7,7 @@
   "DisablePageCaching": "false",
   "Debug": "false",
   "FirstReportingYear": "2017",
+  "SendGoogleAnalyticsDataToGovUk": "true",
   "StartUrl": "https://www.gov.uk/report-gender-pay-gap-data",
   "TESTING-SkipSpamProtection": "false",
   "TrustedIPDomains": "",

--- a/GenderPayGap.WebUI/appsettings.json
+++ b/GenderPayGap.WebUI/appsettings.json
@@ -240,6 +240,7 @@
   "SecurityCodeChars": "123456789ABCDEFGHKLMNPQRSTUXYZ",
   "SecurityCodeExpiryDays": "90",
   "SecurityCodeLength": "8",
+  "SendGoogleAnalyticsDataToGovUk": "false",
   "SessionTimeOut": null,
   "StartUrl": null,
   "StickySessions": null,


### PR DESCRIPTION
We send Google Analytics data to GDS / Gov.UK
They have asked us to stop sending them data from our non-production environments.
This change fixes that problem.