### PR TITLE
#40576 GEODistricutionList needs to accept a list of email addresses, and is always the same, so can be simplified a bit

### DIFF
--- a/GenderPayGap.Core/Global.cs
+++ b/GenderPayGap.Core/Global.cs
@@ -144,6 +144,8 @@ namespace GenderPayGap.Core
 
         public static string AzureInstanceId => Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID");
 
+        public static List<string> GeoDistributionList => Config.GetAppSetting("GEODistributionList").Split(";", StringSplitOptions.RemoveEmptyEntries).ToList<string>();
+
         public static void SetupAppInsights()
         {
             if (AppInsightsSetupComplete)

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/AppSettings.UnitTests.json
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/AppSettings.UnitTests.json
@@ -3,7 +3,7 @@
   "DatabaseAdminEmails": "databaseadmin@email.com;test1@test.com;*@DatabaseAdmin.com",
   "DefaultEncryptionKey": "", // some unit tests require this key to be empty
   "APPINSIGHTS_APPLICATIONID": "70a248ef-6a35-4f3c-99a5-0a3eb69ca0dc",
-  "GEODistributionList": "recipient;stephen.mccabe@cadenceinnova.com",
+  "GEODistributionList": "geo-distribution-list@example.com",
   "LocalStorageRoot": ".\\",
   "ObfuscationSeed": 197, // some unit tests require this key to be 197
   "OffsetCurrentDateTimeForSite": "917",

--- a/GenderPayGap.WebJob/Functions/Functions.CheckSiteCert.cs
+++ b/GenderPayGap.WebJob/Functions/Functions.CheckSiteCert.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -46,26 +47,21 @@ namespace GenderPayGap.WebJob
                                 new {environment = Config.EnvironmentName, time});
 
                             emailSendingService.SendGeoSiteCertificateExpiredEmail(
-                                Config.GetAppSetting("GEODistributionList"),
                                 Global.ExternalHost,
                                 expires.ToFriendlyDate());
                         }
-                        else
+                        else if (expires < VirtualDateTime.UtcNow.AddDays(Global.CertExpiresWarningDays))
                         {
                             TimeSpan remainingTime = expires - VirtualDateTime.Now;
 
-                            if (expires < VirtualDateTime.UtcNow.AddDays(Global.CertExpiresWarningDays))
-                            {
-                                CustomLogger.Error(
-                                    $"The website certificate for '{Global.ExternalHost}' is due expire on {expires.ToFriendlyDate()} and will need replacing within {remainingTime.ToFriendly(maxParts: 2)}.",
-                                    new {environment = Config.EnvironmentName, time});
+                            CustomLogger.Error(
+                                $"The website certificate for '{Global.ExternalHost}' is due expire on {expires.ToFriendlyDate()} and will need replacing within {remainingTime.ToFriendly(maxParts: 2)}.",
+                                new {environment = Config.EnvironmentName, time});
 
-                                emailSendingService.SendGeoSiteCertificateSoonToExpireEmail(
-                                    Config.GetAppSetting("GEODistributionList"),
-                                    Global.ExternalHost,
-                                    expires.ToFriendlyDate(),
-                                    remainingTime.ToFriendly(maxParts: 2));
-                            }
+                            emailSendingService.SendGeoSiteCertificateSoonToExpireEmail(
+                                Global.ExternalHost,
+                                expires.ToFriendlyDate(),
+                                remainingTime.ToFriendly(maxParts: 2));
                         }
                     }
                 }

--- a/GenderPayGap.WebJob/Services/EmailSendingService.cs
+++ b/GenderPayGap.WebJob/Services/EmailSendingService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GenderPayGap.Core;
 using GenderPayGap.Core.Classes;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Extensions.AspNetCore;
@@ -15,7 +16,7 @@ namespace GenderPayGap.WebJob.Services
             this.govNotifyApi = govNotifyApi;
         }
 
-        public void SendGeoSiteCertificateSoonToExpireEmail(string emailAddress, string host, string expiryDate, string remainingDays)
+        public void SendGeoSiteCertificateSoonToExpireEmail(string host, string expiryDate, string remainingDays)
         {
             var personalisation = new Dictionary<string, dynamic>
             {
@@ -25,17 +26,20 @@ namespace GenderPayGap.WebJob.Services
                 {"Environment", GetEnvironmentNameForTestEnvironments()}
             };
 
-            var notifyEmail = new NotifyEmail
+            foreach (string emailAddress in Global.GeoDistributionList)
             {
-                EmailAddress = emailAddress,
-                TemplateId = EmailTemplates.GeoSiteCertificateSoonToExpireEmail,
-                Personalisation = personalisation
-            };
+                var notifyEmail = new NotifyEmail
+                {
+                    EmailAddress = emailAddress,
+                    TemplateId = EmailTemplates.GeoSiteCertificateSoonToExpireEmail,
+                    Personalisation = personalisation
+                };
 
-            SendEmail(notifyEmail);
+                SendEmail(notifyEmail);
+            }
         }
 
