### PR TITLE
AB#39793 Swap table layout for nested lists

### DIFF
--- a/GenderPayGap.WebUI/Views/Shared/_SicCodeList.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_SicCodeList.cshtml
@@ -5,25 +5,29 @@
 @{
     IQueryable<SicCode> sicCodes = DataRepo.GetAll<SicCode>().Where(s => Model.Contains(s.SicCodeId));
 }
-<table class="compact">
+<ul>
     @foreach (SicSection sector in sicCodes.Select(s => s.SicSection).Distinct().OrderBy(s => s.Description))
     {
-        <tr>
-            <td colspan="2" style="padding-top:10px">
-                <b>@sector.Description</b>
-            </td>
-        </tr>
-        if (sector.SicSectionId != "X")
-        {
-            foreach (SicCode sicCode in sicCodes.Where(s => s.SicSectionId == sector.SicSectionId).Distinct().OrderBy(s => s.SicCodeId))
+        <li>
+            <b>@sector.Description</b>
+            
+            @if (sector.SicSectionId != "X")
             {
-                <tr>
-                    <td>
-                        <li style="list-style-position:inside;white-space:nowrap">@sicCode.SicCodeId</li>
-                    </td>
-                    <td>@sicCode.Description</td>
-                </tr>
+                <ul class="list list-bullet">
+                    @foreach (SicCode sicCode in sicCodes.Where(s => s.SicSectionId == sector.SicSectionId).Distinct().OrderBy(s => s.SicCodeId))
+                    {
+                        <li>
+                            <span style="font-weight: bold; margin-right: 5px">
+                                @sicCode.SicCodeId
+                            </span>
+                            <span>
+                                @sicCode.Description
+                            </span>
+                        </li>
+                            
+                    }
+                </ul>
             }
-        }
+        </li>
     }
-</table>
+</ul>


### PR DESCRIPTION
Replace a table that was being used for layout purposes with nested lists. 

I have also checked through the codebase for other instances and couldn't find any other cases.
I checked all occurrences of `<li`. 

(ps. I also tried `<tr>\s*<td>\s*<li>` to look for the same pattern, and a negative lookback but I had less regex success with that one.)


Before 

![image](https://user-images.githubusercontent.com/33458055/76431220-351df500-63a9-11ea-97e1-813f88b44d34.png)


After

![image](https://user-images.githubusercontent.com/33458055/76431462-81693500-63a9-11ea-8f15-314b9106819c.png)
