### PR TITLE
Remove another unnecessary webjob (duplicate storage backups)

### DIFF
--- a/GenderPayGap.WebJob/Functions/Functions.ExecuteWebJob.cs
+++ b/GenderPayGap.WebJob/Functions/Functions.ExecuteWebJob.cs
@@ -44,9 +44,6 @@ namespace GenderPayGap.WebJob
                 case "UpdateDownloadFiles":
                     await UpdateDownloadFilesAsync(log, parameters["userEmail"], true);
                     break;
-                case "TakeSnapshot":
-                    await TakeSnapshotAsync(log);
-                    break;
                 default:
                     DateTime errorEndTime = VirtualDateTime.Now;
                     CustomLogger.Error(

--- a/GenderPayGap.WebJob/Functions/Functions.MergeLogs.cs
+++ b/GenderPayGap.WebJob/Functions/Functions.MergeLogs.cs
@@ -26,9 +26,6 @@ namespace GenderPayGap.WebJob
 
             try
             {
-                //Backup the log files first
-                await ArchiveAzureStorageAsync();
-
                 var actions = new List<Task>();
 
                 #region WebServer Logs


### PR DESCRIPTION
I found another unrelated web job that can be deleted.

This one zips up log files (as a backup mechanism).
It's unnecessary because there's another web job that takes backups using an Azure mechanism.