### PR TITLE
AB#39251 improve understanding on late submission journey

### DIFF
--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Models/Submit/SubmissionChangeSummaryTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Models/Submit/SubmissionChangeSummaryTests.cs
@@ -82,7 +82,7 @@ namespace GenderPayGap.WebUI.Tests.Models.Submit
         #region PersonResonsibleChanged
 
         [Test]
-        public void SubmissionChangeSummary_ShouldProvideLateReason_PersonResponsibleChanged_Returns_True_When_Changed()
+        public void SubmissionChangeSummary_ShouldProvideLateReason_PersonResponsibleChanged_Returns_False_When_Changed()
         {
             // Arrange
             var submissionChangeSummary = new SubmissionChangeSummary {PersonResonsibleChanged = true, IsPrevReportingStartYear = true};
@@ -91,9 +91,9 @@ namespace GenderPayGap.WebUI.Tests.Models.Submit
             bool actual = submissionChangeSummary.ShouldProvideLateReason;
 
             // Assert
-            Assert.True(
+            Assert.False(
                 actual,
-                "When the Person Responsible has changed for a report belonging to the previous year, the user 'ShouldProvideLateReason'");
+                "When the Person Responsible has changed for a report belonging to the previous year, the user does not need to provide a late reason");
         }
 
         [Test]

--- a/GenderPayGap.WebUI/Controllers/OrganisationController.cs
+++ b/GenderPayGap.WebUI/Controllers/OrganisationController.cs
@@ -276,8 +276,14 @@ namespace GenderPayGap.WebUI.Controllers
 
             await SubmissionService.RestartDraftFileAsync(organisationId, reportingStartYear, currentUser.UserId);
 
+            var reportingRequirement =
+                await ScopeBusinessLogic.GetLatestScopeStatusForSnapshotYearAsync(organisationId, reportingStartYear);
+            
+            bool requiredToReport =
+                reportingRequirement == ScopeStatuses.InScope || reportingRequirement == ScopeStatuses.PresumedInScope;
+            
             // When previous reporting year then do late submission flow
-            if (isPrevReportingYear)
+            if (isPrevReportingYear && requiredToReport)
             {
                 // Change an existing late submission
                 if (change)

--- a/GenderPayGap.WebUI/Models/Submit/SubmissionChangeSummary.cs
+++ b/GenderPayGap.WebUI/Models/Submit/SubmissionChangeSummary.cs
@@ -19,7 +19,7 @@
             || WebsiteUrlChanged
             || ShouldProvideLateReason && LateReasonChanged;
 
-        public bool ShouldProvideLateReason => (FiguresChanged || PersonResonsibleChanged) && IsPrevReportingStartYear;
+        public bool ShouldProvideLateReason => FiguresChanged && IsPrevReportingStartYear;
 
         public string Modifications { get; set; }
 

--- a/GenderPayGap.WebUI/Views/Submit/LateWarning.cshtml
+++ b/GenderPayGap.WebUI/Views/Submit/LateWarning.cshtml
@@ -8,18 +8,28 @@
             @await Html.PartialAsync("ReportingOrgPart", controller.ReportingOrganisation.OrganisationName)
             Late Submission
         </h1>
-        <p>You are adding or changing a Gender Pay Gap report after the deadline.</p>
-        <p>
-            You will need to provide a reason and your report may be shared with the Equalities and Human Rights Commission if:
+        <p style="margin-top: 35px">You are adding or changing a Gender Pay Gap report after the deadline.</p>
+        <p style="margin-top: 50px">
+            <strong>
+                You will not be asked for a reason and your report will not be treated as late if you are changing:
+            </strong> 
             <ul class="list list-bullet">
-                <li>You are submitting a report for the first time after the deadline</li>
-                <li>You are changing previously reported figures or your Senior Responsible Person after the deadline</li>
+                <li>your Senior Responsible Person</li>
+                <li>your organisation size</li>
+                <li>the link to your organisation's gender pay gap narrative</li>
             </ul>
         </p>
-        <p>
-            The submission date recorded is always the latest date you changed your GPG figures.
+        
+        <p style="margin-top: 50px">
+            <strong>
+                You will be asked for a reason and your information may be shared with the Equalities and Human Rights Commission if you are:
+            </strong>
+            <ul class="list list-bullet">
+                <li>changing previously reported figures</li>
+                <li>reporting for the first time</li>
+            </ul>
         </p>
 
-        <a id="NextStep" href="@Url.Action(Model.ReturnUrl)" class="button">Continue</a>
+        <a id="NextStep" href="@Url.Action(Model.ReturnUrl)" class="button" style="margin-top: 50px">Continue</a>
     </div>
 </div>


### PR DESCRIPTION
- Update late warning message
- Don't ask for late reason when changing SRO
- Don't show late warning for voluntary reports

Before:

![image](https://user-images.githubusercontent.com/33458055/74260194-fdac2200-4cf0-11ea-90e3-a939de9205cd.png)

After:

![image](https://user-images.githubusercontent.com/33458055/74260172-f7b64100-4cf0-11ea-9e8c-18a819f914dc.png)
