### PR TITLE
AB#38745 Remove unused PINHash property from UserOrganisation

### DIFF
--- a/GenderPayGap.Database.Models/UserOrganisation.cs
+++ b/GenderPayGap.Database.Models/UserOrganisation.cs
@@ -16,7 +16,6 @@ namespace GenderPayGap.Database
         public long UserId { get; set; }
         public long OrganisationId { get; set; }
         public string PIN { get; set; }
-        public string PINHash { get; set; }
         public DateTime? PINSentDate { get; set; }
         public string PITPNotifyLetterId { get; set; }
         public DateTime? PINConfirmedDate { get; set; }

--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -504,9 +504,6 @@ namespace GenderPayGap.Database
                     entity.HasIndex(e => e.UserId)
                         .HasName("IX_UserId");
 
-                    entity.Property(e => e.PINHash)
-                        .HasMaxLength(250);
-
                     entity.Property(e => e.Method).HasColumnName("MethodId").HasDefaultValueSql("((0))");
 
                     entity.HasOne(d => d.Address)

--- a/GenderPayGap.Database/Migrations/20200207093155_RemovePINHashFromUserOrganisation.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20200207093155_RemovePINHashFromUserOrganisation.Designer.cs
@@ -4,14 +4,16 @@ using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GenderPayGap.Database.Core21.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20200207093155_RemovePINHashFromUserOrganisation")]
+    partial class RemovePINHashFromUserOrganisation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20200207093155_RemovePINHashFromUserOrganisation.cs
+++ b/GenderPayGap.Database/Migrations/20200207093155_RemovePINHashFromUserOrganisation.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Core21.Migrations
+{
+    public partial class RemovePINHashFromUserOrganisation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PINHash",
+                table: "UserOrganisations");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PINHash",
+                table: "UserOrganisations",
+                maxLength: 250,
+                nullable: true);
+        }
+    }
+}

--- a/GenderPayGap.WebUI/Controllers/RegisterController.Organisation.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.Organisation.cs
@@ -1732,7 +1732,6 @@ namespace GenderPayGap.WebUI.Controllers
 
             userOrg.Address = address;
             userOrg.PIN = null;
-            userOrg.PINHash = null;
             userOrg.PINSentDate = null;
 
             #endregion

--- a/GenderPayGap.WebUI/Controllers/RegisterController.ServiceActivated.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.ServiceActivated.cs
@@ -247,12 +247,6 @@ namespace GenderPayGap.WebUI.Controllers
                 return true;
             }
 
-            string hashedPin = Crypto.GetSHA512Checksum(normalisedPin);
-            if (userOrg.PINHash == hashedPin)
-            {
-                return true;
-            }
-
             return false;
         }
 

--- a/GenderPayGap.WebUI/Controllers/RegisterController.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.cs
@@ -140,7 +140,7 @@ namespace GenderPayGap.WebUI.Controllers
                 .FirstOrDefaultAsync(uo => uo.UserId == currentUser.UserId && uo.OrganisationId == ReportingOrganisationId);
 
             //If a pin has never been sent or resend button submitted then send one immediately
-            if (string.IsNullOrWhiteSpace(userOrg.PIN) && string.IsNullOrWhiteSpace(userOrg.PINHash)
+            if (string.IsNullOrWhiteSpace(userOrg.PIN)
                 || userOrg.PINSentDate.EqualsI(null, DateTime.MinValue)
                 || userOrg.PINSentDate.Value.AddDays(Global.PinInPostExpiryDays) < VirtualDateTime.Now)
             {
@@ -156,7 +156,6 @@ namespace GenderPayGap.WebUI.Controllers
 
                     // Save the PIN and confirm code
                     userOrg.PIN = pin;
-                    userOrg.PINHash = null;
                     userOrg.PINSentDate = now;
                     userOrg.Method = RegistrationMethods.PinInPost;
                     await DataRepository.SaveChangesAsync();
@@ -257,7 +256,6 @@ namespace GenderPayGap.WebUI.Controllers
 
             //Mark the user org as ready to send a pin
             userOrg.PIN = null;
-            userOrg.PINHash = null;
             userOrg.PINSentDate = null;
             await DataRepository.SaveChangesAsync();
 


### PR DESCRIPTION
More unused code (PINHash on UserOrganisation).
This was part of the Pin-in-the-Post process, but we now store an un-hashed PIN instead (in the PIN column)