### PR TITLE
AB#40561 Add feature flag around PITP journeys

### DIFF
--- a/GenderPayGap.WebUI/Classes/BaseClasses/BaseController.cs
+++ b/GenderPayGap.WebUI/Classes/BaseClasses/BaseController.cs
@@ -583,6 +583,11 @@ namespace GenderPayGap.WebUI.Classes
                         {
                             return null;
                         }
+                        
+                        if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.PrivateManualRegistration) )
+                        {
+                            return RedirectToAction("ManageOrganisations", "Organisation");
+                        }
 
                         return RedirectToAction("PINSent", "Register");
                     }

--- a/GenderPayGap.WebUI/Controllers/RegisterController.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.cs
@@ -242,6 +242,12 @@ namespace GenderPayGap.WebUI.Controllers
         [HttpPost("request-pin")]
         public async Task<IActionResult> RequestPIN(CompleteViewModel model)
         {
+            
+            if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.PrivateManualRegistration) )
+            {
+                return RedirectToAction("ManageOrganisations", "Organisation");
+            }
+            
             //Ensure user has completed the registration process
             User currentUser;
             IActionResult checkResult = CheckUserRegisteredOk(out currentUser);


### PR DESCRIPTION
- I've put a feature flag around the block in BaseController. 
- For the `RequestPIN` action on line 262 of RegisterController, it is used in 2 views for requesting a new PIN (ActivateService.cshtml and RequestPIN.cshtml). With the new journey you should be unable to reach either of those pages, but in the `RequestPIN` action I have added an early return if the feature flag is on just in case, which redirects back to the manage organisations page.

----
From the ticket 

RegisterController.cs line 202
The "PINSent" action is the one we want to avoid calling.

If we do a Find Usages, we can see it's referred to in 4 places (+ extras in unit tests)
PINSent.cshtml
"Html.BeginForm()" - this doesn't actually do anything because there's no way to submit the form!

RegisterController.Organisation.cs line 1379
This is correctly guarded by the Feature Flag

RegisterController.cs line 262
Not sure where this is used (we should find out)
This should probably be guarded by the Feature Flag

BaseController.cs line 587
This one is a big risk - this should be guarded by the Feature Flag

