### PR TITLE
#37500 Remove extra radio buttons and update copy

### DIFF
--- a/GenderPayGap.WebUI/Views/Register/OrganisationType.cshtml
+++ b/GenderPayGap.WebUI/Views/Register/OrganisationType.cshtml
@@ -34,37 +34,17 @@
                     <div class="multiple-choice">
                         <input id="public" type="radio" name="SectorType" value="@(SectorTypes.Public)">
                         <label for="public">
-                            Public sector organisation
+                            <span class="form-label-bold">Public sector organisation</span>
+                            This includes most government departments, the armed forces, local authorities, NHS bodies, 
+                            universities, and most schools (including academies and multi-academy trusts).
                         </label>
                     </div>
                     <div class="multiple-choice">
                         <input id="private" type="radio" name="SectorType" value="@(SectorTypes.Private)">
                         <label for="private">
-                            Private limited company
-                        </label>
-                    </div>
-                    <div class="multiple-choice">
-                        <input id="publicLimitedCompany" type="radio" name="SectorType" value="@(SectorTypes.Private)">
-                        <label for="publicLimitedCompany">
-                            Public limited company
-                        </label>
-                    </div>
-                    <div class="multiple-choice">
-                        <input id="limitedLiabilityPartnership" type="radio" name="SectorType" value="@(SectorTypes.Private)">
-                        <label for="limitedLiabilityPartnership">
-                            Limited liability partnership
-                        </label>
-                    </div>
-                    <div class="multiple-choice">
-                        <input id="charity" type="radio" name="SectorType" value="@(SectorTypes.Private)">
-                        <label for="charity">
-                            Charity
-                        </label>
-                    </div>
-                    <div class="multiple-choice">
-                        <input id="otherPrivate" type="radio" name="SectorType" value="@(SectorTypes.Private)">
-                        <label for="otherPrivate">
-                            Other private organisation
+                            <span class="form-label-bold">Private and voluntary sector organisation</span>
+                            This includes private limited companies, public limited companies, limited liability 
+                            partnerships, charities, independent and private schools, and other private sector organisations.
                         </label>
                     </div>
                 </fieldset>

--- a/GenderPayGap.WebUI/Views/Register/OrganisationType.cshtml
+++ b/GenderPayGap.WebUI/Views/Register/OrganisationType.cshtml
@@ -1,6 +1,4 @@
 ﻿@using GenderPayGap.Core
-@using GovUkDesignSystem
-@using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.Register.OrganisationViewModel
 @{
     ViewBag.Title = "Your organisation type - Gender pay gap reporting service";
@@ -18,16 +16,13 @@
 
             @await Html.CustomValidationSummaryAsync()
 
-            <h1 class="heading-large">
-                Registration options
+            <h1 class="heading-large" style="margin-bottom: 50px;">
+                Select the type of organisation you would like to add
             </h1>
 
             <div id="SectorTypeGroup" class="form-group @Html.SetErrorClass(model => model.SectorType, "error")">
                 <fieldset>
                     <legend>
-                        <h1 class="heading-medium" style="margin-top: 15px">
-                            Select which type of organisation you would like to register
-                        </h1>
                         @Html.ValidationMessageFor(model => model.SectorType, null, new {@class = "error-danger"})
                     </legend>
 
@@ -35,7 +30,7 @@
                         <input id="public" type="radio" name="SectorType" value="@(SectorTypes.Public)">
                         <label for="public">
                             <span class="form-label-bold">Public sector organisation</span>
-                            This includes most government departments, the armed forces, local authorities, NHS bodies, 
+                            This includes most government departments, the armed forces, local authorities, NHS bodies,
                             universities, and most schools (including academies and multi-academy trusts).
                         </label>
                     </div>
@@ -43,27 +38,29 @@
                         <input id="private" type="radio" name="SectorType" value="@(SectorTypes.Private)">
                         <label for="private">
                             <span class="form-label-bold">Private and voluntary sector organisation</span>
-                            This includes private limited companies, public limited companies, limited liability 
+                            This includes private limited companies, public limited companies, limited liability
                             partnerships, charities, independent and private schools, and other private sector organisations.
                         </label>
                     </div>
                 </fieldset>
             </div>
             <div class="panel panel-border-wide">
-                   <p>
-                       If you are not sure what type of organisation you are please read our
-                       <a class="govuk-link" href="https://www.gov.uk/guidance/gender-pay-gap-reporting-overview#relevant-employer">
-                           guidance</a>.
-                   </p>
+                <p>
+                    If you are not sure what type of organisation you are please read our
+                    <a class="govuk-link" href="https://www.gov.uk/guidance/gender-pay-gap-reporting-overview#relevant-employer">
+                        guidance
+                    </a>.
+                </p>
 
-                   <p>
-                       The full list of organisations required to report their gender pay gap data as a public sector organisation
-                       can be found in
-                       <a class="govuk-link" href="https://www.legislation.gov.uk/ukdsi/2017/9780111153277/schedule/2">
-                           Schedule 2 of the The Equality Act 2010 (Specific Duties and Public Authorities) Regulations
-                           2017</a>.
-                   </p>
-               </div>
+                <p>
+                    The full list of organisations required to report their gender pay gap data as a public sector organisation
+                    can be found in
+                    <a class="govuk-link" href="https://www.legislation.gov.uk/ukdsi/2017/9780111153277/schedule/2">
+                        Schedule 2 of the The Equality Act 2010 (Specific Duties and Public Authorities) Regulations
+                        2017
+                    </a>.
+                </p>
+            </div>
             <input type="submit" class="button" value="Continue"/>
 
             <div>


### PR DESCRIPTION
These buttons were recently split out from 2 to 5. This change moves back to just two buttons, as the feedback was that it is more confusing to have 5. This change also adds more guidance around the choice.

The styling is taken from the [GDS Elements components](https://govuk-elements.herokuapp.com/form-elements/example-radios-checkboxes/) as this page still uses the old style.

This page is still being discussed on the ticket so might not yet be ready to go in.

**Before**
![image](https://user-images.githubusercontent.com/33458055/74928356-3d4dca80-53d1-11ea-84f9-6a7162ae4402.png)

**After**
![image](https://user-images.githubusercontent.com/33458055/74928275-1abbb180-53d1-11ea-8872-c408e129250e.png)
