### PR TITLE
Remove underscore from feature flag config values

### DIFF
--- a/GenderPayGap.Core/FeatureFlagHelper.cs
+++ b/GenderPayGap.Core/FeatureFlagHelper.cs
@@ -14,7 +14,7 @@ namespace GenderPayGap.Core
 
         public static bool? GetFeatureFlagValue(FeatureFlag featureFlag)
         {
-            string appSettingName = $"FeatureFlag_{featureFlag}";
+            string appSettingName = $"FeatureFlag{featureFlag}";
 
             string appSettingValue = Config.GetAppSetting(appSettingName);
 

--- a/GenderPayGap.WebUI/appsettings.LOCAL.json
+++ b/GenderPayGap.WebUI/appsettings.LOCAL.json
@@ -1,5 +1,5 @@
 {
-  "FeatureFlag_ReportingStepByStep": "true",
+  "FeatureFlagReportingStepByStep": "true",
   "thisFileInfo": "WebUI; appsettings.LOCAL.json",
   "OffsetCurrentDateTimeForSite": "0",
   "UseDeveloperExceptions": "true"

--- a/GenderPayGap.WebUI/appsettings.json
+++ b/GenderPayGap.WebUI/appsettings.json
@@ -195,7 +195,7 @@
   "EmployerPageSize": "20",
   "EnableSubmitAlerts": null,
   "EncryptEmails": "true",
-  "FeatureFlag_ReportingStepByStep": "false",
+  "FeatureFlagReportingStepByStep": "false",
   "GEODistributionList": null,
   "GoogleAnalyticsAccountId": null,
   "GovUkNotifyPinInThePostTemplateId": "4cc0b2e0-d8c2-43ab-a61a-9fba6575514e",


### PR DESCRIPTION
Azure's configuration allows underscores, but the key vault doesn't. We should keep all app level config values in the key vault, so this change helps to bring things in line