### PR TITLE
AB#38814 Improvements to Admin Return Details view in response to testing

### DIFF
--- a/GenderPayGap.WebUI/Views/AdminOrganisationReturn/ViewReturnDetails.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationReturn/ViewReturnDetails.cshtml
@@ -65,18 +65,27 @@
         <table class="govuk-table admin-return-details-table">
             <tbody class="govuk-table__body">
                 @{
-                    List<Return> returnsForYear = Model.Organisation.Returns
+                    List<Return> returnVersions = Model.Organisation.Returns
                         .Where(r => r.AccountingDate.Year == Model.Year)
                         .OrderByDescending(r => r.StatusDate)
                         .ToList();
+
+                    int numberOfVersions = returnVersions.Count;
+
+                    Func<int, Return> GetVersion = (i => returnVersions[i]);
+                    Func<int, Return> GetPreviousVersion = (i => i < numberOfVersions - 1 ? returnVersions[i + 1] : null);
+                    Func<int, int> GetVersionNumber = (i => returnVersions.Count - i);
                 }
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Revision number</th>
-                    @for (int version = returnsForYear.Count; version > 0; version--)
+
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
+                        int versionNumber = GetVersionNumber(i);
+
                         <th scope="col" class="govuk-table__header">
-                            version @(version)
+                            version @versionNumber
                         </th>
                     }
                 </tr>
@@ -86,14 +95,16 @@
                         <span class="govuk-visually-hidden">Date</span>
                         Modified
                     </th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
+                        Return thisVersion = GetVersion(i);
+
                         <td class="govuk-table__cell">
                             <span style="white-space: nowrap">
-                                @(returnForYear.Modified.ToString("d MMM yyyy"))
+                                @(thisVersion.Modified.ToString("d MMM yyyy"))
                             </span>
                             <span style="white-space: nowrap">
-                                @(returnForYear.Modified.ToString("HH:mm"))
+                                @(thisVersion.Modified.ToString("HH:mm"))
                             </span>
                         </td>
                     }
@@ -101,19 +112,23 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Status</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.Status)</td>
+                        Return thisVersion = GetVersion(i);
+
+                        <td class="govuk-table__cell">@(thisVersion.Status)</td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Modifications</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
+                        Return thisVersion = GetVersion(i);
+
                         <td class="govuk-table__cell">
-                            @(returnForYear.Modifications != null
-                                ? string.Join(", ", returnForYear.Modifications.Split(",", StringSplitOptions.RemoveEmptyEntries))
+                            @(thisVersion.Modifications != null
+                                ? string.Join(", ", thisVersion.Modifications.Split(",", StringSplitOptions.RemoveEmptyEntries))
                                 : "")
                         </td>
                     }
@@ -121,10 +136,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Late submission</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.IsLateSubmission != previousVersion.IsLateSubmission);
@@ -137,10 +152,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Reason for late submission</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.LateReason != previousVersion.LateReason);
@@ -156,10 +171,10 @@
                         <span class="govuk-visually-hidden">Number of</span>
                         Employees
                     </th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.MinEmployees != previousVersion.MinEmployees) ||
