### PR TITLE
GPG-362 Anonymise Feedback

### DIFF
--- a/GenderPayGap.Database/Migrations/20200828111240_AddHasBeenAnonymisedToFeedbackTable.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20200828111240_AddHasBeenAnonymisedToFeedbackTable.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20200828111240_AddHasBeenAnonymisedToFeedbackTable")]
+    partial class AddHasBeenAnonymisedToFeedbackTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20200828111240_AddHasBeenAnonymisedToFeedbackTable.cs
+++ b/GenderPayGap.Database/Migrations/20200828111240_AddHasBeenAnonymisedToFeedbackTable.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class AddHasBeenAnonymisedToFeedbackTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "HasBeenAnonymised",
+                table: "Feedback",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HasBeenAnonymised",
+                table: "Feedback");
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/Feedback.cs
+++ b/GenderPayGap.Database/Models/Feedback.cs
@@ -31,6 +31,9 @@ namespace GenderPayGap.Database.Models
         [JsonProperty]
         public DateTime CreatedDate { get; set; }
 
+        [JsonProperty]
+        public bool HasBeenAnonymised { get; set; }
+
         #region HowDidYouHearAboutGpg
 
         [JsonProperty]

--- a/GenderPayGap.WebUI/BackgroundJobs/BackgroundJobsApi.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/BackgroundJobsApi.cs
@@ -61,7 +61,7 @@ namespace GenderPayGap.WebUI.BackgroundJobs
 
             RecurringJob.AddOrUpdate<AnonymiseThreeYearOldFeedbackJob>(
                 ScheduledJobIds.AnonymiseThreeYearOldFeedbackJobId,
-                j => j.AnonymiseFeedback(),
+                j => j.AnonymiseFeedbackAction(),
                 "20 5 * * *" /* 05:20 once per day */);
         }
 

--- a/GenderPayGap.WebUI/BackgroundJobs/BackgroundJobsApi.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/BackgroundJobsApi.cs
@@ -58,6 +58,11 @@ namespace GenderPayGap.WebUI.BackgroundJobs
                 ScheduledJobIds.SetPresumedScopesJobId,
                 j => j.SetPresumedScopes(),
                 "50 4 * * *" /* 04:50 once per day */);
+
+            RecurringJob.AddOrUpdate<AnonymiseThreeYearOldFeedbackJob>(
+                ScheduledJobIds.AnonymiseThreeYearOldFeedbackJobId,
+                j => j.AnonymiseFeedback(),
+                "20 5 * * *" /* 05:20 once per day */);
         }
 
         public void AddEmailToQueue(NotifyEmail notifyEmail)
@@ -77,5 +82,7 @@ namespace GenderPayGap.WebUI.BackgroundJobs
         public const string PurgeRegistrationsJobId = "PURG_REGISTRATIONS_JOB";
         public const string PurgeOrganisationsJobId = "PURGE_ORGANISATIONS_JOB";
         public const string SetPresumedScopesJobId = "SET_PRESUMED_SCOPES_JOB";
+        public const string AnonymiseThreeYearOldFeedbackJobId = "ANONYMISE_THREE_YEAR_OLD_FEEDBACK_JOB";
+
     }
 }

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GenderPayGap.Core.Interfaces;
+using GenderPayGap.Database.Models;
 using GenderPayGap.Extensions;
 
 namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
@@ -17,25 +18,39 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
             this.dataRepository = dataRepository;
         }
 
