### PR TITLE
AB#41007 Refactor Search

### DIFF
--- a/GenderPayGap.WebUI/Controllers/Admin/AdminSearchController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminSearchController.cs
@@ -1,4 +1,5 @@
 ﻿using GenderPayGap.WebUI.Models.Admin;
+using GenderPayGap.WebUI.Search;
 using GenderPayGap.WebUI.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,11 +11,11 @@ namespace GenderPayGap.WebUI.Controllers
     public class AdminSearchController : Controller
     {
 
-        private readonly AdminSearchService adminSearchService;
+        private readonly SearchRepository searchRepository;
 
-        public AdminSearchController(AdminSearchService adminSearchService)
+        public AdminSearchController(SearchRepository searchRepository)
         {
-            this.adminSearchService = adminSearchService;
+            this.searchRepository = searchRepository;
         }
 
         [HttpGet("search")]
@@ -33,7 +34,7 @@ namespace GenderPayGap.WebUI.Controllers
             }
             else
             {
-                AdminSearchResultsViewModel results = adminSearchService.Search(query);
+                AdminSearchResultsViewModel results = searchRepository.Search(query);
 
                 viewModel.SearchResults = results;
             }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminSearchController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminSearchController.cs
@@ -11,11 +11,11 @@ namespace GenderPayGap.WebUI.Controllers
     public class AdminSearchController : Controller
     {
 
-        private readonly SearchRepository searchRepository;
+        private readonly AdminSearchService adminSearchService;
 
-        public AdminSearchController(SearchRepository searchRepository)
+        public AdminSearchController(AdminSearchService adminSearchService)
         {
-            this.searchRepository = searchRepository;
+            this.adminSearchService = adminSearchService;
         }
 
         [HttpGet("search")]
@@ -34,7 +34,7 @@ namespace GenderPayGap.WebUI.Controllers
             }
             else
             {
-                AdminSearchResultsViewModel results = searchRepository.Search(query);
+                AdminSearchResultsViewModel results = adminSearchService.Search(query);
 
                 viewModel.SearchResults = results;
             }

--- a/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
@@ -19,12 +19,10 @@ namespace GenderPayGap.WebUI.Models.Admin
         public List<AdminSearchResultOrganisationViewModel> OrganisationResults { get; set; }
         public List<AdminSearchResultUserViewModel> UserResults { get; set; }
 
-        public double LoadingMilliSeconds { get; set; }
         public double FilteringMilliSeconds { get; set; }
         public double OrderingMilliSeconds { get; set; }
         public double HighlightingMilliSeconds { get; set; }
         public int SearchCacheUpdatedSecondsAgo { get; set; }
-        public bool UsedCache { get; set; }
 
     }
 

--- a/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/AdminSearchViewModel.cs
@@ -19,9 +19,6 @@ namespace GenderPayGap.WebUI.Models.Admin
         public List<AdminSearchResultOrganisationViewModel> OrganisationResults { get; set; }
         public List<AdminSearchResultUserViewModel> UserResults { get; set; }
 
-        public double FilteringMilliSeconds { get; set; }
-        public double OrderingMilliSeconds { get; set; }
-        public double HighlightingMilliSeconds { get; set; }
         public int SearchCacheUpdatedSecondsAgo { get; set; }
 
     }

--- a/GenderPayGap.WebUI/Search/AdminSearchService.cs
+++ b/GenderPayGap.WebUI/Search/AdminSearchService.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GenderPayGap.Extensions;
+using GenderPayGap.WebUI.Models.Admin;
+using GenderPayGap.WebUI.Search.CachedObjects;
+
+namespace GenderPayGap.WebUI.Search
+{
+    public class AdminSearchService
+    {
+
+        public AdminSearchResultsViewModel Search(string query)
+        {
+            query = query.Trim();
+
+            List<string> searchTerms = ExtractSearchTermsFromQuery(query);
+
+            DateTime timeDetailsLoaded = SearchRepository.CacheLastUpdated; // Do this before we run the search, in case the cache is updated whilst the search is running
+
+            var results = new AdminSearchResultsViewModel
+            {
+                OrganisationResults = SearchOrganisations(query, searchTerms),
+                UserResults = SearchUsers(searchTerms),
+
+                SearchCacheUpdatedSecondsAgo = (int)VirtualDateTime.Now.Subtract(timeDetailsLoaded).TotalSeconds,
+            };
+            return results;
+        }
+
+        private List<string> ExtractSearchTermsFromQuery(string query)
+        {
+            return WordSplittingRegex.SplitValueIntoWords(query);
+        }
+
+
+        #region Search Organisations
+        private List<AdminSearchResultOrganisationViewModel> SearchOrganisations(string query, List<string> searchTerms)
+        {
+            List<SearchCachedOrganisation> allOrganisations = SearchRepository.CachedOrganisations;
+
+            List<SearchCachedOrganisation> matchingOrganisations = GetMatchingOrganisations(allOrganisations, searchTerms, query);
+
+            List<SearchCachedOrganisation> matchingOrganisationsOrderedByName =
+                matchingOrganisations.OrderBy(o => o.OrganisationName.OriginalValue.ToLower()).ToList();
+
+            List<AdminSearchResultOrganisationViewModel> matchingOrganisationsWithHighlightedMatches =
+                HighlightOrganisationMatches(matchingOrganisationsOrderedByName, searchTerms, query);
+
+            return matchingOrganisationsWithHighlightedMatches;
+        }
+
+        private List<SearchCachedOrganisation> GetMatchingOrganisations(
+            List<SearchCachedOrganisation> allOrganisations,
+            List<string> searchTerms,
+            string query)
+        {
+            return allOrganisations
+                .Where(
+                    organisation =>
+                    {
+                        bool nameMatches = CurrentOrPreviousOrganisationNameMatchesSearchTerms(organisation, searchTerms);
+                        bool employerRefMatches = organisation.EmployerReference == query;
+                        bool companyNumberMatches = organisation.CompanyNumber == query;
+                        return nameMatches || employerRefMatches || companyNumberMatches;
+                    })
+                .ToList();
+        }
+
+        private bool CurrentOrPreviousOrganisationNameMatchesSearchTerms(SearchCachedOrganisation organisation, List<string> searchTerms)
+        {
+            return organisation.OrganisationNames.Any(on => on.Matches(searchTerms));
+        }
+
+        private List<AdminSearchResultOrganisationViewModel> HighlightOrganisationMatches(
+            List<SearchCachedOrganisation> organisations,
+            List<string> searchTerms,
+            string query)
+        {
+            return organisations
+                .Select(
+                    organisation =>
+                    {
+                        AdminSearchMatchViewModel matchGroupsForCurrentName = GetMatchGroups(organisation.OrganisationName.OriginalValue, searchTerms);
+
+                        IEnumerable<SearchReadyValue> previousNames = organisation.OrganisationNames
+                            .Where(on => on.OriginalValue != organisation.OrganisationName.OriginalValue);
+
+                        List<AdminSearchMatchViewModel> matchGroupsForPreviousNames = previousNames
+                            .Where(on => on.Matches(searchTerms))
+                            .Select(on => GetMatchGroups(on.OriginalValue, searchTerms))
+                            .ToList();
+
+                        string employerRefMatch = organisation.EmployerReference == query
+                            ? organisation.EmployerReference
+                            : null;
+
+                        string companyNumberMatch = organisation.CompanyNumber == query
+                            ? organisation.CompanyNumber
+                            : null;
+
+                        return new AdminSearchResultOrganisationViewModel
+                        {
+                            OrganisationName = matchGroupsForCurrentName,
+                            OrganisationPreviousNames = matchGroupsForPreviousNames,
+                            EmployerRef = employerRefMatch,
+                            CompanyNumber = companyNumberMatch,
+                            OrganisationId = organisation.OrganisationId,
+                            Status = organisation.Status
+                        };
+                    })
+                .ToList();
+        }
+        #endregion
+
+
+        #region Search Users
+        private List<AdminSearchResultUserViewModel> SearchUsers(List<string> searchTerms)
+        {
+            List<SearchCachedUser> allUsers = SearchRepository.CachedUsers;
+
+            List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
+
+            List<SearchCachedUser> matchingUsersOrderedByName =
+                matchingUsers.OrderBy(u => u.FullName.OriginalValue).ToList();
+
+            List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
+                HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
+
+            return matchingUsersWithHighlightedMatches;
+        }
+
+        private List<SearchCachedUser> GetMatchingUsers(List<SearchCachedUser> allUsers, List<string> searchTerms)
+        {
+            return allUsers
+                .Where(user => user.FullName.Matches(searchTerms) || user.EmailAddress.Matches(searchTerms))
+                .ToList();
+        }
+
+        private List<AdminSearchResultUserViewModel> HighlightUserMatches(
+            List<SearchCachedUser> users,
+            List<string> searchTerms
+        )
+        {
+            return users
+                .Select(
+                    user =>
+                    {
+                        AdminSearchMatchViewModel matchGroupsForFullName = GetMatchGroups(user.FullName.OriginalValue, searchTerms);
+                        AdminSearchMatchViewModel matchGroupsForEmailAddress = GetMatchGroups(user.EmailAddress.OriginalValue, searchTerms);
+
+                        return new AdminSearchResultUserViewModel
+                        {
+                            UserId = user.UserId,
+                            UserFullName = matchGroupsForFullName,
+                            UserEmailAddress = matchGroupsForEmailAddress,
+                            Status = user.Status
+                        };
+                    })
+                .ToList();
+        }
+        #endregion
+
+
+        #region Helpers
+        private AdminSearchMatchViewModel GetMatchGroups(string organisationName, List<string> searchTerms)
+        {
+            var matchGroups = new List<AdminSearchMatchGroupViewModel>();
+
+            var stillSearching = true;
+            var searchStart = 0;
+            while (stillSearching)
+            {
+                AdminSearchMatchGroupViewModel nextMatch = GetNextMatch(organisationName, searchTerms, searchStart);
+                if (nextMatch != null)
+                {
+                    matchGroups.Add(nextMatch);
+                    searchStart = nextMatch.Start + nextMatch.Length;
+                    if (searchStart >= organisationName.Length)
+                    {
+                        stillSearching = false;
+                    }
+                }
+                else
+                {
+                    stillSearching = false;
+                }
+            }
+
+            return new AdminSearchMatchViewModel { Text = organisationName, MatchGroups = matchGroups };
+        }
+
+        private static AdminSearchMatchGroupViewModel GetNextMatch(string organisationName, List<string> searchTerms, int searchStart)
+        {
+            var possibleMatches = new List<AdminSearchMatchGroupViewModel>();
+
+            foreach (string searchTerm in searchTerms)
+            {
+                int matchStart = organisationName.IndexOf(searchTerm, searchStart, StringComparison.InvariantCultureIgnoreCase);
+                if (matchStart != -1)
+                {
+                    possibleMatches.Add(new AdminSearchMatchGroupViewModel { Start = matchStart, Length = searchTerm.Length });
+                }
+            }
+
+            return possibleMatches
+                .OrderBy(m => m.Start)
+                .ThenByDescending(m => m.Length)
+                .FirstOrDefault();
+        }
+        #endregion
+
+    }
+
+}

