### PR TITLE
AB#41224 Remove unclear addresses

### DIFF
--- a/GenderPayGap.BusinessLogic/Services/UpdateFromCompaniesHouseService.cs
+++ b/GenderPayGap.BusinessLogic/Services/UpdateFromCompaniesHouseService.cs
@@ -140,7 +140,6 @@ namespace GenderPayGap.BusinessLogic.Services
 
             oldOrganisationAddress.Status = AddressStatuses.Retired;
             oldOrganisationAddress.StatusDate = VirtualDateTime.Now;
-            oldOrganisationAddress.Modified = VirtualDateTime.Now;
 
             _DataRepository.Insert(newOrganisationAddressFromCompaniesHouse);
         }
@@ -189,7 +188,6 @@ namespace GenderPayGap.BusinessLogic.Services
                 Status = AddressStatuses.Active,
                 StatusDate = VirtualDateTime.Now,
                 StatusDetails = DetailsOfChange,
-                Modified = VirtualDateTime.Now,
                 Created = VirtualDateTime.Now,
                 Source = SourceOfChange,
                 IsUkAddress = isUkAddress

--- a/GenderPayGap.Database.Models/Extensions/Organisation.cs
+++ b/GenderPayGap.Database.Models/Extensions/Organisation.cs
@@ -414,11 +414,6 @@ namespace GenderPayGap.Database
                 .FirstOrDefault();
         }
 
-        public OrganisationAddress FindAddress(AddressModel address, AddressStatuses status = AddressStatuses.Active)
-        {
-            return OrganisationAddresses.FirstOrDefault(a => a.Status == status && a.Equals(address));
-        }
-
         public bool GetIsDissolved()
         {
             return DateOfCessation != null && DateOfCessation < SectorType.GetAccountingStartDate();

--- a/GenderPayGap.Database.Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database.Models/OrganisationAddress.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using GenderPayGap.Core;
 using GenderPayGap.Extensions;
@@ -28,7 +28,10 @@ namespace GenderPayGap.Database
         public DateTime StatusDate { get; set; } = VirtualDateTime.Now;
         public string StatusDetails { get; set; }
         public DateTime Created { get; set; }
+
+        [Obsolete("DO NOT USE: OrganisationAddress.Modified will be deleted soon")]
         public DateTime Modified { get; set; } = VirtualDateTime.Now;
+
         public long OrganisationId { get; set; }
         public string Source { get; set; }
 

--- a/GenderPayGap.Database.Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database.Models/OrganisationAddress.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using GenderPayGap.Core;
 using GenderPayGap.Extensions;
@@ -35,7 +35,10 @@ namespace GenderPayGap.Database
         public bool? IsUkAddress { get; set; }
 
         public virtual Organisation Organisation { get; set; }
+
+        [Obsolete("DO NOT USE: OrganisationAddress.AddressStatuses will be deleted soon")]
         public virtual ICollection<AddressStatus> AddressStatuses { get; set; }
+
         public virtual ICollection<UserOrganisation> UserOrganisations { get; set; }
 
     }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationAddressController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationAddressController.cs
@@ -231,7 +231,6 @@ namespace GenderPayGap.WebUI.Controllers.Admin
             OrganisationAddress oldOrganisationAddress = organisation.GetLatestAddress();
             oldOrganisationAddress.Status = AddressStatuses.Retired;
             oldOrganisationAddress.StatusDate = VirtualDateTime.Now;
-            oldOrganisationAddress.Modified = VirtualDateTime.Now;
         }
 
         private OrganisationAddress CreateOrganisationAddressFromViewModel(ChangeOrganisationAddressViewModel viewModel)
@@ -248,7 +247,6 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                 Status = AddressStatuses.Active,
                 StatusDate = VirtualDateTime.Now,
                 StatusDetails = viewModel.Reason,
-                Modified = VirtualDateTime.Now,
                 Created = VirtualDateTime.Now,
                 Source = "Service Desk",
             };

--- a/GenderPayGap.WebUI/Controllers/RegisterController.Organisation.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.Organisation.cs
@@ -1627,7 +1627,6 @@ namespace GenderPayGap.WebUI.Controllers
             AddressModel oldAddressModel = oldAddress?.GetAddressModel();
 
             AddressModel newAddressModel = null;
-            string oldAddressSource = oldAddress?.Source;
             string newAddressSource = null;
 
             if (model.ManualRegistration || model.ManualAddress)
@@ -1645,17 +1644,6 @@ namespace GenderPayGap.WebUI.Controllers
             if (newAddressModel == null || newAddressModel.IsEmpty())
             {
                 throw new Exception("Cannot save a registration with no address");
-            }
-
-            if (oldAddressModel == null || !oldAddressModel.Equals(newAddressModel))
-            {
-                OrganisationAddress pendingAddress = org.FindAddress(newAddressModel, AddressStatuses.Pending);
-                if (pendingAddress != null)
-                {
-                    oldAddress = pendingAddress;
-                    oldAddressModel = pendingAddress.GetAddressModel();
-                    oldAddressSource = pendingAddress.Source;
-                }
             }
 
 

--- a/GenderPayGap.WebUI/Services/PinInThePostService.cs
+++ b/GenderPayGap.WebUI/Services/PinInThePostService.cs
@@ -32,9 +32,7 @@ namespace GenderPayGap.WebUI.Services
 
             List<string> address = GetAddressInFourLineFormat(userOrganisation.Organisation);
 
-            string postCode = userOrganisation.Organisation.OrganisationAddresses.OrderByDescending(a => a.Modified)
-                .FirstOrDefault()
-                .PostCode;
+            string postCode = userOrganisation.Organisation.GetLatestAddress().PostCode;
 
             string returnUrl = controller.Url.Action(nameof(OrganisationController.ManageOrganisations), "Organisation", null, "https");
             DateTime pinExpiryDate = VirtualDateTime.Now.AddDays(Global.PinInPostExpiryDays);
@@ -80,7 +78,7 @@ namespace GenderPayGap.WebUI.Services
         {
             var address = new List<string>();
 
-            OrganisationAddress latestAddress = organisation.OrganisationAddresses.OrderByDescending(a => a.Modified).FirstOrDefault();
+            OrganisationAddress latestAddress = organisation.GetLatestAddress();
 
             if (!string.IsNullOrWhiteSpace(latestAddress.PoBox))
             {


### PR DESCRIPTION
* LatestAddress - removed in yesterday's release
* OrganisationAddress.Status - this looks like it's being used for Pending addresses, but might be removed when we re-build the Add Organisation journey (so I've not change anything for now)
* Most recently created address - this is the one we want
* Most recently modified address - I've removed usages and marked it as obsolete
* GetAddress - removed all usages in this morning's release, now marked as obsolete