### PR TITLE
#39493 Show user status in admin search (if the user is not active)

### DIFF
--- a/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GenderPayGap.Core;
 
 namespace GenderPayGap.WebUI.Models.Admin
 {
@@ -44,6 +45,7 @@ namespace GenderPayGap.WebUI.Models.Admin
         public AdminSearchMatchViewModel UserFullName { get; set; }
         public AdminSearchMatchViewModel UserEmailAddress { get; set; }
         public long UserId { get; set; }
+        public UserStatuses Status { get; set; }
 
     }
 

--- a/GenderPayGap.WebUI/Services/AdminSearchService.cs
+++ b/GenderPayGap.WebUI/Services/AdminSearchService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using GenderPayGap.Core;
 using GenderPayGap.Core.Classes.Logger;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
@@ -29,6 +30,7 @@ namespace GenderPayGap.WebUI.Services
         public long UserId { get; set; }
         public string FullName { get; set; }
         public string EmailAddress { get; set; }
+        public UserStatuses Status { get; set; }
     }
 
     public class AdminSearchServiceCacheUpdater : IHostedService, IDisposable
@@ -184,7 +186,8 @@ namespace GenderPayGap.WebUI.Services
                 {
                     UserId = u.UserId,
                     FullName = u.Fullname,
-                    EmailAddress = u.EmailAddress
+                    EmailAddress = u.EmailAddress,
+                    Status = u.Status
                 })
                 .ToList();
         }
@@ -271,7 +274,10 @@ namespace GenderPayGap.WebUI.Services
                         AdminSearchMatchViewModel matchGroupsForEmailAddress = GetMatchGroups(user.EmailAddress, searchTerms);
 
                         return new AdminSearchResultUserViewModel {
-                            UserFullName = matchGroupsForFullName, UserEmailAddress = matchGroupsForEmailAddress, UserId = user.UserId
+                            UserId = user.UserId,
+                            UserFullName = matchGroupsForFullName,
+                            UserEmailAddress = matchGroupsForEmailAddress,
+                            Status = user.Status
                         };
                     })
                 .ToList();

--- a/GenderPayGap.WebUI/Views/Admin/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/Admin/Search.cshtml
@@ -1,3 +1,4 @@
+@using GenderPayGap.Core
 @using GenderPayGap.WebUI.Models.Admin
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
@@ -184,6 +185,12 @@
                                     </a>
                                     <br/>
                                     @(HighlightMatches(user.UserEmailAddress))
+                                    
+                                    @if (user.Status != UserStatuses.Active)
+                                    {
+                                        <br/>
+                                        <span class="govuk-!-font-weight-bold">(@(user.Status))</span>
+                                    }
                                 </td>
                             </tr>
                         }


### PR DESCRIPTION
If we delete a user and they re-create their account, it becomes unclear which is which in the admin search.
This should make that a bit clearer.
If they are not active, we show "(Retired)" below their name

![image](https://user-images.githubusercontent.com/7769588/74734524-a48b4380-5246-11ea-9d9c-5f02e32b927a.png)
