### PR TITLE
AB#39420 Fix page titles

### DIFF
--- a/GenderPayGap.WebUI/Views/ActionHub1/Effective.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub1/Effective.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GenderPayGap.WebUI.Models.Shared
 @{
+    ViewBag.Title = "Actions to close the gap - GOV.UK";
     Layout = "Index.cshtml";
     var index = 1;
 }

--- a/GenderPayGap.WebUI/Views/ActionHub1/MixedResult.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub1/MixedResult.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GenderPayGap.WebUI.Models.Shared
 @{
+    ViewBag.Title = "Actions to close the gap - GOV.UK";
     Layout = "Index.cshtml";
     var index = 1;
 }

--- a/GenderPayGap.WebUI/Views/ActionHub1/Overview.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub1/Overview.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GenderPayGap.WebUI.Models.Shared
 @{
+    ViewBag.Title = "Actions to close the gap - GOV.UK";   
     Layout = "Index.cshtml";
 }
 

--- a/GenderPayGap.WebUI/Views/ActionHub1/Promising.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub1/Promising.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GenderPayGap.WebUI.Models.Shared
 @{
+    ViewBag.Title = "Actions to close the gap - GOV.UK";
     Layout = "Index.cshtml";
     var index = 1;
 }

--- a/GenderPayGap.WebUI/Views/ActionHub2/Hiring.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub2/Hiring.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    ViewBag.Title = "Hiring and selection actions to close the gender pay gap - GOV.UK";    
+    ViewBag.pageDescription = "Find the most effective hiring and selection actions to close the gender pay gap";
     Layout = "Index.cshtml";
 }
 

--- a/GenderPayGap.WebUI/Views/ActionHub2/Leadership.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub2/Leadership.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    ViewBag.Title = "Leadership and accountability actions to close the gender pay gap - GOV.UK";   
+    ViewBag.pageDescription = "Find the most effective leadership and accountability actions to close the gender pay gap";
     Layout = "Index.cshtml";
     var index = 1;
 }

--- a/GenderPayGap.WebUI/Views/ActionHub2/Overview.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub2/Overview.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    ViewBag.Title = "";   
+    ViewBag.pageDescription = "Find out how employers can close the gender pay gap. See the evidence and download our 'What Works' Guide";
     Layout = "Index.cshtml";
 }
 

--- a/GenderPayGap.WebUI/Views/ActionHub2/Reading.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub2/Reading.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    ViewBag.Title = "Further reading on how to close the gap - GOV.UK";   
+    ViewBag.pageDescription = "Find out more about closing the gender pay gap";
     Layout = "Index.cshtml";
 }
 

--- a/GenderPayGap.WebUI/Views/ActionHub2/Talent.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub2/Talent.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    ViewBag.Title = "Talent management, learning and development actions to close the gender pay gap - GOV.UK";   
+    ViewBag.pageDescription = "Find the most effective talent management, learning and development actions to close the gender pay gap";
     Layout = "Index.cshtml";
 }
 

--- a/GenderPayGap.WebUI/Views/ActionHub2/Workplace.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub2/Workplace.cshtml
@@ -1,4 +1,6 @@
 ﻿@{
+    ViewBag.Title = "Workplace flexibility actions to close the gender pay gap - GOV.UK";   
+    ViewBag.pageDescription = "Find out how workplace flexibility can help close the gender pay gap";
     Layout = "Index.cshtml";
     var index = 1;
 }

--- a/GenderPayGap.WebUI/Views/Compare/CompareEmployers.cshtml
+++ b/GenderPayGap.WebUI/Views/Compare/CompareEmployers.cshtml
@@ -1,6 +1,6 @@
 ﻿@model CompareViewModel
 @{
-    ViewBag.Title = "Gender pay gap: Employer comparison";
+    ViewBag.Title = "Select and compare gender pay gap data for employers - GOV.UK";
     string backUrl = string.IsNullOrWhiteSpace(Model.LastSearchUrl) ? "/" : Model.LastSearchUrl;
 }
 