-        public void SendGeoSiteCertificateExpiredEmail(string emailAddress, string host, string expiryDate)
+        public void SendGeoSiteCertificateExpiredEmail(string host, string expiryDate)
         {
             var personalisation = new Dictionary<string, dynamic>
             {
@@ -44,14 +48,17 @@ namespace GenderPayGap.WebJob.Services
                 {"Environment", GetEnvironmentNameForTestEnvironments()}
             };
 
-            var notifyEmail = new NotifyEmail
+            foreach (string emailAddress in Global.GeoDistributionList)
             {
-                EmailAddress = emailAddress,
-                TemplateId = EmailTemplates.GeoSiteCertificateExpiredEmail,
-                Personalisation = personalisation
-            };
+                var notifyEmail = new NotifyEmail
+                {
+                    EmailAddress = emailAddress,
+                    TemplateId = EmailTemplates.GeoSiteCertificateExpiredEmail,
+                    Personalisation = personalisation
+                };
 
-            SendEmail(notifyEmail);
+                SendEmail(notifyEmail);
+            }
         }
 
         public void SendEmailFromQueue(NotifyEmail notifyEmail)

--- a/GenderPayGap.WebUI/Areas/Account/ViewServices/CloseAccountViewService.cs
+++ b/GenderPayGap.WebUI/Areas/Account/ViewServices/CloseAccountViewService.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using GenderPayGap.BusinessLogic.Account.Abstractions;
 using GenderPayGap.Database;
 using GenderPayGap.Extensions;
-using GenderPayGap.Extensions.AspNetCore;
 using GenderPayGap.WebUI.Areas.Account.Abstractions;
 using GenderPayGap.WebUI.Areas.Account.ViewModels;
 using GenderPayGap.WebUI.Services;
@@ -79,9 +78,7 @@ namespace GenderPayGap.WebUI.Areas.Account.ViewServices
             //Create the notification to GEO for each newly orphaned organisation
             userOrgs.Where(org => org.GetIsOrphan())
                 .ForEach(
-                    org => emailSendingService.SendGeoOrphanOrganisationEmail(
-                        Config.GetAppSetting("GEODistributionList"),
-                        org.OrganisationName));
+                    org => emailSendingService.SendGeoOrphanOrganisationEmail(org.OrganisationName));
 
             return errorState;
         }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminRemoveUserFromOrganisationController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminRemoveUserFromOrganisationController.cs
@@ -6,7 +6,6 @@ using GenderPayGap.BusinessLogic.Services;
 using GenderPayGap.Core;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
-using GenderPayGap.Extensions.AspNetCore;
 using GenderPayGap.WebUI.Classes;
 using GenderPayGap.WebUI.Helpers;
 using GenderPayGap.WebUI.Models.Admin;
@@ -144,7 +143,7 @@ namespace GenderPayGap.WebUI.Controllers
             // Send the notification to GEO for each newly orphaned organisation
             if (organisation.GetIsOrphan())
             {
-                emailSendingService.SendGeoOrphanOrganisationEmail(Config.GetAppSetting("GEODistributionList"), organisation.OrganisationName);
+                emailSendingService.SendGeoOrphanOrganisationEmail(organisation.OrganisationName);
             }
 
             // Audit log

--- a/GenderPayGap.WebUI/Controllers/OrganisationController.cs
+++ b/GenderPayGap.WebUI/Controllers/OrganisationController.cs
@@ -533,7 +533,7 @@ namespace GenderPayGap.WebUI.Controllers
             // Send the notification to GEO for each newly orphaned organisation
             if (orgToRemove.GetIsOrphan())
             {
-                emailSendingService.SendGeoOrphanOrganisationEmail(Config.GetAppSetting("GEODistributionList"), orgToRemove.OrganisationName);
+                emailSendingService.SendGeoOrphanOrganisationEmail(orgToRemove.OrganisationName);
             }
 
             //Make sure this organisation is no longer selected

