### PR TITLE
GPG-396 Create Accessibility Statement Page

### DIFF
--- a/GenderPayGap.WebUI/Controllers/HomeController.cs
+++ b/GenderPayGap.WebUI/Controllers/HomeController.cs
@@ -85,6 +85,16 @@ namespace GenderPayGap.WebUI.Controllers
         }
 
         #endregion
+        
+        #region Accessibility Statement
+        
+        [HttpGet("~/accessibility-statement")]
+        public IActionResult AccessibilityStatement()
+        {
+            return View("AccessibilityStatement");
+        }
+        
+        #endregion
 
     }
 }

--- a/GenderPayGap.WebUI/Controllers/HomeController.cs
+++ b/GenderPayGap.WebUI/Controllers/HomeController.cs
@@ -22,7 +22,7 @@ namespace GenderPayGap.WebUI.Controllers
         }
 
 
-        [HttpGet("~/ping")]
+        [HttpGet("ping")]
         public IActionResult Ping()
         {
             return new OkResult(); // OK = 200
@@ -38,7 +38,7 @@ namespace GenderPayGap.WebUI.Controllers
 
         #endregion
 
-        [HttpGet("~/report-concerns")]
+        [HttpGet("report-concerns")]
         public IActionResult ReportConcerns()
         {
             return View(nameof(ReportConcerns));
@@ -46,7 +46,7 @@ namespace GenderPayGap.WebUI.Controllers
 
         #region PrivacyPolicy
 
-        [HttpGet("~/privacy-policy")]
+        [HttpGet("privacy-policy")]
         public IActionResult PrivacyPolicy()
         {
             return View("PrivacyPolicy", null);
@@ -54,7 +54,7 @@ namespace GenderPayGap.WebUI.Controllers
 
         [PreventDuplicatePost]
         [ValidateAntiForgeryToken]
-        [HttpPost("~/privacy-policy")]
+        [HttpPost("privacy-policy")]
         public async Task<IActionResult> PrivacyPolicyPost()
         {
             if (!User.Identity.IsAuthenticated)
@@ -88,7 +88,7 @@ namespace GenderPayGap.WebUI.Controllers
         
         #region Accessibility Statement
         
-        [HttpGet("~/accessibility-statement")]
+        [HttpGet("accessibility-statement")]
         public IActionResult AccessibilityStatement()
         {
             return View("AccessibilityStatement");

--- a/GenderPayGap.WebUI/Views/GOVUK/Layouts/template.cshtml
+++ b/GenderPayGap.WebUI/Views/GOVUK/Layouts/template.cshtml
@@ -191,6 +191,9 @@
                     <li>
                         <a href="/report-concerns">Report Concerns</a>
                     </li>
+                    <li>
+                        <a href="/accessibility-statement">Accessibility Statement</a>
+                    </li>
                     @if (Config.OffsetCurrentDateTimeForSite() != TimeSpan.Zero)
                     {
                         <li style="font-size: smaller">@(VirtualDateTime.Now)</li>

--- a/GenderPayGap.WebUI/Views/GOVUK/Layouts/template.cshtml
+++ b/GenderPayGap.WebUI/Views/GOVUK/Layouts/template.cshtml
@@ -180,19 +180,19 @@
             <div class="footer-meta-inner">
                 <ul>
                     <li>
-                        <a href="/contact-us">Contact Us</a>
+                        <a href="@(Url.Action("ContactUs", "Home"))">Contact Us</a>
                     </li>
                     <li>
-                        <a href="/cookies">Cookies</a>
+                        <a href="@(Url.Action("CookieDetails", "Cookie"))">Cookies</a>
                     </li>
                     <li>
-                        <a href="/privacy-policy">Privacy Policy</a>
+                        <a href="@(Url.Action("PrivacyPolicy", "Home"))">Privacy Policy</a>
                     </li>
                     <li>
-                        <a href="/report-concerns">Report Concerns</a>
+                        <a href="@(Url.Action("ReportConcerns", "Home"))">Report Concerns</a>
                     </li>
                     <li>
-                        <a href="/accessibility-statement">Accessibility Statement</a>
+                        <a href="@(Url.Action("AccessibilityStatement", "Home"))">Accessibility statement</a>
                     </li>
                     @if (Config.OffsetCurrentDateTimeForSite() != TimeSpan.Zero)
                     {

--- a/GenderPayGap.WebUI/Views/GovUkFrontend/GovUkFrontendLayout.cshtml
+++ b/GenderPayGap.WebUI/Views/GovUkFrontend/GovUkFrontendLayout.cshtml
@@ -166,6 +166,11 @@
                 {
                     Text = "Report Concerns",
                     Href = Url.Action("ReportConcerns", "Home")
+                },
+                new FooterLinksViewModel
+                {
+                    Text = "Accessibility Statement",
+                    Href = Url.Action("AccessibilityStatement", "Home")
                 }
             }
         }

--- a/GenderPayGap.WebUI/Views/Home/AccessibilityStatement.cshtml
+++ b/GenderPayGap.WebUI/Views/Home/AccessibilityStatement.cshtml
@@ -1,0 +1,42 @@
+﻿@using GenderPayGap.Core
+@{
+    ViewBag.Title = "Accessibility Statement - Gender pay gap reporting service";
+    Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
+}
+
+<div id="contact-us-content" class="grid-row">
+    <div class="column-two-thirds">
+
+        <h1 class="heading-large ">
+            Contact Us
+        </h1>
+        <h2 class="heading-medium">Email</h2>
+        <p>
+            If you are an employer you can contact the gender pay gap team about the service or registration issues you're having at <a href="mailto:@(Global.GpgReportingEmail)" target="_blank">@Global.GpgReportingEmail</a>
+        </p>
+
+        <h2 class="heading-medium">Online</h2>
+        <p>If you would like to leave general feedback on the service please complete this <a href="@Url.Action("SendFeedbackGet", "Feedback")">online feedback form</a>.</p>
+        <p>Read our <a href="https://www.gov.uk/guidance/gender-pay-gap-reporting-overview" target="_blank" rel="noopener noreferrer">guidance to gender pay gap reporting<span class="visually-hidden">(opens in a new window)</span></a>.</p>
+
+        <h2 class="heading-medium">Post</h2>
+        <p>
+            Write to the Government Equalities Office:
+        </p>
+        <div class="panel">
+            <address style="font-style: normal">
+                Gender pay gap team<br/>
+                Government Equalities Office<br/>
+                6th Floor, Sanctuary Buildings<br/>
+                Great Smith Street<br/>
+                London<br/>
+                SW1P 3BT
+            </address>
+        </div>
+        <p></p>
+        <p class="script-only" style="text-align:center;">
+            <button class="button" onclick="windowClose()">Close Window</button>
+        </p>
+
+    </div>
+</div>

--- a/GenderPayGap.WebUI/Views/Home/AccessibilityStatement.cshtml
+++ b/GenderPayGap.WebUI/Views/Home/AccessibilityStatement.cshtml
@@ -4,39 +4,119 @@
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
-<div id="contact-us-content" class="grid-row">
-    <div class="column-two-thirds">
-
-        <h1 class="heading-large ">
-            Contact Us
+<div class="govuk-grid-row" xmlns="http://www.w3.org/1999/html">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+            Accessibility statement for Gender pay gap service
         </h1>
-        <h2 class="heading-medium">Email</h2>
-        <p>
-            If you are an employer you can contact the gender pay gap team about the service or registration issues you're having at <a href="mailto:@(Global.GpgReportingEmail)" target="_blank">@Global.GpgReportingEmail</a>
+        <p class="govuk-body">
+            We want everyone to be able to do what they need to do with our website, regardless of their access needs, due to a disability or condition.
         </p>
-
-        <h2 class="heading-medium">Online</h2>
-        <p>If you would like to leave general feedback on the service please complete this <a href="@Url.Action("SendFeedbackGet", "Feedback")">online feedback form</a>.</p>
-        <p>Read our <a href="https://www.gov.uk/guidance/gender-pay-gap-reporting-overview" target="_blank" rel="noopener noreferrer">guidance to gender pay gap reporting<span class="visually-hidden">(opens in a new window)</span></a>.</p>
-
-        <h2 class="heading-medium">Post</h2>
-        <p>
-            Write to the Government Equalities Office:
+        
+        <h2 class="govuk-heading-m">A detailed accessibility statement about the Gender pay gap service</h2>
+        <p class="govuk-body">
+            This page describes:
         </p>
-        <div class="panel">
-            <address style="font-style: normal">
-                Gender pay gap team<br/>
-                Government Equalities Office<br/>
-                6th Floor, Sanctuary Buildings<br/>
-                Great Smith Street<br/>
-                London<br/>
-                SW1P 3BT
-            </address>
-        </div>
-        <p></p>
-        <p class="script-only" style="text-align:center;">
-            <button class="button" onclick="windowClose()">Close Window</button>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>how accessible our website is</li>
+            <li>what to do if you have a problem</li>
+            <li>what we are doing to meet the regulations</li>
+        </ul>
+        <p class="govuk-body">
+            This accessibility statement applies to the Gender pay gap service.
         </p>
-
+        
+        <h2 class="govuk-heading-m">
+            Using our website and services
+        </h2>
+        <p class="govuk-body">
+            This service is run by the Government Equalities Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>change colours, contrast levels, zoom and fonts</li>
+            <li>complete tasks without a mouse by using input controls such as speech or a keyboard</li>
+            <li>listen using a screen reader</li>
+        </ul>
+        <p class="govuk-body">
+            We’ve also made the website text as simple as possible to understand.
+        </p>
+        <p class="govuk-body">
+            AbilityNet has advice on making your device easier to use if you have a disability.
+        </p>
+        
+        <h2 class="govuk-heading-l">
+            How accessible this website is
+        </h2>
+        <p class="govuk-body">
+            We aim to meet international accessibility guidelines, however this may not always be possible, or we may have missed a problem.
+        </p>
+        <p class="govuk-body">
+            We know some parts of this website are not fully accessible.
+        </p>
+        <h3 class="govuk-heading-m">
+            What to do if you cannot access parts of this website
+        </h3>
+        <p class="govuk-body">
+            If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille, contact <a class="govuk-link" href="mailto:@(Global.GpgReportingEmail)" target="_blank">@(Global.GpgReportingEmail)</a>.
+        </p>
+        <p class="govuk-body">
+            We’ll consider your request and get back to you within 5 working days.
+        </p>   
+        <h3 class="govuk-heading-m">
+            Reporting accessibility problems with this website
+        </h3>
+        <p class="govuk-body">
+            We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact <a class="govuk-link" href="mailto:@(Global.GpgReportingEmail)" target="_blank">@(Global.GpgReportingEmail)</a>.
+        </p>
+        <h3 class="govuk-heading-m">
+            Enforcement procedure
+        </h3>
+        <p class="govuk-body">
+            The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the Equality Advisory and Support Service (EASS).
+        </p>
+        
+        <h2 class="govuk-heading-l">
+            Technical information about this website’s accessibility
+        </h2>
+        <p class="govuk-body">
+            The Government Equalities Office is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+        </p>
+        <p class="govuk-body">
+            This website is partially compliant with the <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines version 2.1</a> AA standard, due to ‘the non-compliances’, listed below.
+        </p>
+        
+        <h2 class="govuk-heading-l">
+            Non-accessible content
+        </h2>
+        <p class="govuk-body">
+            The content listed below is non-accessible for the following reasons.
+        </p>
+        <h3 class="govuk-heading-m">
+            Non-compliance with the accessibility regulations
+        </h3>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>the highlighted yellow colour of text boxes has the incorrect colour ratio and is hard to see. This fails WCAG 2.1 success criterion 1.4.11 ‘Non-text Contrast’.</li>
+        </ul>
+        <p class="govuk-body">
+            We aim to fix this issue by the end of 2020.
+        </p>
+        <h3 class="govuk-heading-m">
+            Disproportionate burden
+        </h3>
+        <p class="govuk-body">
+            We have not yet identified a part of the service where it would be a disproportionate burden on the Government Equalities Office to resolve the non-compliance. If this becomes the case, we will publish full details here explaining our decision.
+        </p>
+        <h3 class="govuk-heading-m">
+            How we tested
+        </h3>
+        <p class="govuk-body">
+            Testing has been conducted internally by Government Equalities Office staff and externally audited by the <a class="govuk-link" href="https://digitalaccessibilitycentre.org/">Digital Accessibility Centre</a>. Where they have been checked for compliance, it has been against WCAG 2.1 AA.
+        </p>
+        <h3 class="govuk-heading-m">
+            What we’re doing to improve accessibility
+        </h3>
+        <p class="govuk-body">
+            We have recorded these issues in our backlog and will be handling them as part of our normal workflow. The website will be fully accessible by December 2020.
+        </p>
     </div>
 </div>

--- a/GenderPayGap.WebUI/Views/Home/AccessibilityStatement.cshtml
+++ b/GenderPayGap.WebUI/Views/Home/AccessibilityStatement.cshtml
@@ -1,10 +1,10 @@
 ﻿@using GenderPayGap.Core
 @{
-    ViewBag.Title = "Accessibility Statement - Gender pay gap reporting service";
+    ViewBag.Title = "Accessibility Statement - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
-<div class="govuk-grid-row" xmlns="http://www.w3.org/1999/html">
+<div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">
             Accessibility statement for Gender pay gap service


### PR DESCRIPTION
### Context
We need an accessibility statement in place by 23rd September to be compliant with legislation. An outline of what should be shown on the page can be found [in this Google doc](https://docs.google.com/document/d/1M2LdOu1QgSG9boBDKaE49JaCD-7B4Fdw2Z1EsqsSvBk/edit).

### Changes
- Added 'Accessibility Statement' link to footer, as well as method in HomeController to navigate to it
- Added AccessibilityStatement.cshtml page with content as described in above Google doc