@@ -173,10 +188,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Hourly pay gap (mean)</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.DiffMeanHourlyPayPercent != previousVersion.DiffMeanHourlyPayPercent);
@@ -189,10 +204,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Hourly pay gap (median)</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.DiffMedianHourlyPercent != previousVersion.DiffMedianHourlyPercent);
@@ -205,10 +220,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Who is paid a bonus</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.MaleMedianBonusPayPercent != previousVersion.MaleMedianBonusPayPercent) ||
@@ -224,10 +239,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Bonus pay gap (mean)</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.DiffMeanBonusPercent != previousVersion.DiffMeanBonusPercent);
@@ -240,10 +255,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Bonus pay gap (median)</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.DiffMedianBonusPercent != previousVersion.DiffMedianBonusPercent);
@@ -256,10 +271,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Highest paid quarter</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.MaleUpperQuartilePayBand != previousVersion.MaleUpperQuartilePayBand) ||
@@ -275,10 +290,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">2nd-highest paid quarter</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.MaleUpperPayBand != previousVersion.MaleUpperPayBand) ||
@@ -294,10 +309,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">2nd-lowest paid quarter</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.MaleMiddlePayBand != previousVersion.MaleMiddlePayBand) ||
@@ -313,10 +328,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Lowest paid quarter</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.MaleLowerPayBand != previousVersion.MaleLowerPayBand) ||
@@ -332,10 +347,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Link to company website</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          (thisVersion.CompanyLinkToGPGInfo != previousVersion.CompanyLinkToGPGInfo);
@@ -365,10 +380,10 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Senior Responsible Officer</th>
-                    @for (int i = 0; i < returnsForYear.Count; i++)
+                    @for (int i = 0; i < numberOfVersions; i++)
                     {
-                        Return thisVersion = returnsForYear[i];
-                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+                        Return thisVersion = GetVersion(i);
+                        Return previousVersion = GetPreviousVersion(i);
 
                         bool isChanged = previousVersion != null &&
                                          ((thisVersion.FirstName != previousVersion.FirstName) ||

--- a/GenderPayGap.WebUI/Views/AdminOrganisationReturn/ViewReturnDetails.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationReturn/ViewReturnDetails.cshtml
@@ -62,7 +62,7 @@
             </a>
         </p>
 
-        <table class="govuk-table">
+        <table class="govuk-table admin-return-details-table">
             <tbody class="govuk-table__body">
                 @{
                     List<Return> returnsForYear = Model.Organisation.Returns
@@ -121,19 +121,33 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Late submission</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            @(returnForYear.IsLateSubmission ? "Yes" : "No")
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.IsLateSubmission != previousVersion.IsLateSubmission);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @(thisVersion.IsLateSubmission ? "Yes" : "No")
                         </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Reason for late submission</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.LateReason)</td>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.LateReason != previousVersion.LateReason);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @thisVersion.LateReason
+                        </td>
                     }
                 </tr>
 
@@ -142,121 +156,203 @@
                         <span class="govuk-visually-hidden">Number of</span>
                         Employees
                     </th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.MinEmployees) - @(returnForYear.MaxEmployees)</td>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.MinEmployees != previousVersion.MinEmployees) ||
+                                          (thisVersion.MaxEmployees != previousVersion.MaxEmployees));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @thisVersion.MinEmployees - @thisVersion.MaxEmployees
+                        </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Hourly pay gap (mean)</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.DiffMeanHourlyPayPercent.ToString("0.#"))%</td>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.DiffMeanHourlyPayPercent != previousVersion.DiffMeanHourlyPayPercent);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @(thisVersion.DiffMeanHourlyPayPercent.ToString("0.#"))%
+                        </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Hourly pay gap (median)</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.DiffMedianHourlyPercent.ToString("0.#"))%</td>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.DiffMedianHourlyPercent != previousVersion.DiffMedianHourlyPercent);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @(thisVersion.DiffMedianHourlyPercent.ToString("0.#"))%
+                        </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Who is paid a bonus</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            <span style="white-space: nowrap;">@(returnForYear.MaleMedianBonusPayPercent.ToString("0"))% of men</span>
-                            <br/>
-                            <span style="white-space: nowrap;">@(returnForYear.FemaleMedianBonusPayPercent.ToString("0"))% of women</span>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.MaleMedianBonusPayPercent != previousVersion.MaleMedianBonusPayPercent) ||
+                                          (thisVersion.FemaleMedianBonusPayPercent != previousVersion.FemaleMedianBonusPayPercent));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            <span style="white-space: nowrap;">@(thisVersion.MaleMedianBonusPayPercent.ToString("0"))% of men</span>
+                            <br />
+                            <span style="white-space: nowrap;">@(thisVersion.FemaleMedianBonusPayPercent.ToString("0"))% of women</span>
                         </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Bonus pay gap (mean)</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.DiffMeanBonusPercent?.ToString("0.##"))%</td>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.DiffMeanBonusPercent != previousVersion.DiffMeanBonusPercent);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @(thisVersion.DiffMeanBonusPercent?.ToString("0.##"))%
+                        </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Bonus pay gap (median)</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">@(returnForYear.DiffMedianBonusPercent?.ToString("0.##"))%</td>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.DiffMedianBonusPercent != previousVersion.DiffMedianBonusPercent);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @(thisVersion.DiffMedianBonusPercent?.ToString("0.##"))%
+                        </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Highest paid quarter</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            <span style="white-space: nowrap;">@(returnForYear.MaleUpperQuartilePayBand.ToString("0"))% male</span>
-                            <br/>
-                            <span style="white-space: nowrap;">@(returnForYear.FemaleUpperQuartilePayBand.ToString("0"))% female</span>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.MaleUpperQuartilePayBand != previousVersion.MaleUpperQuartilePayBand) ||
+                                          (thisVersion.FemaleUpperQuartilePayBand != previousVersion.FemaleUpperQuartilePayBand));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            <span style="white-space: nowrap;">@(thisVersion.MaleUpperQuartilePayBand.ToString("0"))% male</span>
+                            <br />
+                            <span style="white-space: nowrap;">@(thisVersion.FemaleUpperQuartilePayBand.ToString("0"))% female</span>
                         </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">2nd-highest paid quarter</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            <span style="white-space: nowrap;">@(returnForYear.MaleUpperPayBand.ToString("0"))% male</span>