--- a/GenderPayGap.WebUI/Views/Organisation/ManageOrganisations.cshtml
+++ b/GenderPayGap.WebUI/Views/Organisation/ManageOrganisations.cshtml
@@ -3,7 +3,7 @@
 @using GenderPayGap.Database
 @model IEnumerable<GenderPayGap.Database.UserOrganisation>
 @{
-    ViewBag.Title = "Manage your organisation - Gender pay gap reporting service";
+    ViewBag.Title = "Manage your organisation - Gender pay gap reporting service - GOV.UK";
     var controller = ViewData["Controller"] as BaseController;
     bool hasRegisteredOrgs = Model.Any();
 }

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -8,8 +8,8 @@
     ViewBag.EmployerName = Model.Organisation.OrganisationName;
 
     Organisation organisation = Model.Organisation;
-    ViewBag.Title = organisation.OrganisationName + " Details";
-    ViewBag.pageDescription = "View gender pay gap details for " + organisation.OrganisationName;
+    ViewBag.Title = $"Gender pay gap for {organisation.OrganisationName} - GOV.UK";
+    ViewBag.pageDescription = $"View gender pay gap details for {organisation.OrganisationName} and compare with other organisations";
     ViewBag.ogTitle = ViewBag.Title;
     ViewBag.ogType = "business.gender_pay_gap";
     ViewBag.pageClass = "employer-report-page";

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Report.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Report.cshtml
@@ -9,8 +9,8 @@
     ViewBag.EndYear = (Model.AccountingDate.Year + 1).ToTwoDigitYear();
 
 
-    ViewBag.Title = Model.OrganisationName + " gender pay gap data" + " / " + Model.AccountingDate.Year + "-" + (Model.AccountingDate.Year + 1).ToTwoDigitYear();
-    ViewBag.pageDescription = $"View {Model.AccountingDate.Year} gender pay gap data for {Model.OrganisationName}";
+    ViewBag.Title = $"{Model.OrganisationName} gender pay gap data for {Model.AccountingDate.Year}-{(Model.AccountingDate.Year + 1).ToTwoDigitYear()} reporting year - GOV.UK";
+    ViewBag.pageDescription = $"View gender pay gap data for {Model.OrganisationName} for {Model.AccountingDate.Year}-{(Model.AccountingDate.Year + 1).ToTwoDigitYear()} reporting year and compare with other organisations";
     ViewBag.ogTitle = ViewBag.Title;
     ViewBag.ogType = "business.gender_pay_gap";
     ViewBag.pageClass = "employer-report-page";

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -1,7 +1,7 @@
 ﻿@model GenderPayGap.WebUI.Models.Search.SearchViewModel
 @{
-    ViewBag.Title = "Gender pay gap search results";
-    ViewBag.pageDescription = "Employers that have published their gender pay gap data.";
+    ViewBag.Title = "Search for an employer's gender pay gap report - GOV.UK";
+    ViewBag.pageDescription = "Search for an employer by name or type to view their gender pay gap data";
     if (string.IsNullOrWhiteSpace(ViewBag.ReturnUrl))
     {
         ViewBag.ReturnUrl = Context.GetUri().PathAndQuery;

--- a/GenderPayGap.WebUI/Views/Viewing/Launchpad/Index.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Launchpad/Index.cshtml
@@ -1,6 +1,6 @@
 @using GenderPayGap.Core
 @{
-    ViewBag.Title = "Gender pay gap data";
+    ViewBag.Title = "Search and compare gender pay gap data - GOV.UK";
     ViewBag.pageDescription = "Find and compare gender pay gap information reported by employers. Learn more about the gender pay gap and how to close it.";
     ViewBag.pageClass = "landing-page";
     var controller = ViewData["Controller"] as ViewingController;


### PR DESCRIPTION
When the sitemap was removed it broke some of the old page titles and descriptions.

I looked up what the titles should be and added them directly to the cshtml files