### PR TITLE
AB#39796 Remove visually hidden label and wrap visible label in h1

### DIFF
--- a/GenderPayGap.WebUI/Views/Register/OrganisationSearch.cshtml
+++ b/GenderPayGap.WebUI/Views/Register/OrganisationSearch.cshtml
@@ -22,15 +22,13 @@
             <div class="column-two-thirds">
                 @await Html.CustomValidationSummaryAsync()
                 <h1 class="heading-large">
-
-                    <span>Find your organisation</span>
+                    <label for="SearchText">Find your organisation</label>
                 </h1>
                 @Html.ValidationMessageFor(model => model.SearchText, null, new {@class = "error-danger"})
 
                 <div class="gov-uk-c-searchbar">
                     <div class="gov-uk-l-searchbar__table">
                         <div class="gov-uk-l-searchbar__cell">
-                            <label for="SearchText" class="visually-hidden">field to search by organisation name</label>
                             @Html.CustomEditorFor(model => model.SearchText, new {@class = "gov-uk-c-searchbar__input", placeholder = Model.SectorType == SectorTypes.Public ? "Organisation name" : "Organisation name or company no"})
                         </div>
                         <div class="gov-uk-l-searchbar__cell">


### PR DESCRIPTION
This change follows the advice given by DAC. It removes the visually hidden label and wraps the label in the h1. Following [this pattern](https://design-system.service.gov.uk/get-started/labels-legends-headings/). This change doesn't change the way the page looks.

I've also done a few searches for other visually hidden labels but didn't find anything. I only found this case with `<label.*class="visually-hidden">` and I also went through all cases of  `visually-hidden`. Let me know if you think there are any other searches I should be doing.