-                            <br/>
-                            <span style="white-space: nowrap;">@(returnForYear.FemaleUpperPayBand.ToString("0"))% female</span>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.MaleUpperPayBand != previousVersion.MaleUpperPayBand) ||
+                                          (thisVersion.FemaleUpperPayBand != previousVersion.FemaleUpperPayBand));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            <span style="white-space: nowrap;">@(thisVersion.MaleUpperPayBand.ToString("0"))% male</span>
+                            <br />
+                            <span style="white-space: nowrap;">@(thisVersion.FemaleUpperPayBand.ToString("0"))% female</span>
                         </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">2nd-lowest paid quarter</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            <span style="white-space: nowrap;">@(returnForYear.MaleMiddlePayBand.ToString("0"))% male</span>
-                            <br/>
-                            <span style="white-space: nowrap;">@(returnForYear.FemaleMiddlePayBand.ToString("0"))% female</span>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.MaleMiddlePayBand != previousVersion.MaleMiddlePayBand) ||
+                                          (thisVersion.FemaleMiddlePayBand != previousVersion.FemaleMiddlePayBand));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            <span style="white-space: nowrap;">@(thisVersion.MaleMiddlePayBand.ToString("0"))% male</span>
+                            <br />
+                            <span style="white-space: nowrap;">@(thisVersion.FemaleMiddlePayBand.ToString("0"))% female</span>
                         </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Lowest paid quarter</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            <span style="white-space: nowrap;">@(returnForYear.MaleLowerPayBand.ToString("0"))% male</span>
-                            <br/>
-                            <span style="white-space: nowrap;">@(returnForYear.FemaleLowerPayBand.ToString("0"))% female</span>
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.MaleLowerPayBand != previousVersion.MaleLowerPayBand) ||
+                                          (thisVersion.FemaleLowerPayBand != previousVersion.FemaleLowerPayBand));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            <span style="white-space: nowrap;">@(thisVersion.MaleLowerPayBand.ToString("0"))% male</span>
+                            <br />
+                            <span style="white-space: nowrap;">@(thisVersion.FemaleLowerPayBand.ToString("0"))% female</span>
                         </td>
                     }
                 </tr>
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Link to company website</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            @if (!string.IsNullOrWhiteSpace(returnForYear.CompanyLinkToGPGInfo))
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         (thisVersion.CompanyLinkToGPGInfo != previousVersion.CompanyLinkToGPGInfo);
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @if (!string.IsNullOrWhiteSpace(thisVersion.CompanyLinkToGPGInfo))
                             {
                                 try
                                 {
-                                    <a href="@(returnForYear.CompanyLinkToGPGInfo)"
+                                    <a href="@(thisVersion.CompanyLinkToGPGInfo)"
                                        class="govuk-link">
                                         Link
                                     </a>
                                 }
                                 catch
                                 {
-                                    @(returnForYear.CompanyLinkToGPGInfo)
+                                    @(thisVersion.CompanyLinkToGPGInfo)
                                 }
                             }
                             else
@@ -269,12 +365,20 @@
 
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header">Senior Responsible Officer</th>
-                    @foreach (Return returnForYear in returnsForYear)
+                    @for (int i = 0; i < returnsForYear.Count; i++)
                     {
-                        <td class="govuk-table__cell">
-                            @(returnForYear.FirstName) @(returnForYear.LastName)
+                        Return thisVersion = returnsForYear[i];
+                        Return previousVersion = i < returnsForYear.Count - 1 ? returnsForYear[i + 1] : null;
+
+                        bool isChanged = previousVersion != null &&
+                                         ((thisVersion.FirstName != previousVersion.FirstName) ||
+                                          (thisVersion.LastName != previousVersion.LastName) ||
+                                          (thisVersion.JobTitle != previousVersion.JobTitle));
+
+                        <td class="govuk-table__cell @(isChanged ? "value-changed-from-previous-return" : null)">
+                            @(thisVersion.FirstName) @(thisVersion.LastName)
                             <br />
-                            (@(returnForYear.JobTitle))
+                            (@(thisVersion.JobTitle))
                         </td>
                     }
                 </tr>