--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedOrganisation.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedOrganisation.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using GenderPayGap.Core;
+
+namespace GenderPayGap.WebUI.Search.CachedObjects {
+
+    internal class SearchCachedOrganisation
+    {
+        public long OrganisationId { get; set; }
+        public string OrganisationName { get; set; }
+        public List<string> OrganisationNames { get; set; } // All names (current and previous)
+        public string CompanyNumber { get; set; }
+        public string EmployerReference { get; set; }
+        public OrganisationStatuses Status { get; set; }
+    }
+}

--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedOrganisation.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedOrganisation.cs
@@ -6,8 +6,8 @@ namespace GenderPayGap.WebUI.Search.CachedObjects {
     internal class SearchCachedOrganisation
     {
         public long OrganisationId { get; set; }
-        public string OrganisationName { get; set; }
-        public List<string> OrganisationNames { get; set; } // All names (current and previous)
+        public SearchReadyValue OrganisationName { get; set; }
+        public List<SearchReadyValue> OrganisationNames { get; set; } // All names (current and previous)
         public string CompanyNumber { get; set; }
         public string EmployerReference { get; set; }
         public OrganisationStatuses Status { get; set; }

--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedUser.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedUser.cs
@@ -1,0 +1,12 @@
+﻿using GenderPayGap.Core;
+
+namespace GenderPayGap.WebUI.Search.CachedObjects {
+
+    internal class SearchCachedUser
+    {
+        public long UserId { get; set; }
+        public string FullName { get; set; }
+        public string EmailAddress { get; set; }
+        public UserStatuses Status { get; set; }
+    }
+}

--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedUser.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedUser.cs
@@ -5,8 +5,8 @@ namespace GenderPayGap.WebUI.Search.CachedObjects {
     internal class SearchCachedUser
     {
         public long UserId { get; set; }
-        public string FullName { get; set; }
-        public string EmailAddress { get; set; }
+        public SearchReadyValue FullName { get; set; }
+        public SearchReadyValue EmailAddress { get; set; }
         public UserStatuses Status { get; set; }
     }
 }

--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchReadyValue.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchReadyValue.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace GenderPayGap.WebUI.Search.CachedObjects
 {
@@ -17,20 +17,8 @@ namespace GenderPayGap.WebUI.Search.CachedObjects
         public SearchReadyValue(string originalValue)
         {
             OriginalValue = originalValue;
-            LowercaseWords = SplitValueIntoWords(originalValue);
+            LowercaseWords = WordSplittingRegex.SplitValueIntoWords(originalValue);
             Acronym = MakeAcronymFromWords(LowercaseWords);
-        }
-
-        private static List<string> SplitValueIntoWords(string originalValue)
-        {
-            Match match = WordSplittingRegex.Regex.Match(originalValue);
-            if (match.Success)
-            {
-                return match.Groups
-                    .Select(g => g.Value.ToLower())
-                    .ToList();
-            }
-            return new List<string>();
         }
 
         private string MakeAcronymFromWords(List<string> words)
@@ -38,6 +26,38 @@ namespace GenderPayGap.WebUI.Search.CachedObjects
             var firstLetterOfEachWord = words.Select(word => word.Substring(0, 1));
             string acronym = string.Join("", firstLetterOfEachWord);
             return acronym;
+        }
+
+
+        public bool Matches(List<string> searchTerms)
+        {
+            foreach (string searchTerm in searchTerms)
+            {
+                if (!(SearchTermIsPartOfAcronym(searchTerm) || SearchTermIsPartOfAWord(searchTerm)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool SearchTermIsPartOfAcronym(string searchTerm)
+        {
+            return Acronym.Contains(searchTerm);
+        }
+
+        private bool SearchTermIsPartOfAWord(string searchTerm)
+        {
+            foreach (string word in LowercaseWords)
+            {
+                if (word.Contains(searchTerm))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
     }

--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchReadyValue.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchReadyValue.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace GenderPayGap.WebUI.Search.CachedObjects
+{
+    public class SearchReadyValue
+    {
+
+        public string OriginalValue { get; }
+
+        public List<string> LowercaseWords { get; }
+
+        public string Acronym { get; }
+
+
+        public SearchReadyValue(string originalValue)
+        {
+            OriginalValue = originalValue;
+            LowercaseWords = SplitValueIntoWords(originalValue);
+            Acronym = MakeAcronymFromWords(LowercaseWords);
+        }
+
+        private static List<string> SplitValueIntoWords(string originalValue)
+        {
+            Match match = WordSplittingRegex.Regex.Match(originalValue);
+            if (match.Success)
+            {
+                return match.Groups
+                    .Select(g => g.Value.ToLower())
+                    .ToList();
+            }
+            return new List<string>();
+        }
+
+        private string MakeAcronymFromWords(List<string> words)
+        {
+            var firstLetterOfEachWord = words.Select(word => word.Substring(0, 1));
+            string acronym = string.Join("", firstLetterOfEachWord);
+            return acronym;
+        }
+
+    }
+}

--- a/GenderPayGap.WebUI/Search/SearchCacheUpdaterService.cs
+++ b/GenderPayGap.WebUI/Search/SearchCacheUpdaterService.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
 using GenderPayGap.Core.Classes.Logger;
-using GenderPayGap.Core.Interfaces;
-using GenderPayGap.Extensions;
-using GenderPayGap.WebUI.Search.CachedObjects;
 using Microsoft.Extensions.Hosting;
 
 namespace GenderPayGap.WebUI.Search {
@@ -34,13 +29,7 @@ namespace GenderPayGap.WebUI.Search {
         {
             CustomLogger.Information("Starting cache update (SearchRepository.StartCacheUpdateThread)");
 
-            var dataRepository = MvcApplication.ContainerIoC.Resolve<IDataRepository>();
-            List<SearchCachedOrganisation> allOrganisations = SearchRepository.LoadAllOrganisations(dataRepository);
-            List<SearchCachedUser> allUsers = SearchRepository.LoadAllUsers(dataRepository);
-
-            SearchRepository.cachedOrganisations = allOrganisations;
-            SearchRepository.cachedUsers = allUsers;
-            SearchRepository.cacheLastUpdated = VirtualDateTime.Now;
+            SearchRepository.LoadSearchDataIntoCache();
 
             CustomLogger.Information("Finished cache update (SearchRepository.StartCacheUpdateThread)");
         }

--- a/GenderPayGap.WebUI/Search/SearchCacheUpdaterService.cs
+++ b/GenderPayGap.WebUI/Search/SearchCacheUpdaterService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +22,7 @@ namespace GenderPayGap.WebUI.Search {
             timer = new Timer(
                 DoWork,
                 null,
-                dueTime: TimeSpan.FromSeconds(10), // How long to wait before the cache is first updated 
+                dueTime: TimeSpan.FromSeconds(0), // How long to wait before the cache is first updated 
                 period: TimeSpan.FromMinutes(1));  // How often is the cache updated 
 
             CustomLogger.Information("Started timer (SearchRepository.StartCacheUpdateThread)");

--- a/GenderPayGap.WebUI/Search/SearchCacheUpdaterService.cs
+++ b/GenderPayGap.WebUI/Search/SearchCacheUpdaterService.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using GenderPayGap.Core.Classes.Logger;
+using GenderPayGap.Core.Interfaces;
+using GenderPayGap.Extensions;
+using GenderPayGap.WebUI.Search.CachedObjects;
+using Microsoft.Extensions.Hosting;
+
+namespace GenderPayGap.WebUI.Search {
+
+    public class SearchCacheUpdaterService : IHostedService, IDisposable
+    {
+        private Timer timer;
+
+        public Task StartAsync(CancellationToken stoppingToken)
+        {
+            CustomLogger.Information("Starting timer (SearchRepository.StartCacheUpdateThread)");
+
+            timer = new Timer(
+                DoWork,
+                null,
+                dueTime: TimeSpan.FromSeconds(10), // How long to wait before the cache is first updated 
+                period: TimeSpan.FromMinutes(1));  // How often is the cache updated 
+
+            CustomLogger.Information("Started timer (SearchRepository.StartCacheUpdateThread)");
+
+            return Task.CompletedTask;
+        }
+
+        private void DoWork(object state)
+        {
+            CustomLogger.Information("Starting cache update (SearchRepository.StartCacheUpdateThread)");
+
+            var dataRepository = MvcApplication.ContainerIoC.Resolve<IDataRepository>();
+            List<SearchCachedOrganisation> allOrganisations = SearchRepository.LoadAllOrganisations(dataRepository);
+            List<SearchCachedUser> allUsers = SearchRepository.LoadAllUsers(dataRepository);
+
+            SearchRepository.cachedOrganisations = allOrganisations;
+            SearchRepository.cachedUsers = allUsers;
+            SearchRepository.cacheLastUpdated = VirtualDateTime.Now;
+
+            CustomLogger.Information("Finished cache update (SearchRepository.StartCacheUpdateThread)");
+        }
+
+        public Task StopAsync(CancellationToken stoppingToken)
+        {
+            CustomLogger.Information("Timed Hosted Service is stopping.");
+
+            timer?.Change(Timeout.Infinite, 0);
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            timer?.Dispose();
+        }
+    }
+}

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -64,26 +64,11 @@ namespace GenderPayGap.WebUI.Search
         {
             List<string> searchTerms = ExtractSearchTermsFromQuery(query);
 
-            List<SearchCachedOrganisation> allOrganisations = cachedOrganisations;
-            List<SearchCachedUser> allUsers = cachedUsers;
-            DateTime timeDetailsLoaded = cacheLastUpdated;
-
-            List<SearchCachedOrganisation> matchingOrganisations = GetMatchingOrganisations(allOrganisations, searchTerms, query);
-            List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
-
-            List<SearchCachedOrganisation> matchingOrganisationsOrderedByName =
-                matchingOrganisations.OrderBy(o => o.OrganisationName.ToLower()).ToList();
-            List<SearchCachedUser> matchingUsersOrderedByName =
-                matchingUsers.OrderBy(u => u.FullName).ToList();
-
-            List<AdminSearchResultOrganisationViewModel> matchingOrganisationsWithHighlightedMatches =
-                HighlightOrganisationMatches(matchingOrganisationsOrderedByName, searchTerms, query);
-            List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
-                HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
+            DateTime timeDetailsLoaded = cacheLastUpdated; // Do this before we run the search, in case the cache is updated whilst the search is running
 
             var results = new AdminSearchResultsViewModel {
-                OrganisationResults = matchingOrganisationsWithHighlightedMatches,
-                UserResults = matchingUsersWithHighlightedMatches,
+                OrganisationResults = SearchOrganisations(query, searchTerms),
+                UserResults = SearchUsers(searchTerms),
 
                 SearchCacheUpdatedSecondsAgo = (int)VirtualDateTime.Now.Subtract(timeDetailsLoaded).TotalSeconds,
             };
@@ -95,6 +80,36 @@ namespace GenderPayGap.WebUI.Search
             return query.Split(" ", StringSplitOptions.RemoveEmptyEntries)
                 .Select(st => st.ToLower())
                 .ToList();
+        }
+
+        private List<AdminSearchResultOrganisationViewModel> SearchOrganisations(string query, List<string> searchTerms)
+        {
+            List<SearchCachedOrganisation> allOrganisations = cachedOrganisations;
+
+            List<SearchCachedOrganisation> matchingOrganisations = GetMatchingOrganisations(allOrganisations, searchTerms, query);
+            
+            List<SearchCachedOrganisation> matchingOrganisationsOrderedByName =
+                matchingOrganisations.OrderBy(o => o.OrganisationName.ToLower()).ToList();
+            
+            List<AdminSearchResultOrganisationViewModel> matchingOrganisationsWithHighlightedMatches =
+                HighlightOrganisationMatches(matchingOrganisationsOrderedByName, searchTerms, query);
+            
+            return matchingOrganisationsWithHighlightedMatches;
+        }
+
+        private List<AdminSearchResultUserViewModel> SearchUsers(List<string> searchTerms)
+        {
+            List<SearchCachedUser> allUsers = cachedUsers;
+            
+            List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
+            
+            List<SearchCachedUser> matchingUsersOrderedByName =
+                matchingUsers.OrderBy(u => u.FullName).ToList();
+            
+            List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
+                HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
+            
+            return matchingUsersWithHighlightedMatches;
         }
 
         private List<SearchCachedOrganisation> GetMatchingOrganisations(

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -5,30 +5,28 @@ using Autofac;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Extensions;
-using GenderPayGap.WebUI.Models.Admin;
 using GenderPayGap.WebUI.Search.CachedObjects;
 using Microsoft.EntityFrameworkCore;
 
 namespace GenderPayGap.WebUI.Search
 {
 
-    public class SearchRepository
+    public static class SearchRepository
     {
 
-        private static List<SearchCachedOrganisation> cachedOrganisations;
-        private static List<SearchCachedUser> cachedUsers;
-        private static DateTime cacheLastUpdated = DateTime.MinValue;
+        internal static List<SearchCachedOrganisation> CachedOrganisations { get; private set; }
+        internal static List<SearchCachedUser> CachedUsers { get; private set; }
+        internal static DateTime CacheLastUpdated { get; private set; } = DateTime.MinValue;
 
 
-        #region Load data into cache
         public static void LoadSearchDataIntoCache()
         {
             var dataRepository = MvcApplication.ContainerIoC.Resolve<IDataRepository>();
 
-            cachedOrganisations = LoadAllOrganisations(dataRepository);
-            cachedUsers = LoadAllUsers(dataRepository);
+            CachedOrganisations = LoadAllOrganisations(dataRepository);
+            CachedUsers = LoadAllUsers(dataRepository);
 
-            cacheLastUpdated = VirtualDateTime.Now;
+            CacheLastUpdated = VirtualDateTime.Now;
         }
 
         private static List<SearchCachedOrganisation> LoadAllOrganisations(IDataRepository repository)
@@ -36,15 +34,16 @@ namespace GenderPayGap.WebUI.Search
             return repository
                 .GetAll<Organisation>()
                 .Include(o => o.OrganisationNames)
-                .Select(o => new SearchCachedOrganisation
-                {
-                    OrganisationId = o.OrganisationId,
-                    OrganisationName = new SearchReadyValue(o.OrganisationName),
-                    CompanyNumber = o.CompanyNumber != null ? o.CompanyNumber.Trim() : null,
-                    EmployerReference = o.EmployerReference != null ? o.EmployerReference.Trim() : null,
-                    OrganisationNames = o.OrganisationNames.Select(on => new SearchReadyValue(on.Name)).ToList(),
-                    Status = o.Status
-                })
+                .Select(
+                    o => new SearchCachedOrganisation
+                    {
+                        OrganisationId = o.OrganisationId,
+                        OrganisationName = new SearchReadyValue(o.OrganisationName),
+                        CompanyNumber = o.CompanyNumber != null ? o.CompanyNumber.Trim() : null,
+                        EmployerReference = o.EmployerReference != null ? o.EmployerReference.Trim() : null,
+                        OrganisationNames = o.OrganisationNames.Select(on => new SearchReadyValue(on.Name)).ToList(),
+                        Status = o.Status
+                    })
                 .ToList();
         }
 
@@ -52,217 +51,16 @@ namespace GenderPayGap.WebUI.Search
         {
             return repository
                 .GetAll<User>()
-                .Select(u => new SearchCachedUser
-                {
-                    UserId = u.UserId,
-                    FullName = new SearchReadyValue(u.Fullname),
-                    EmailAddress = new SearchReadyValue(u.EmailAddress),
-                    Status = u.Status
-                })
-                .ToList();
-        }
-        #endregion
-
-
-        public AdminSearchResultsViewModel Search(string query)
-        {
-            query = query.Trim();
-
-            List<string> searchTerms = ExtractSearchTermsFromQuery(query);
-
-            DateTime timeDetailsLoaded = cacheLastUpdated; // Do this before we run the search, in case the cache is updated whilst the search is running
-
-            var results = new AdminSearchResultsViewModel {
-                OrganisationResults = SearchOrganisations(query, searchTerms),
-                UserResults = SearchUsers(searchTerms),
-
-                SearchCacheUpdatedSecondsAgo = (int)VirtualDateTime.Now.Subtract(timeDetailsLoaded).TotalSeconds,
-            };
-            return results;
-        }
-
-        private List<string> ExtractSearchTermsFromQuery(string query)
-        {
-            return WordSplittingRegex.SplitValueIntoWords(query);
-        }
-
-
-        #region Search Organisations
-        private List<AdminSearchResultOrganisationViewModel> SearchOrganisations(string query, List<string> searchTerms)
-        {
-            List<SearchCachedOrganisation> allOrganisations = cachedOrganisations;
-
-            List<SearchCachedOrganisation> matchingOrganisations = GetMatchingOrganisations(allOrganisations, searchTerms, query);
-            
-            List<SearchCachedOrganisation> matchingOrganisationsOrderedByName =
-                matchingOrganisations.OrderBy(o => o.OrganisationName.OriginalValue.ToLower()).ToList();
-            
-            List<AdminSearchResultOrganisationViewModel> matchingOrganisationsWithHighlightedMatches =
-                HighlightOrganisationMatches(matchingOrganisationsOrderedByName, searchTerms, query);
-            
-            return matchingOrganisationsWithHighlightedMatches;
-        }
-
-        private List<SearchCachedOrganisation> GetMatchingOrganisations(
-            List<SearchCachedOrganisation> allOrganisations,
-            List<string> searchTerms,
-            string query)
-        {
-            return allOrganisations
-                .Where(
-                    organisation =>
-                    {
-                        bool nameMatches = CurrentOrPreviousOrganisationNameMatchesSearchTerms(organisation, searchTerms);
-                        bool employerRefMatches = organisation.EmployerReference == query;
-                        bool companyNumberMatches = organisation.CompanyNumber == query;
-                        return nameMatches || employerRefMatches || companyNumberMatches;
-                    })
-                .ToList();
-        }
-
-        private bool CurrentOrPreviousOrganisationNameMatchesSearchTerms(SearchCachedOrganisation organisation, List<string> searchTerms)
-        {
-            return organisation.OrganisationNames.Any(on => on.Matches(searchTerms));
-        }
-
-        private List<AdminSearchResultOrganisationViewModel> HighlightOrganisationMatches(
-            List<SearchCachedOrganisation> organisations,
-            List<string> searchTerms,
-            string query)
-        {
-            return organisations
                 .Select(
-                    organisation =>
+                    u => new SearchCachedUser
                     {
-                        AdminSearchMatchViewModel matchGroupsForCurrentName = GetMatchGroups(organisation.OrganisationName.OriginalValue, searchTerms);
-
-                        IEnumerable<SearchReadyValue> previousNames = organisation.OrganisationNames
-                            .Where(on => on.OriginalValue != organisation.OrganisationName.OriginalValue);
-
-                        List<AdminSearchMatchViewModel> matchGroupsForPreviousNames = previousNames
-                            .Where(on => on.Matches(searchTerms))
-                            .Select(on => GetMatchGroups(on.OriginalValue, searchTerms))
-                            .ToList();
-
-                        string employerRefMatch = organisation.EmployerReference == query
-                            ? organisation.EmployerReference
-                            : null;
-
-                        string companyNumberMatch = organisation.CompanyNumber == query
-                            ? organisation.CompanyNumber
-                            : null;
-
-                        return new AdminSearchResultOrganisationViewModel
-                        {
-                            OrganisationName = matchGroupsForCurrentName,
-                            OrganisationPreviousNames = matchGroupsForPreviousNames,
-                            EmployerRef = employerRefMatch,
-                            CompanyNumber = companyNumberMatch,
-                            OrganisationId = organisation.OrganisationId,
-                            Status = organisation.Status
-                        };
+                        UserId = u.UserId,
+                        FullName = new SearchReadyValue(u.Fullname),
+                        EmailAddress = new SearchReadyValue(u.EmailAddress),
+                        Status = u.Status
                     })
                 .ToList();
         }
-        #endregion
-
-
-        #region Search Users
-        private List<AdminSearchResultUserViewModel> SearchUsers(List<string> searchTerms)
-        {
-            List<SearchCachedUser> allUsers = cachedUsers;
-
-            List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
-
-            List<SearchCachedUser> matchingUsersOrderedByName =
-                matchingUsers.OrderBy(u => u.FullName).ToList();
-
-            List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
-                HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
-
-            return matchingUsersWithHighlightedMatches;
-        }
-
-        private List<SearchCachedUser> GetMatchingUsers(List<SearchCachedUser> allUsers, List<string> searchTerms)
-        {
-            return allUsers
-                .Where(user => user.FullName.Matches(searchTerms) || user.EmailAddress.Matches(searchTerms))
-                .ToList();
-        }
-
-        private List<AdminSearchResultUserViewModel> HighlightUserMatches(
-            List<SearchCachedUser> users,
-            List<string> searchTerms
-        )
-        {
-            return users
-                .Select(
-                    user =>
-                    {
-                        AdminSearchMatchViewModel matchGroupsForFullName = GetMatchGroups(user.FullName.OriginalValue, searchTerms);
-                        AdminSearchMatchViewModel matchGroupsForEmailAddress = GetMatchGroups(user.EmailAddress.OriginalValue, searchTerms);
-
-                        return new AdminSearchResultUserViewModel
-                        {
-                            UserId = user.UserId,
-                            UserFullName = matchGroupsForFullName,
-                            UserEmailAddress = matchGroupsForEmailAddress,
-                            Status = user.Status
-                        };
-                    })
-                .ToList();
-        }
-        #endregion
-
-
-        #region Helpers
-
-        private AdminSearchMatchViewModel GetMatchGroups(string organisationName, List<string> searchTerms)
-        {
-            var matchGroups = new List<AdminSearchMatchGroupViewModel>();
-
-            var stillSearching = true;
-            var searchStart = 0;
-            while (stillSearching)
-            {
-                AdminSearchMatchGroupViewModel nextMatch = GetNextMatch(organisationName, searchTerms, searchStart);
-                if (nextMatch != null)
-                {
-                    matchGroups.Add(nextMatch);
-                    searchStart = nextMatch.Start + nextMatch.Length;
-                    if (searchStart >= organisationName.Length)
-                    {
-                        stillSearching = false;
-                    }
-                }
-                else
-                {
-                    stillSearching = false;
-                }
-            }
-
-            return new AdminSearchMatchViewModel { Text = organisationName, MatchGroups = matchGroups };
-        }
-
-        private static AdminSearchMatchGroupViewModel GetNextMatch(string organisationName, List<string> searchTerms, int searchStart)
-        {
-            var possibleMatches = new List<AdminSearchMatchGroupViewModel>();
-
-            foreach (string searchTerm in searchTerms)
-            {
-                int matchStart = organisationName.IndexOf(searchTerm, searchStart, StringComparison.InvariantCultureIgnoreCase);
-                if (matchStart != -1)
-                {
-                    possibleMatches.Add(new AdminSearchMatchGroupViewModel { Start = matchStart, Length = searchTerm.Length });
-                }
-            }
-
-            return possibleMatches
-                .OrderBy(m => m.Start)
-                .ThenByDescending(m => m.Length)
-                .FirstOrDefault();
-        }
-        #endregion
 
     }
 }

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -29,6 +29,37 @@ namespace GenderPayGap.WebUI.Search
             cacheLastUpdated = VirtualDateTime.Now;
         }
 
+        private static List<SearchCachedOrganisation> LoadAllOrganisations(IDataRepository repository)
+        {
+            return repository
+                .GetAll<Organisation>()
+                .Include(o => o.OrganisationNames)
+                .Select(o => new SearchCachedOrganisation
+                {
+                    OrganisationId = o.OrganisationId,
+                    OrganisationName = o.OrganisationName,
+                    CompanyNumber = o.CompanyNumber,
+                    EmployerReference = o.EmployerReference,
+                    OrganisationNames = o.OrganisationNames.Select(on => @on.Name).ToList(),
+                    Status = o.Status
+                })
+                .ToList();
+        }
+
+        private static List<SearchCachedUser> LoadAllUsers(IDataRepository repository)
+        {
+            return repository
+                .GetAll<User>()
+                .Select(u => new SearchCachedUser
+                {
+                    UserId = u.UserId,
+                    FullName = u.Fullname,
+                    EmailAddress = u.EmailAddress,
+                    Status = u.Status
+                })
+                .ToList();
+        }
+
         public AdminSearchResultsViewModel Search(string query)
         {
             List<string> searchTerms = ExtractSearchTermsFromQuery(query);
@@ -73,37 +104,6 @@ namespace GenderPayGap.WebUI.Search
         {
             return query.Split(" ", StringSplitOptions.RemoveEmptyEntries)
                 .Select(st => st.ToLower())
-                .ToList();
-        }
-
-        private static List<SearchCachedOrganisation> LoadAllOrganisations(IDataRepository repository)
-        {
-            return repository
-                .GetAll<Organisation>()
-                .Include(o => o.OrganisationNames)
-                .Select(o => new SearchCachedOrganisation
-                {
-                    OrganisationId = o.OrganisationId,
-                    OrganisationName = o.OrganisationName,
-                    CompanyNumber = o.CompanyNumber,
-                    EmployerReference = o.EmployerReference,
-                    OrganisationNames = o.OrganisationNames.Select(on => @on.Name).ToList(),
-                    Status = o.Status
-                })
-                .ToList();
-        }
-
-        private static List<SearchCachedUser> LoadAllUsers(IDataRepository repository)
-        {
-            return repository
-                .GetAll<User>()
-                .Select(u => new SearchCachedUser
-                {
-                    UserId = u.UserId,
-                    FullName = u.Fullname,
-                    EmailAddress = u.EmailAddress,
-                    Status = u.Status
-                })
                 .ToList();
         }
 

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -19,6 +19,8 @@ namespace GenderPayGap.WebUI.Search
         private static List<SearchCachedUser> cachedUsers;
         private static DateTime cacheLastUpdated = DateTime.MinValue;
 
+
+        #region Load data into cache
         public static void LoadSearchDataIntoCache()
         {
             var dataRepository = MvcApplication.ContainerIoC.Resolve<IDataRepository>();
@@ -59,6 +61,8 @@ namespace GenderPayGap.WebUI.Search
                 })
                 .ToList();
         }
+        #endregion
+
 
         public AdminSearchResultsViewModel Search(string query)
         {
@@ -82,6 +86,8 @@ namespace GenderPayGap.WebUI.Search
                 .ToList();
         }
 
+
+        #region Search Organisations
         private List<AdminSearchResultOrganisationViewModel> SearchOrganisations(string query, List<string> searchTerms)
         {
             List<SearchCachedOrganisation> allOrganisations = cachedOrganisations;
@@ -97,21 +103,6 @@ namespace GenderPayGap.WebUI.Search
             return matchingOrganisationsWithHighlightedMatches;
         }
 
-        private List<AdminSearchResultUserViewModel> SearchUsers(List<string> searchTerms)
-        {
-            List<SearchCachedUser> allUsers = cachedUsers;
-            
-            List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
-            
-            List<SearchCachedUser> matchingUsersOrderedByName =
-                matchingUsers.OrderBy(u => u.FullName).ToList();
-            
-            List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
-                HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
-            
-            return matchingUsersWithHighlightedMatches;
-        }
-
         private List<SearchCachedOrganisation> GetMatchingOrganisations(
             List<SearchCachedOrganisation> allOrganisations,
             List<string> searchTerms,
@@ -119,7 +110,8 @@ namespace GenderPayGap.WebUI.Search
         {
             return allOrganisations
                 .Where(
-                    organisation => {
+                    organisation =>
+                    {
                         bool nameMatches = CurrentOrPreviousOrganisationNameMatchesSearchTerms(organisation, searchTerms);
                         bool employerRefMatches = organisation.EmployerReference?.Trim() == query.Trim();
                         bool companyNumberMatches = organisation.CompanyNumber?.Trim() == query.Trim();
@@ -128,21 +120,9 @@ namespace GenderPayGap.WebUI.Search
                 .ToList();
         }
 
-        private List<SearchCachedUser> GetMatchingUsers(List<SearchCachedUser> allUsers, List<string> searchTerms)
-        {
-            return allUsers
-                .Where(user => NameMatchesSearchTerms(user.FullName, searchTerms) || NameMatchesSearchTerms(user.EmailAddress, searchTerms))
-                .ToList();
-        }
-
         private bool CurrentOrPreviousOrganisationNameMatchesSearchTerms(SearchCachedOrganisation organisation, List<string> searchTerms)
         {
             return organisation.OrganisationNames.Any(on => NameMatchesSearchTerms(on, searchTerms));
-        }
-
-        private bool NameMatchesSearchTerms(string name, List<string> searchTerms)
-        {
-            return searchTerms.All(st => name.ToLower().Contains(st));
         }
 
         private List<AdminSearchResultOrganisationViewModel> HighlightOrganisationMatches(
@@ -152,11 +132,12 @@ namespace GenderPayGap.WebUI.Search
         {
             return organisations
                 .Select(
-                    organisation => {
+                    organisation =>
+                    {
                         AdminSearchMatchViewModel matchGroupsForCurrentName = GetMatchGroups(organisation.OrganisationName, searchTerms);
 
                         IEnumerable<string> previousNames = organisation.OrganisationNames
-                            .Except(new[] {organisation.OrganisationName});
+                            .Except(new[] { organisation.OrganisationName });
 
                         List<AdminSearchMatchViewModel> matchGroupsForPreviousNames = previousNames
                             .Where(on => NameMatchesSearchTerms(on, searchTerms))
@@ -171,7 +152,8 @@ namespace GenderPayGap.WebUI.Search
                             ? organisation.CompanyNumber
                             : null;
 
-                        return new AdminSearchResultOrganisationViewModel {
+                        return new AdminSearchResultOrganisationViewModel
+                        {
                             OrganisationName = matchGroupsForCurrentName,
                             OrganisationPreviousNames = matchGroupsForPreviousNames,
                             EmployerRef = employerRefMatch,
@@ -182,6 +164,31 @@ namespace GenderPayGap.WebUI.Search
                     })
                 .ToList();
         }
+        #endregion
+
+
+        #region Search Users
+        private List<AdminSearchResultUserViewModel> SearchUsers(List<string> searchTerms)
+        {
+            List<SearchCachedUser> allUsers = cachedUsers;
+
+            List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
+
+            List<SearchCachedUser> matchingUsersOrderedByName =
+                matchingUsers.OrderBy(u => u.FullName).ToList();
+
+            List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
+                HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
+
+            return matchingUsersWithHighlightedMatches;
+        }
+
+        private List<SearchCachedUser> GetMatchingUsers(List<SearchCachedUser> allUsers, List<string> searchTerms)
+        {
+            return allUsers
+                .Where(user => NameMatchesSearchTerms(user.FullName, searchTerms) || NameMatchesSearchTerms(user.EmailAddress, searchTerms))
+                .ToList();
+        }
 
         private List<AdminSearchResultUserViewModel> HighlightUserMatches(
             List<SearchCachedUser> users,
@@ -190,11 +197,13 @@ namespace GenderPayGap.WebUI.Search
         {
             return users
                 .Select(
-                    user => {
+                    user =>
+                    {
                         AdminSearchMatchViewModel matchGroupsForFullName = GetMatchGroups(user.FullName, searchTerms);
                         AdminSearchMatchViewModel matchGroupsForEmailAddress = GetMatchGroups(user.EmailAddress, searchTerms);
 
-                        return new AdminSearchResultUserViewModel {
+                        return new AdminSearchResultUserViewModel
+                        {
                             UserId = user.UserId,
                             UserFullName = matchGroupsForFullName,
                             UserEmailAddress = matchGroupsForEmailAddress,
@@ -202,6 +211,14 @@ namespace GenderPayGap.WebUI.Search
                         };
                     })
                 .ToList();
+        }
+        #endregion
+
+
+        #region Helpers
+        private bool NameMatchesSearchTerms(string name, List<string> searchTerms)
+        {
+            return searchTerms.All(st => name.ToLower().Contains(st));
         }
 
         private AdminSearchMatchViewModel GetMatchGroups(string organisationName, List<string> searchTerms)
@@ -228,7 +245,7 @@ namespace GenderPayGap.WebUI.Search
                 }
             }
 
-            return new AdminSearchMatchViewModel {Text = organisationName, MatchGroups = matchGroups};
+            return new AdminSearchMatchViewModel { Text = organisationName, MatchGroups = matchGroups };
         }
 
         private static AdminSearchMatchGroupViewModel GetNextMatch(string organisationName, List<string> searchTerms, int searchStart)
@@ -240,7 +257,7 @@ namespace GenderPayGap.WebUI.Search
                 int matchStart = organisationName.IndexOf(searchTerm, searchStart, StringComparison.InvariantCultureIgnoreCase);
                 if (matchStart != -1)
                 {
-                    possibleMatches.Add(new AdminSearchMatchGroupViewModel {Start = matchStart, Length = searchTerm.Length});
+                    possibleMatches.Add(new AdminSearchMatchGroupViewModel { Start = matchStart, Length = searchTerm.Length });
                 }
             }
 
@@ -249,6 +266,7 @@ namespace GenderPayGap.WebUI.Search
                 .ThenByDescending(m => m.Length)
                 .FirstOrDefault();
         }
+        #endregion
 
     }
 }

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autofac;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Extensions;
@@ -14,9 +15,19 @@ namespace GenderPayGap.WebUI.Search
     public class SearchRepository
     {
 
-        internal static List<SearchCachedOrganisation> cachedOrganisations;
-        internal static List<SearchCachedUser> cachedUsers;
-        internal static DateTime cacheLastUpdated = DateTime.MinValue;
+        private static List<SearchCachedOrganisation> cachedOrganisations;
+        private static List<SearchCachedUser> cachedUsers;
+        private static DateTime cacheLastUpdated = DateTime.MinValue;
+
+        public static void LoadSearchDataIntoCache()
+        {
+            var dataRepository = MvcApplication.ContainerIoC.Resolve<IDataRepository>();
+
+            cachedOrganisations = LoadAllOrganisations(dataRepository);
+            cachedUsers = LoadAllUsers(dataRepository);
+
+            cacheLastUpdated = VirtualDateTime.Now;
+        }
 
         public AdminSearchResultsViewModel Search(string query)
         {
@@ -65,7 +76,7 @@ namespace GenderPayGap.WebUI.Search
                 .ToList();
         }
 
-        internal static List<SearchCachedOrganisation> LoadAllOrganisations(IDataRepository repository)
+        private static List<SearchCachedOrganisation> LoadAllOrganisations(IDataRepository repository)
         {
             return repository
                 .GetAll<Organisation>()
@@ -76,13 +87,13 @@ namespace GenderPayGap.WebUI.Search
                     OrganisationName = o.OrganisationName,
                     CompanyNumber = o.CompanyNumber,
                     EmployerReference = o.EmployerReference,
-                    OrganisationNames = o.OrganisationNames.Select(on => on.Name).ToList(),
+                    OrganisationNames = o.OrganisationNames.Select(on => @on.Name).ToList(),
                     Status = o.Status
                 })
                 .ToList();
         }
 
-        internal static List<SearchCachedUser> LoadAllUsers(IDataRepository repository)
+        private static List<SearchCachedUser> LoadAllUsers(IDataRepository repository)
         {
             return repository
                 .GetAll<User>()

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -13,42 +13,18 @@ namespace GenderPayGap.WebUI.Search
 
     public class SearchRepository
     {
-        private readonly IDataRepository dataRepository;
 
         internal static List<SearchCachedOrganisation> cachedOrganisations;
         internal static List<SearchCachedUser> cachedUsers;
         internal static DateTime cacheLastUpdated = DateTime.MinValue;
 
-        public SearchRepository(IDataRepository dataRepository)
-        {
-            this.dataRepository = dataRepository;
-        }
-
         public AdminSearchResultsViewModel Search(string query)
         {
             List<string> searchTerms = ExtractSearchTermsFromQuery(query);
 
-            List<SearchCachedOrganisation> allOrganisations;
-            List<SearchCachedUser> allUsers;
-            DateTime timeDetailsLoaded;
-            bool usedCache;
-
-            DateTime loadingStart = VirtualDateTime.Now;
-            if (cacheLastUpdated < VirtualDateTime.Now.AddSeconds(-70))
-            {
-                allOrganisations = LoadAllOrganisations(dataRepository);
-                allUsers = LoadAllUsers(dataRepository);
-                timeDetailsLoaded = VirtualDateTime.Now;
-                usedCache = false;
-            }
-            else
-            {
-                allOrganisations = cachedOrganisations;
-                allUsers = cachedUsers;
-                timeDetailsLoaded = cacheLastUpdated;
-                usedCache = true;
-            }
-            DateTime loadingEnd = VirtualDateTime.Now;
+            List<SearchCachedOrganisation> allOrganisations = cachedOrganisations;
+            List<SearchCachedUser> allUsers = cachedUsers;
+            DateTime timeDetailsLoaded = cacheLastUpdated;
 
             DateTime filteringStart = VirtualDateTime.Now;
             List<SearchCachedOrganisation> matchingOrganisations = GetMatchingOrganisations(allOrganisations, searchTerms, query);
@@ -73,13 +49,11 @@ namespace GenderPayGap.WebUI.Search
                 OrganisationResults = matchingOrganisationsWithHighlightedMatches,
                 UserResults = matchingUsersWithHighlightedMatches,
 
-                LoadingMilliSeconds = loadingEnd.Subtract(loadingStart).TotalMilliseconds,
                 FilteringMilliSeconds = filteringEnd.Subtract(filteringStart).TotalMilliseconds,
                 OrderingMilliSeconds = orderingEnd.Subtract(orderingStart).TotalMilliseconds,
                 HighlightingMilliSeconds = highlightingEnd.Subtract(highlightingStart).TotalMilliseconds,
 
                 SearchCacheUpdatedSecondsAgo = (int)VirtualDateTime.Now.Subtract(timeDetailsLoaded).TotalSeconds,
-                UsedCache = usedCache
             };
             return results;
         }

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -1,72 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Autofac;
-using GenderPayGap.Core.Classes.Logger;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Extensions;
 using GenderPayGap.WebUI.Models.Admin;
-using GenderPayGap.WebUI.Search;
 using GenderPayGap.WebUI.Search.CachedObjects;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Hosting;
 
-namespace GenderPayGap.WebUI.Services
+namespace GenderPayGap.WebUI.Search
 {
 
-    public class AdminSearchServiceCacheUpdater : IHostedService, IDisposable
-    {
-        private Timer timer;
-
-        public Task StartAsync(CancellationToken stoppingToken)
-        {
-            CustomLogger.Information("Starting timer (AdminSearchService.StartCacheUpdateThread)");
-
-            timer = new Timer(
-                DoWork,
-                null,
-                dueTime: TimeSpan.FromSeconds(10), // How long to wait before the cache is first updated 
-                period: TimeSpan.FromMinutes(1));  // How often is the cache updated 
-
-            CustomLogger.Information("Started timer (AdminSearchService.StartCacheUpdateThread)");
-
-            return Task.CompletedTask;
-        }
-
-        private void DoWork(object state)
-        {
-            CustomLogger.Information("Starting cache update (AdminSearchService.StartCacheUpdateThread)");
-
-            var dataRepository = MvcApplication.ContainerIoC.Resolve<IDataRepository>();
-            List<SearchCachedOrganisation> allOrganisations = AdminSearchService.LoadAllOrganisations(dataRepository);
-            List<SearchCachedUser> allUsers = AdminSearchService.LoadAllUsers(dataRepository);
-
-            AdminSearchService.cachedOrganisations = allOrganisations;
-            AdminSearchService.cachedUsers = allUsers;
-            AdminSearchService.cacheLastUpdated = VirtualDateTime.Now;
-
-            CustomLogger.Information("Finished cache update (AdminSearchService.StartCacheUpdateThread)");
-        }
-
-        public Task StopAsync(CancellationToken stoppingToken)
-        {
-            CustomLogger.Information("Timed Hosted Service is stopping.");
-
-            timer?.Change(Timeout.Infinite, 0);
-
-            return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            timer?.Dispose();
-        }
-    }
-
-    public class AdminSearchService
+    public class SearchRepository
     {
         private readonly IDataRepository dataRepository;
 
@@ -74,7 +19,7 @@ namespace GenderPayGap.WebUI.Services
         internal static List<SearchCachedUser> cachedUsers;
         internal static DateTime cacheLastUpdated = DateTime.MinValue;
 
-        public AdminSearchService(IDataRepository dataRepository)
+        public SearchRepository(IDataRepository dataRepository)
         {
             this.dataRepository = dataRepository;
         }

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -40,9 +40,9 @@ namespace GenderPayGap.WebUI.Search
                 {
                     OrganisationId = o.OrganisationId,
                     OrganisationName = new SearchReadyValue(o.OrganisationName),
-                    CompanyNumber = o.CompanyNumber,
-                    EmployerReference = o.EmployerReference,
-                    OrganisationNames = o.OrganisationNames.Select(on => new SearchReadyValue(@on.Name)).ToList(),
+                    CompanyNumber = o.CompanyNumber != null ? o.CompanyNumber.Trim() : null,
+                    EmployerReference = o.EmployerReference != null ? o.EmployerReference.Trim() : null,
+                    OrganisationNames = o.OrganisationNames.Select(on => new SearchReadyValue(on.Name)).ToList(),
                     Status = o.Status
                 })
                 .ToList();
@@ -66,6 +66,8 @@ namespace GenderPayGap.WebUI.Search
 
         public AdminSearchResultsViewModel Search(string query)
         {
+            query = query.Trim();
+
             List<string> searchTerms = ExtractSearchTermsFromQuery(query);
 
             DateTime timeDetailsLoaded = cacheLastUpdated; // Do this before we run the search, in case the cache is updated whilst the search is running
@@ -113,8 +115,8 @@ namespace GenderPayGap.WebUI.Search
                     organisation =>
                     {
                         bool nameMatches = CurrentOrPreviousOrganisationNameMatchesSearchTerms(organisation, searchTerms);
-                        bool employerRefMatches = organisation.EmployerReference?.Trim() == query.Trim();
-                        bool companyNumberMatches = organisation.CompanyNumber?.Trim() == query.Trim();
+                        bool employerRefMatches = organisation.EmployerReference == query;
+                        bool companyNumberMatches = organisation.CompanyNumber == query;
                         return nameMatches || employerRefMatches || companyNumberMatches;
                     })
                 .ToList();
@@ -145,11 +147,11 @@ namespace GenderPayGap.WebUI.Search
                             .Select(on => GetMatchGroups(on, searchTerms))
                             .ToList();
 
-                        string employerRefMatch = organisation.EmployerReference?.Trim() == query.Trim()
+                        string employerRefMatch = organisation.EmployerReference == query
                             ? organisation.EmployerReference
                             : null;
 
-                        string companyNumberMatch = organisation.CompanyNumber?.Trim() == query.Trim()
+                        string companyNumberMatch = organisation.CompanyNumber == query
                             ? organisation.CompanyNumber
                             : null;
 

--- a/GenderPayGap.WebUI/Search/SearchRepository.cs
+++ b/GenderPayGap.WebUI/Search/SearchRepository.cs
@@ -68,32 +68,22 @@ namespace GenderPayGap.WebUI.Search
             List<SearchCachedUser> allUsers = cachedUsers;
             DateTime timeDetailsLoaded = cacheLastUpdated;
 
-            DateTime filteringStart = VirtualDateTime.Now;
             List<SearchCachedOrganisation> matchingOrganisations = GetMatchingOrganisations(allOrganisations, searchTerms, query);
             List<SearchCachedUser> matchingUsers = GetMatchingUsers(allUsers, searchTerms);
-            DateTime filteringEnd = VirtualDateTime.Now;
 
-            DateTime orderingStart = VirtualDateTime.Now;
             List<SearchCachedOrganisation> matchingOrganisationsOrderedByName =
                 matchingOrganisations.OrderBy(o => o.OrganisationName.ToLower()).ToList();
             List<SearchCachedUser> matchingUsersOrderedByName =
                 matchingUsers.OrderBy(u => u.FullName).ToList();
-            DateTime orderingEnd = VirtualDateTime.Now;
 
-            DateTime highlightingStart = VirtualDateTime.Now;
             List<AdminSearchResultOrganisationViewModel> matchingOrganisationsWithHighlightedMatches =
                 HighlightOrganisationMatches(matchingOrganisationsOrderedByName, searchTerms, query);
             List<AdminSearchResultUserViewModel> matchingUsersWithHighlightedMatches =
                 HighlightUserMatches(matchingUsersOrderedByName, searchTerms);
-            DateTime highlightingEnd = VirtualDateTime.Now;
 
             var results = new AdminSearchResultsViewModel {
                 OrganisationResults = matchingOrganisationsWithHighlightedMatches,
                 UserResults = matchingUsersWithHighlightedMatches,
-
-                FilteringMilliSeconds = filteringEnd.Subtract(filteringStart).TotalMilliseconds,
-                OrderingMilliSeconds = orderingEnd.Subtract(orderingStart).TotalMilliseconds,
-                HighlightingMilliSeconds = highlightingEnd.Subtract(highlightingStart).TotalMilliseconds,
 
                 SearchCacheUpdatedSecondsAgo = (int)VirtualDateTime.Now.Subtract(timeDetailsLoaded).TotalSeconds,
             };

--- a/GenderPayGap.WebUI/Search/WordSplittingRegex.cs
+++ b/GenderPayGap.WebUI/Search/WordSplittingRegex.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace GenderPayGap.WebUI.Search
 {
@@ -15,29 +17,29 @@ namespace GenderPayGap.WebUI.Search
                     return regex;
                 }
 
-                // The "language=regexp" comments below tell Resharper to do regex syntax highlighting
-                // "CG" means "character group" - i.e. [A-Z] in regex
-
+                // The "language=regexp" comment below tells Resharper to do regex syntax highlighting
                 //language=regexp
-                string wordCG = "[a-zA-Z0-9'-]";
-                //language=regexp
-                string nonWordCG = "[^a-zA-Z0-9'-]";
-
-                //language=regexp
-                string regexPattern =
-                    "^" // Start of line
-                    + "(?:" // Start of non-capturing group
-                    +    $"{nonWordCG}*" // Start with non-word characters (0+ times - i.e. optional)
-                    +    "(" // Capture this next bit - we only want to capture the word characters, not the non-word characters
-                    +        $"{wordCG}+" // Some word characters (1+ i.e. there must be some word characters!)
-                    +    ")" // End capture
-                    + ")+"  // End of non-capturing group - repeat this 1+ times
-                    + $"{nonWordCG}*" // End with non-word characters (0+ times - i.e. optional)
-                    + "$"; // End of line
+                var regexPattern = "[a-zA-Z0-9'-]+";
 
                 regex = new Regex(regexPattern, RegexOptions.Compiled);
                 return regex;
             }
+        }
+
+        public static List<string> SplitValueIntoWords(string originalValue)
+        {
+            if (originalValue != null)
+            {
+                MatchCollection matches = Regex.Matches(originalValue);
+                //if (matches.Success)
+                {
+                    return matches
+                        .Select(m => m.Value.ToLower())
+                        .ToList();
+                }
+            }
+
+            return new List<string>();
         }
 
     }

--- a/GenderPayGap.WebUI/Search/WordSplittingRegex.cs
+++ b/GenderPayGap.WebUI/Search/WordSplittingRegex.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.RegularExpressions;
+
+namespace GenderPayGap.WebUI.Search
+{
+    public static class WordSplittingRegex
+    {
+        private static Regex regex;
+
+        public static Regex Regex
+        {
+            get
+            {
+                if (regex != null)
+                {
+                    return regex;
+                }
+
+                // The "language=regexp" comments below tell Resharper to do regex syntax highlighting
+                // "CG" means "character group" - i.e. [A-Z] in regex
+
+                //language=regexp
+                string wordCG = "[a-zA-Z0-9'-]";
+                //language=regexp
+                string nonWordCG = "[^a-zA-Z0-9'-]";
+
+                //language=regexp
+                string regexPattern =
+                    "^" // Start of line
+                    + "(?:" // Start of non-capturing group
+                    +    $"{nonWordCG}*" // Start with non-word characters (0+ times - i.e. optional)
+                    +    "(" // Capture this next bit - we only want to capture the word characters, not the non-word characters
+                    +        $"{wordCG}+" // Some word characters (1+ i.e. there must be some word characters!)
+                    +    ")" // End capture
+                    + ")+"  // End of non-capturing group - repeat this 1+ times
+                    + $"{nonWordCG}*" // End with non-word characters (0+ times - i.e. optional)
+                    + "$"; // End of line
+
+                regex = new Regex(regexPattern, RegexOptions.Compiled);
+                return regex;
+            }
+        }
+
+    }
+}

--- a/GenderPayGap.WebUI/Search/WordSplittingRegex.cs
+++ b/GenderPayGap.WebUI/Search/WordSplittingRegex.cs
@@ -31,15 +31,22 @@ namespace GenderPayGap.WebUI.Search
             if (originalValue != null)
             {
                 MatchCollection matches = Regex.Matches(originalValue);
-                //if (matches.Success)
-                {
-                    return matches
-                        .Select(m => m.Value.ToLower())
-                        .ToList();
-                }
+
+                return matches
+                    .Select(m => m.Value.ToLower())
+                    .Select(RemovePunctuation)
+                    .Where(word => word != "")
+                    .ToList();
             }
 
             return new List<string>();
+        }
+
+        private static string RemovePunctuation(string input)
+        {
+            return input
+                .Replace("'", "")
+                .Replace("-", "");
         }
 
     }

--- a/GenderPayGap.WebUI/Startup.cs
+++ b/GenderPayGap.WebUI/Startup.cs
@@ -280,7 +280,7 @@ namespace GenderPayGap.WebUI
             builder.RegisterType<SearchViewService>().As<ISearchViewService>().InstancePerLifetimeScope();
             builder.RegisterType<CompareViewService>().As<ICompareViewService>().InstancePerLifetimeScope();
             builder.RegisterType<ScopePresentation>().As<IScopePresentation>().InstancePerLifetimeScope();
-            builder.RegisterType<SearchRepository>().As<SearchRepository>().InstancePerLifetimeScope();
+            builder.RegisterType<AdminSearchService>().As<AdminSearchService>().InstancePerLifetimeScope();
             builder.RegisterType<AuditLogger>().As<AuditLogger>().InstancePerLifetimeScope();
 
             //Register some singletons

--- a/GenderPayGap.WebUI/Startup.cs
+++ b/GenderPayGap.WebUI/Startup.cs
@@ -30,6 +30,7 @@ using GenderPayGap.WebUI.Classes;
 using GenderPayGap.WebUI.Classes.Presentation;
 using GenderPayGap.WebUI.Classes.Services;
 using GenderPayGap.WebUI.Options;
+using GenderPayGap.WebUI.Search;
 using GenderPayGap.WebUI.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -147,7 +148,7 @@ namespace GenderPayGap.WebUI
                 Config.GetAppSetting("AuthSecret", "secret"),
                 BackChannelHandler);
 
-            services.AddHostedService<AdminSearchServiceCacheUpdater>();
+            services.AddHostedService<SearchCacheUpdaterService>();
 
             HangfireConfigurationHelper.ConfigureServices(services);
 
@@ -279,7 +280,7 @@ namespace GenderPayGap.WebUI
             builder.RegisterType<SearchViewService>().As<ISearchViewService>().InstancePerLifetimeScope();
             builder.RegisterType<CompareViewService>().As<ICompareViewService>().InstancePerLifetimeScope();
             builder.RegisterType<ScopePresentation>().As<IScopePresentation>().InstancePerLifetimeScope();
-            builder.RegisterType<AdminSearchService>().As<AdminSearchService>().InstancePerLifetimeScope();
+            builder.RegisterType<SearchRepository>().As<SearchRepository>().InstancePerLifetimeScope();
             builder.RegisterType<AuditLogger>().As<AuditLogger>().InstancePerLifetimeScope();
 
             //Register some singletons

--- a/GenderPayGap.WebUI/Views/Admin/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/Admin/Search.cshtml
@@ -110,17 +110,13 @@
         @if (Model.SearchResults != null)
         {
             <!--
-            Loading      @(Model.SearchResults.LoadingMilliSeconds)ms
             Filtering    @(Model.SearchResults.FilteringMilliSeconds)ms
             Ordering     @(Model.SearchResults.OrderingMilliSeconds)ms
             Highlighting @(Model.SearchResults.HighlightingMilliSeconds)ms
             -->
-            @if (Model.SearchResults.UsedCache)
-            {
-                <p class="govuk-body-s">
-                    Changes made within the last @(Model.SearchResults.SearchCacheUpdatedSecondsAgo) seconds will not be reflected in these results.
-                </p>
-            }
+            <p class="govuk-body-s">
+                Changes made within the last @(Model.SearchResults.SearchCacheUpdatedSecondsAgo) seconds will not be reflected in these results.
+            </p>
 
             <details class="govuk-details" data-module="govuk-details" open>
                 <summary class="govuk-details__summary">

--- a/GenderPayGap.WebUI/Views/Admin/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/Admin/Search.cshtml
@@ -109,11 +109,6 @@
 
         @if (Model.SearchResults != null)
         {
-            <!--
-            Filtering    @(Model.SearchResults.FilteringMilliSeconds)ms
-            Ordering     @(Model.SearchResults.OrderingMilliSeconds)ms
-            Highlighting @(Model.SearchResults.HighlightingMilliSeconds)ms
-            -->
             <p class="govuk-body-s">
                 Changes made within the last @(Model.SearchResults.SearchCacheUpdatedSecondsAgo) seconds will not be reflected in these results.
             </p>


### PR DESCRIPTION
* Split out these bits from AdminSearchService
  * SearchRepository
  * SearchCacheUpdaterService
  * 2 cached objects (for Organisations and Users)
* Keep AdminSearchService for the admin-specific search logic
* Make the Admin Search able to search by acronyms (e.g. "bbc" for "British Broadcasting Corporation Limited"