### PR TITLE
#39077 Add hint and placeholder text

### DIFF
--- a/GenderPayGap.WebUI/Views/Submit/EmployerWebsite.cshtml
+++ b/GenderPayGap.WebUI/Views/Submit/EmployerWebsite.cshtml
@@ -61,9 +61,10 @@
                 <p>You can publish your gender pay gap narrative on your organisation's website. This can provide context for your figures.</p>
                 <fieldset>
                     <div class="form-group @Html.SetErrorClass(model => model.CompanyLinkToGPGInfo, "error")">
-                        @Html.LabelFor(model => model.CompanyLinkToGPGInfo, "Enter the web address (URL)", new {@class = "form-label"})
+                        <label class="form-label" for="OtherName">Enter the web address (URL). <br/>
+                            <span class="optional" style="font-size: inherit">This must start with http:// or https://</span></label>
                         @Html.ValidationMessageFor(model => model.CompanyLinkToGPGInfo, "", new {@class = "error-message"})
-                        @Html.TextAreaFor(model => model.CompanyLinkToGPGInfo, 6, 30, new {@class = "form-control form-control-3-4"})
+                        @Html.TextAreaFor(model => model.CompanyLinkToGPGInfo, 6, 30, new {@class = "form-control form-control-3-4", placeholder = "http"})
                     </div>
                 </fieldset>
             </div>

--- a/GenderPayGap.WebUI/Views/Submit/EmployerWebsite.cshtml
+++ b/GenderPayGap.WebUI/Views/Submit/EmployerWebsite.cshtml
@@ -61,7 +61,7 @@
                 <p>You can publish your gender pay gap narrative on your organisation's website. This can provide context for your figures.</p>
                 <fieldset>
                     <div class="form-group @Html.SetErrorClass(model => model.CompanyLinkToGPGInfo, "error")">
-                        <label class="form-label" for="OtherName">Enter the web address (URL). <br/>
+                        <label class="form-label" for="CompanyLinkToGPGInfo">Enter the web address (URL). <br/>
                             <span class="optional" style="font-size: inherit">This must start with http:// or https://</span></label>
                         @Html.ValidationMessageFor(model => model.CompanyLinkToGPGInfo, "", new {@class = "error-message"})
                         @Html.TextAreaFor(model => model.CompanyLinkToGPGInfo, 6, 30, new {@class = "form-control form-control-3-4", placeholder = "http"})


### PR DESCRIPTION
Update the page for inputting a link to organisation's GPG report.

Previously it looked like this 

![image](https://user-images.githubusercontent.com/33458055/74173349-e35b4100-4c29-11ea-8fbb-a5bf91c5363f.png)

There is now an extra hint above the input and placeholder text to guide the user.

![image](https://user-images.githubusercontent.com/33458055/74173402-f40bb700-4c29-11ea-991f-4291a84c9db8.png)
