### PR TITLE
GPG-529 Remove confusing email behaviour

### DIFF
--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/Registration/RegisterControllerTests.Email.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/Registration/RegisterControllerTests.Email.cs
@@ -181,8 +181,8 @@ namespace GenderPayGap.WebUI.Tests.Controllers.Registration
                 $"Expected the correct templateId to be in the email send queue, expected {EmailTemplates.UserAddedToOrganisationEmail}");
             UiTestHelper.MockBackgroundJobsApi.Verify(
                 x => x.AddEmailToQueue(It.Is<NotifyEmail>(inst => inst.EmailAddress.Contains(newUser.EmailAddress))),
-                Times.Never,
-                "Do not expect new user's email address to be in the email send queue");
+                Times.Once(),
+                "Expect new user's email address to be in the email send queue");
         }
     }
 }

--- a/GenderPayGap.WebUI/Controllers/RegisterController.Request.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.Request.cs
@@ -569,12 +569,6 @@ namespace GenderPayGap.WebUI.Controllers
         //Send the registration request
         protected void SendRegistrationAccepted(string emailAddress)
         {
-            //Always use the administrators email when not on production
-            if (!Config.IsProduction())
-            {
-                emailAddress = CurrentUser.EmailAddress;
-            }
-
             //Send an acceptance link to the email address
             string returnUrl = Url.Action(nameof(OrganisationController.ManageOrganisations), "Organisation", null, "https");
             emailSendingService.SendOrganisationRegistrationApprovedEmail(emailAddress, returnUrl);
@@ -715,12 +709,6 @@ namespace GenderPayGap.WebUI.Controllers
         //Send the registration request
         protected void SendRegistrationDeclined(string emailAddress, string reason)
         {
-            //Always use the administrators email when not on production
-            if (!Config.IsProduction())
-            {
-                emailAddress = CurrentUser.EmailAddress;
-            }
-
             //Send a verification link to the email address
             emailSendingService.SendOrganisationRegistrationDeclinedEmail(emailAddress, reason);
         }


### PR DESCRIPTION
In test environments, "registration approved/rejected" emails are sent to the admin instead of the normal user.
This behaviour is very confusing and not needed (since we have different Notify API keys for test/live)