--- a/GenderPayGap.WebUI/Controllers/RegisterController.Organisation.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.Organisation.cs
@@ -1868,7 +1868,6 @@ namespace GenderPayGap.WebUI.Controllers
             }
 
             emailSendingService.SendGeoOrganisationRegistrationRequestEmail(
-                Config.GetAppSetting("GEODistributionList"),
                 contactName,
                 reportingOrg,
                 reportingAddress,

--- a/GenderPayGap.WebUI/Controllers/SubmitController.CheckData.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.CheckData.cs
@@ -7,7 +7,6 @@ using GenderPayGap.Core;
 using GenderPayGap.Core.Models;
 using GenderPayGap.Core.Models.HttpResultModels;
 using GenderPayGap.Database;
-using GenderPayGap.Extensions.AspNetCore;
 using GenderPayGap.WebUI.Classes;
 using GenderPayGap.WebUI.Models.Submit;
 using GenderPayGap.WebUI.Services;
@@ -228,7 +227,6 @@ namespace GenderPayGap.WebUI.Controllers.Submission
                 && postedReturn.Organisation.Returns.Count(r => r.AccountingDate == postedReturn.AccountingDate) == 1)
             {
                 emailSendingService.SendGeoFirstTimeDataSubmissionEmail(
-                    Config.GetAppSetting("GEODistributionList"),
                     postedReturn.AccountingDate.Year.ToString(),
                     postedReturn.Organisation.OrganisationName,
                     postedReturn.StatusDate.ToShortDateString(),

--- a/GenderPayGap.WebUI/Services/EmailSendingService.cs
+++ b/GenderPayGap.WebUI/Services/EmailSendingService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GenderPayGap.Core;
 using GenderPayGap.Core.Classes;
 using GenderPayGap.Core.Classes.Logger;
 using GenderPayGap.Core.Interfaces;
@@ -327,28 +328,27 @@ namespace GenderPayGap.WebUI.Services
             await AddEmailToQueue(notifyEmail);
         }
 
-        public async void SendGeoOrphanOrganisationEmail(string emailAddress, string organisationName)
+        public async void SendGeoOrphanOrganisationEmail(string organisationName)
         {
             var personalisation = new Dictionary<string, dynamic>
             {
                 {"OrganisationName", organisationName}
             };
 
-            var notifyEmail = new NotifyEmail
+            foreach (string emailAddress in Global.GeoDistributionList)
             {
-                EmailAddress = emailAddress,
-                TemplateId = EmailTemplates.SendGeoOrphanOrganisationEmail,
-                Personalisation = personalisation
-            };
+                var notifyEmail = new NotifyEmail
+                {
+                    EmailAddress = emailAddress,
+                    TemplateId = EmailTemplates.SendGeoOrphanOrganisationEmail,
+                    Personalisation = personalisation
+                };
 
-            await AddEmailToQueue(notifyEmail);
+                await AddEmailToQueue(notifyEmail);
+            }
         }
 
-        public async void SendGeoOrganisationRegistrationRequestEmail(string emailAddress,
-            string contactName,
-            string reportingOrg,
-            string reportingAddress,
-            string url)
+        public async void SendGeoOrganisationRegistrationRequestEmail(string contactName, string reportingOrg, string reportingAddress, string url)
         {
             var personalisation = new Dictionary<string, dynamic>
             {
@@ -359,19 +359,21 @@ namespace GenderPayGap.WebUI.Services
                 {"Environment", GetEnvironmentNameForTestEnvironments()}
             };
 
-            var notifyEmail = new NotifyEmail
+            foreach (string emailAddress in Global.GeoDistributionList)
             {
-                EmailAddress = emailAddress,
-                TemplateId = EmailTemplates.SendGeoOrganisationRegistrationRequestEmail,
-                Personalisation = personalisation
-            };
+                var notifyEmail = new NotifyEmail
+                {
+                    EmailAddress = emailAddress,
+                    TemplateId = EmailTemplates.SendGeoOrganisationRegistrationRequestEmail,
+                    Personalisation = personalisation
+                };
 
-            await AddEmailToQueue(notifyEmail);
+                await AddEmailToQueue(notifyEmail);
+            }
         }
 
-        public async void SendGeoFirstTimeDataSubmissionEmail(string emailAddress, string year, string organisationName, string postedDate, string url)
+        public async void SendGeoFirstTimeDataSubmissionEmail(string year, string organisationName, string postedDate, string url)
         {
-
             var personalisation = new Dictionary<string, dynamic>
             {
                 {"year", year},
@@ -380,14 +382,17 @@ namespace GenderPayGap.WebUI.Services
                 {"url", url},
             };
 
-            var notifyEmail = new NotifyEmail
+            foreach (string emailAddress in Global.GeoDistributionList)
             {
-                EmailAddress = emailAddress,
-                TemplateId = EmailTemplates.SendGeoFirstTimeDataSubmissionEmail,
-                Personalisation = personalisation
-            };
+                var notifyEmail = new NotifyEmail
+                {
+                    EmailAddress = emailAddress,
+                    TemplateId = EmailTemplates.SendGeoFirstTimeDataSubmissionEmail,
+                    Personalisation = personalisation
+                };
 
-            await AddEmailToQueue(notifyEmail);
+                await AddEmailToQueue(notifyEmail);
+            }
         }
 
         private async Task<bool> AddEmailToQueue(NotifyEmail notifyEmail)


### PR DESCRIPTION
Two things related to the `GEODistributionList` setting:
* It should allow a list of email addresses, separated by `;`
* Since the GEO emails always go to the GEO DL, we don't need to pass the email address parameter in all the GEO emails