--- a/GenderPayGap.WebUI/Views/AdminOrganisationReturn/ViewReturns.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationReturn/ViewReturns.cshtml
@@ -58,14 +58,14 @@
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header">Snapshot date</th>
-                    <th scope="col" class="govuk-table__header">Public page</th>
+                    <th scope="col" class="govuk-table__header">Full details</th>
                     <th scope="col" class="govuk-table__header">Modified</th>
                     <th scope="col" class="govuk-table__header">Employees</th>
                     <th scope="col" class="govuk-table__header">Modifications</th>
                     <th scope="col" class="govuk-table__header">Status</th>
                     <th scope="col" class="govuk-table__header">Late</th>
                     <th scope="col" class="govuk-table__header">Late reason</th>
-                    <th scope="col" class="govuk-table__header">Full details</th>
+                    <th scope="col" class="govuk-table__header">Public page</th>
                 </tr>
             </thead>
             <tbody class="govuk-table__body">
@@ -83,9 +83,13 @@
                             @(returnForYear.AccountingDate.ToString("d MMM yyyy"))
                         </th>
                         <td class="govuk-table__cell" rowspan="@(Model.Returns.Count(s => s.AccountingDate == returnForYear.AccountingDate))">
-                            <a href="@Url.Action("Report", "Viewing", new {employerIdentifier = Model.GetEncryptedId(), year = returnForYear.AccountingDate.Year})"
+                            <a href="@Url.Action("ViewReturnDetailsForYear", "AdminOrganisationReturn",
+                                         new { id = Model.OrganisationId, year = returnForYear.AccountingDate.Year })"
                                class="govuk-link">
-                                <span class="govuk-visually-hidden">Public page for return year </span>@(returnForYear.AccountingDate.Year)
+                                <span class="govuk-visually-hidden">Full history of returns for @(Model.OrganisationName) for</span>
+                                <span style="white-space: nowrap;">
+                                    @(returnForYear.AccountingDate.Year)-@((returnForYear.AccountingDate.Year + 1) % 100)
+                                </span>
                             </a>
                         </td>
                     }
@@ -121,13 +125,9 @@
                     else
                     {
                         <td class="govuk-table__cell" rowspan="@(Model.Returns.Count(s => s.AccountingDate == returnForYear.AccountingDate))">
-                            <a href="@Url.Action("ViewReturnDetailsForYear", "AdminOrganisationReturn",
-                                         new { id = Model.OrganisationId, year = returnForYear.AccountingDate.Year })"
+                            <a href="@Url.Action("Report", "Viewing", new {employerIdentifier = Model.GetEncryptedId(), year = returnForYear.AccountingDate.Year})"
                                class="govuk-link">
-                                <span class="govuk-visually-hidden">Full history of returns for @(Model.OrganisationName) for</span>
-                                <span style="white-space: nowrap;">
-                                    @(returnForYear.AccountingDate.Year)-@((returnForYear.AccountingDate.Year + 1) % 100)
-                                </span>
+                                <span class="govuk-visually-hidden">Public page for return year </span>@(returnForYear.AccountingDate.Year)
                             </a>
                         </td>
                     }

--- a/GenderPayGap.WebUI/wwwroot/styles/_gender-pay-gap-custom.scss
+++ b/GenderPayGap.WebUI/wwwroot/styles/_gender-pay-gap-custom.scss
@@ -1,5 +1,6 @@
 ﻿
 @import "./pages/cookie-settings";
+@import "./pages/_admin-return-details-page";
 
 @import "./components/_accessible-autocomplete";
 @import "./components/_admin-search-box";

--- a/GenderPayGap.WebUI/wwwroot/styles/pages/_admin-return-details-page.scss
+++ b/GenderPayGap.WebUI/wwwroot/styles/pages/_admin-return-details-page.scss
@@ -1,0 +1,7 @@
+﻿.admin-return-details-table {
+
+    .value-changed-from-previous-return {
+        background-color: govuk-colour("light-blue");
+    }
+
+}


### PR DESCRIPTION
* Swap two columns on the Returns page
* Highlight changes on the Return Details page

Looks like this:
![image](https://user-images.githubusercontent.com/7769588/76863789-faf49d80-6857-11ea-858b-34363fa0a21e.png)
