### PR TITLE
GPG-182 Adds single sector edge case

### DIFF
--- a/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationSector/ViewOrganisationSector.cshtml
@@ -123,6 +123,16 @@
                         {
                             // Add a final row for the original scope (not audited so doesn't appear in the list automatically)
                             <tr class="govuk-table__row">
+                                
+                                @if (sectorChanges.Count == 1)
+                                {
+                                    // If this is the only row added (so the Previous sectors header isn't present yet)
+                                    // Add the Previous sectors header
+                                    <th scope="row" class="govuk-table__header" rowspan="@(sectorChanges.Count)">
+                                        Previous sectors
+                                    </th>
+                                }
+                                
                                 <td class="govuk-table__cell">@(sectorChangeDetails.OldSector)</td>
                                 <td class="govuk-table__cell"></td>
                                 <td class="govuk-table__cell"></td>


### PR DESCRIPTION
I tested this on dev and noticed a bug when there's only one sector change, so the Previous sectors header isn't added to the table and the subsequent initial sector line is misaligned:

![image](https://user-images.githubusercontent.com/15341769/94245624-6f4c7f80-ff12-11ea-8d7a-5a7b91454e63.png)

I've fixed this here by adding a check for if the sectorChanges list has count 1 - and if so, I add the Previous sectors header.

I really should have caught this earlier - sorry 😕 