### PR TITLE
Remove a few remaining SiteMap references

### DIFF
--- a/GenderPayGap.IdentityServer4/Views/Shared/_GovTemplate.cshtml
+++ b/GenderPayGap.IdentityServer4/Views/Shared/_GovTemplate.cshtml
@@ -20,9 +20,9 @@
 <!--<![endif]-->
 <head>
     <title>@metaTitle</title>
-    <sitemap:meta http-equiv="content-type" default-content="text/html; charset=UTF-8" />
-    <sitemap:meta name="description" default-content="@ViewBag.pageDescription" required="false" />
-    <sitemap:meta name="robots" required="false" />
+    <meta http-equiv="content-type" default-content="text/html; charset=UTF-8" />
+    <meta name="description" default-content="@ViewBag.pageDescription" required="false" />
+    <meta name="robots" required="false" />
 
     <meta charset="utf-8" />
 

--- a/GenderPayGap.IdentityServer4/Views/_ViewImports.cshtml
+++ b/GenderPayGap.IdentityServer4/Views/_ViewImports.cshtml
@@ -1,2 +1,1 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper  *, GenderPayGap.Sitemap

--- a/GenderPayGap.WebUI/Views/GOVUK/Layouts/template.cshtml
+++ b/GenderPayGap.WebUI/Views/GOVUK/Layouts/template.cshtml
@@ -15,9 +15,9 @@
 <html lang="en">
 <head>
     <title>@documentTitle</title>
-    <sitemap:meta http-equiv="content-type" default-content="text/html; charset=UTF-8" />
-    <sitemap:meta name="description" default-content="@ViewBag.pageDescription" required="false" />
-    <sitemap:meta name="robots" required="false" />
+    <meta http-equiv="content-type" default-content="text/html; charset=UTF-8" />
+    <meta name="description" default-content="@ViewBag.pageDescription" required="false" />
+    <meta name="robots" required="false" />
 
     @if (User.Identity.IsAuthenticated)
     {

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -4,9 +4,6 @@
 @using GenderPayGap.WebUI.Models.Shared
 @model EmployerDetailsViewModel
 @{
-    //Required for variables in Sitemap taghelpers
-    ViewBag.EmployerName = Model.Organisation.OrganisationName;
-
     Organisation organisation = Model.Organisation;
     ViewBag.Title = $"Gender pay gap for {organisation.OrganisationName} - GOV.UK";
     ViewBag.pageDescription = $"View gender pay gap details for {organisation.OrganisationName} and compare with other organisations";

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Report.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Report.cshtml
@@ -3,12 +3,6 @@
 @using GenderPayGap.WebUI.Helpers
 @model GenderPayGap.BusinessLogic.Models.Submit.ReturnViewModel
 @{
-    //Required for variables in Sitemap taghelpers
-    ViewBag.EmployerName = Model.OrganisationName;
-    ViewBag.StartYear = Model.AccountingDate.Year;
-    ViewBag.EndYear = (Model.AccountingDate.Year + 1).ToTwoDigitYear();
-
-
     ViewBag.Title = $"{Model.OrganisationName} gender pay gap data for {Model.AccountingDate.Year}-{(Model.AccountingDate.Year + 1).ToTwoDigitYear()} reporting year - GOV.UK";
     ViewBag.pageDescription = $"View gender pay gap data for {Model.OrganisationName} for {Model.AccountingDate.Year}-{(Model.AccountingDate.Year + 1).ToTwoDigitYear()} reporting year and compare with other organisations";
     ViewBag.ogTitle = ViewBag.Title;

--- a/GenderPayGap.WebUI/Views/_ViewImports.cshtml
+++ b/GenderPayGap.WebUI/Views/_ViewImports.cshtml
@@ -10,5 +10,4 @@
 @using Microsoft.Extensions.Options;
 @using GenderPayGap.WebUI.Areas.Account.Controllers
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper *, GenderPayGap.Sitemap
 @addTagHelper *, GenderPayGap.WebUI


### PR DESCRIPTION
In Dev Tools, the HTML is looking a bit weird.
There's almost nothing in the <head> and the <body> starts with a few nested layers of "sitemap" stuff.
These changes should fix that