-        public void AnonymiseFeedback()
+        public void AnonymiseFeedbackAction()
         {
             var runId = JobHelpers.CreateRunId();
             var startTime = VirtualDateTime.Now;
-            JobHelpers.LogFunctionStart(runId, nameof(AnonymiseFeedback), startTime);
+            JobHelpers.LogFunctionStart(runId, nameof(AnonymiseFeedbackAction), startTime);
 
             try
             {
-                // TODO: Add clever stuff here
+                DateTime threeYearsAgo = VirtualDateTime.Now.AddYears(-3);
 
-                JobHelpers.LogFunctionEnd(runId, nameof(AnonymiseFeedback), startTime);
+                List<Feedback> feedback = dataRepository.GetAll<Feedback>()
+                    .Where(f => DateTime.Compare(f.CreatedDate, threeYearsAgo) <= 0)
+                    .ToList();
+
+                foreach (Feedback feedbackItem in feedback)
+                {
+                    AnonymiseFeedback(feedbackItem);
+                }
+
+                JobHelpers.LogFunctionEnd(runId, nameof(AnonymiseFeedbackAction), startTime);
             }
             catch (Exception ex)
             {
-                JobHelpers.LogFunctionError(runId, nameof(AnonymiseFeedback), startTime, ex);
+                JobHelpers.LogFunctionError(runId, nameof(AnonymiseFeedbackAction), startTime, ex);
 
                 //Rethrow the error
                 throw;
             }
+        }
+
+        public void AnonymiseFeedback(Feedback feedback)
+        {
+            // TODO: Anonymise individual feedback item here (check what to anonymise to)
         }
 
     }

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
@@ -30,6 +30,7 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
 
                 List<Feedback> feedback = dataRepository.GetAll<Feedback>()
                     .Where(f => DateTime.Compare(f.CreatedDate, threeYearsAgo) <= 0)
+                    .Where(f => !f.HasBeenAnonymised)
                     .ToList();
 
                 foreach (Feedback feedbackItem in feedback)
@@ -73,6 +74,8 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
             feedback.Details = string.IsNullOrWhiteSpace(feedback.Details)
                 ? "not supplied"
                 : "supplied";
+
+            feedback.HasBeenAnonymised = true;
 
             dataRepository.SaveChangesAsync().Wait();
         }

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GenderPayGap.Core.Interfaces;
+using GenderPayGap.Extensions;
+
+namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
+{
+    public class AnonymiseThreeYearOldFeedbackJob
+    {
+
+        private readonly IDataRepository dataRepository;
+
+        public AnonymiseThreeYearOldFeedbackJob(IDataRepository dataRepository)
+        {
+            this.dataRepository = dataRepository;
+        }
+
+        public void AnonymiseFeedback()
+        {
+            var runId = JobHelpers.CreateRunId();
+            var startTime = VirtualDateTime.Now;
+            JobHelpers.LogFunctionStart(runId, nameof(AnonymiseFeedback), startTime);
+
+            try
+            {
+                // TODO: Add clever stuff here
+
+                JobHelpers.LogFunctionEnd(runId, nameof(AnonymiseFeedback), startTime);
+            }
+            catch (Exception ex)
+            {
+                JobHelpers.LogFunctionError(runId, nameof(AnonymiseFeedback), startTime, ex);
+
+                //Rethrow the error
+                throw;
+            }
+        }
+
+    }
+}

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/AnonymiseThreeYearOldFeedbackJob.cs
@@ -50,7 +50,31 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
 
         public void AnonymiseFeedback(Feedback feedback)
         {
-            // TODO: Anonymise individual feedback item here (check what to anonymise to)
+            feedback.OtherSourceText = string.IsNullOrWhiteSpace(feedback.OtherSourceText)
+                ? "not supplied"
+                : "supplied";
+
+            feedback.OtherReasonText = string.IsNullOrWhiteSpace(feedback.OtherReasonText)
+                ? "not supplied"
+                : "supplied";
+
+            feedback.OtherPersonText = string.IsNullOrWhiteSpace(feedback.OtherPersonText)
+                ? "not supplied"
+                : "supplied";
+
+            feedback.EmailAddress = string.IsNullOrWhiteSpace(feedback.EmailAddress)
+                ? "not supplied"
+                : "supplied";
+
+            feedback.PhoneNumber = string.IsNullOrWhiteSpace(feedback.PhoneNumber)
+                ? "not supplied"
+                : "supplied";
+
+            feedback.Details = string.IsNullOrWhiteSpace(feedback.Details)
+                ? "not supplied"
+                : "supplied";
+
+            dataRepository.SaveChangesAsync().Wait();
         }
 
     }


### PR DESCRIPTION
### Context
The new Data Retention Policy means that we should anonymise all PII after 3 years.

> As GEO I want to permanently delete all written feedback on the site three years after submission but keep scoring feedback so that the GPG team can monitor the performance of the site. 

### Changes
- Creates db migration to add HasBeenAnonymised field to Feedback table
- Adds daily job to check for any un-anonymised Feedback which is over 3 years old
- Implements function in job to anonymise any PII to "supplied" and "not supplied" values depending on original data