### PR TITLE
#37486 Update ReminderEmailDays config value

### DIFF
--- a/GenderPayGap.WebJob/appsettings.json
+++ b/GenderPayGap.WebJob/appsettings.json
@@ -254,7 +254,7 @@
   "PurgeUnconfirmedPinDays": "30",
   "PurgeUnusedOrganisationDays": "30",
   "PurgeUnverifiedUserDays": "7",
-  "ReminderEmailDays": "[30, 7, 1]",
+  "ReminderEmailDays": "[30, 7, 3]",
   "ReportsReaderPassword": null,
   "SaveDraftPath": "draftReturns",
   "SecurityCodeChars": "123456789ABCDEFGHKLMNPQRSTUXYZ",


### PR DESCRIPTION
Updates values from `[30, 7, 1]` to `[30, 7, 3]` in line with the original ticket.

Alongside this PR I will remove the env settings on PROD (currently set to `[30, 7, 3]`), so that it picks up the default settings.

This will also happen on TEST and PREPROD. 

DEV is already set to `[35, 12, 8]`
