### PR TITLE
GPG-321 Add HTTP Basic Auth for non-production environments

### DIFF
--- a/GenderPayGap.Core/Global.cs
+++ b/GenderPayGap.Core/Global.cs
@@ -45,6 +45,8 @@ namespace GenderPayGap.Core
         public static string EhrcIPRange => Config.GetAppSetting("EhrcIPRange");
         public static string GpgAnalysisAppApiPassword => Config.GetAppSetting("GpgAnalysisAppApiPassword");
         public static string DataMigrationPassword => Config.GetAppSetting("DataMigrationPassword");
+        public static string BasicAuthUsername => Config.GetAppSetting("BasicAuthUsername");
+        public static string BasicAuthPassword => Config.GetAppSetting("BasicAuthPassword");
 
         #endregion
 

--- a/GenderPayGap.WebUI/Helpers/BasicAuthMiddleware.cs
+++ b/GenderPayGap.WebUI/Helpers/BasicAuthMiddleware.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using GenderPayGap.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace GenderPayGap.WebUI.Helpers
+{
+    public class BasicAuthMiddleware
+    {
+
+        private readonly RequestDelegate _next;
+
+        public BasicAuthMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            // Add HTTP Basic Authentication in our non-production environments to make sure people don't accidentally stumble across the site
+            // The site will still also be secured by the usual login/cookie auth - this is just an extra layer to make the site not publicly accessible
+            try
+            {
+                var authHeader = AuthenticationHeaderValue.Parse(httpContext.Request.Headers["Authorization"]);
+                var credentialBytes = Convert.FromBase64String(authHeader.Parameter);
+                var credentials = Encoding.UTF8.GetString(credentialBytes).Split(new[] { ':' }, 2);
+                var username = credentials[0];
+                var password = credentials[1];
+
+                if (Global.BasicAuthUsername == username &&
+                    Global.BasicAuthPassword == password)
+                {
+                    await _next.Invoke(httpContext);
+                }
+                else
+                {
+                    SendUnauthorisedResponse(httpContext);
+                }
+            }
+            catch
+            {
+                SendUnauthorisedResponse(httpContext);
+            }
+        }
+
+        private static void SendUnauthorisedResponse(HttpContext httpContext)
+        {
+            httpContext.Response.StatusCode = 401;
+            httpContext.Response.Headers.Add("WWW-Authenticate", "Basic realm=\"Gender Pay Gap service\"");
+        }
+
+
+    }
+}

--- a/GenderPayGap.WebUI/Startup.cs
+++ b/GenderPayGap.WebUI/Startup.cs
@@ -39,7 +39,6 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Newtonsoft.Json.Serialization;
 using StackExchange.Redis;
 
 namespace GenderPayGap.WebUI
@@ -120,9 +119,6 @@ namespace GenderPayGap.WebUI
             AddRedisCache(services);
 
             DataProtectionKeysHelper.AddDataProtectionKeyStorage(services);
-
-            //This may now be required 
-            //services.AddHttpsRedirection(options => { options.HttpsPort = 443; });
 
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie(options =>
@@ -377,6 +373,15 @@ namespace GenderPayGap.WebUI
             app.UseCookiePolicy(cookiePolicyOptions);
             app.UseMaintenancePageMiddleware(Global.MaintenanceMode); //Redirect to maintenance page when Maintenance mode settings = true
             app.UseSecurityHeaderMiddleware(); //Add/remove security headers from all responses
+
+            if (!string.IsNullOrWhiteSpace(Global.BasicAuthUsername)
+                && !string.IsNullOrWhiteSpace(Global.BasicAuthPassword))
+            {
+                // Add HTTP Basic Authentication in our non-production environments to make sure people don't accidentally stumble across the site
+                // The site will still also be secured by the usual login/cookie auth - this is just an extra layer to make the site not publicly accessible
+                app.UseMiddleware<BasicAuthMiddleware>();
+            }
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();


### PR DESCRIPTION
This is just to make the site not publicly accessible / make sure the Googlebot doesn't crawl it - we still have the usual logic system to make sure only authorised users can logic and change data