### PR TITLE
GPG-182 Rearranges the sector history table to look like AddressHistory

### DIFF
--- a/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
@@ -70,9 +70,8 @@
         
         @if (!Model.SectorHistory.Any())
         {
-            <div class="govuk-body">
-                No organisation sector information
-            </div>
+            <p class="govuk-body"><span class="govuk-!-font-weight-bold">Current sector: </span>@Model.Organisation.SectorType</p>
+            <p class="govuk-body">This organisation's sector has never been changed</p>
         }
         else
         {
@@ -104,8 +103,8 @@
                             }
                             else if (i == 1)
                             {
-                                <th scope="row" class="govuk-table__header" rowspan="@(sectorChanges.Count - 1)">
-                                    Previous sector
+                                <th scope="row" class="govuk-table__header" rowspan="@(sectorChanges.Count)">
+                                    Previous sectors
                                 </th>
                             }
 
@@ -119,6 +118,17 @@
                             </td>
                             <td class="govuk-table__cell">@(sectorChangeDetails.Reason)</td>
                         </tr>
+
+                        @if (i == sectorChanges.Count - 1)
+                        {
+                            // Add a final row for the original scope (not audited so doesn't appear in the list automatically)
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">@(sectorChangeDetails.OldSector)</td>
+                                <td class="govuk-table__cell"></td>
+                                <td class="govuk-table__cell"></td>
+                                <td class="govuk-table__cell">Initial sector choice</td>
+                            </tr>
+                        }
                     }
                 </tbody>
             </table>

--- a/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
@@ -87,21 +87,37 @@
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                    @foreach (AuditLog sector in Model.SectorHistory)
+                    @{
+                        List<AuditLog> sectorChanges = Model.SectorHistory;
+                    }
+                    @for (var i = 0; i < sectorChanges.Count; i++)
                     {
-                        var auditLogDetails = JsonConvert.DeserializeObject<AdminChangeSectorAuditLogDetails>(sector.DetailsString);
-                        
+                        AuditLog sectorChange = sectorChanges[i];
+                        var sectorChangeDetails = JsonConvert.DeserializeObject<AdminChangeSectorAuditLogDetails>(sectorChange.DetailsString);
+
                         <tr class="govuk-table__row">
-                            <td class="govuk-table__cell">@(auditLogDetails.OldSector)</td>
-                            <td class="govuk-table__cell">@(auditLogDetails.NewSector)</td>
-                            <td class="govuk-table__cell">@(sector.CreatedDate.ToString("d MMM yyyy"))</td>
+                            @if (i == 0)
+                            {
+                                <th scope="row" class="govuk-table__header">
+                                    Current sector
+                                </th>
+                            }
+                            else if (i == 1)
+                            {
+                                <th scope="row" class="govuk-table__header" rowspan="@(sectorChanges.Count - 1)">
+                                    Previous sector
+                                </th>
+                            }
+
+                            <td class="govuk-table__cell">@(sectorChangeDetails.NewSector)</td>
+                            <td class="govuk-table__cell">@(sectorChange.CreatedDate.ToString())</td>
                             <td class="govuk-table__cell">
-                                <a href="@Url.Action("ViewUser", "AdminViewUser", new {id = sector.ImpersonatedUser?.UserId ?? sector.OriginalUser.UserId})"
+                                <a href="@Url.Action("ViewUser", "AdminViewUser", new {id = sectorChange.ImpersonatedUser?.UserId ?? sectorChange.OriginalUser.UserId})"
                                    class="govuk-link">
-                                    @(sector.ImpersonatedUser != null ? sector.ImpersonatedUser.Fullname : sector.OriginalUser.Fullname)
+                                    @(sectorChange.ImpersonatedUser != null ? sectorChange.ImpersonatedUser.Fullname : sectorChange.OriginalUser.Fullname)
                                 </a>
                             </td>
-                            <td class="govuk-table__cell">@(auditLogDetails.Reason)</td>
+                            <td class="govuk-table__cell">@(sectorChangeDetails.Reason)</td>
                         </tr>
                     }
                 </tbody>

--- a/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
@@ -79,8 +79,8 @@
             <table class="govuk-table">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Original Sector</th>
-                        <th scope="col" class="govuk-table__header">Updated Sector</th>
+                        <th scope="col" class="govuk-table__header"></th>
+                        <th scope="col" class="govuk-table__header">Sector</th>
                         <th scope="col" class="govuk-table__header">Changed on date</th>
                         <th scope="col" class="govuk-table__header">User</th>
                         <th scope="col" class="govuk-table__header">Details</th>


### PR DESCRIPTION
Jacob said that he'd prefer the sector history table to look more like address history:
![image](https://user-images.githubusercontent.com/15341769/94160463-8b9ddd00-fe7c-11ea-99ef-2c213a706820.png)