### PR TITLE
GPG-465 Adds detail to download link

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/Launchpad/Index.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Launchpad/Index.cshtml
@@ -85,7 +85,7 @@
 
         <div class="column-one-third">
             <div class="heading-small">
-                <a rel="download track" data-track-category="relatedLinkClicked" data-track-action="1.1 Related content" data-track-label="/public/assets/pdf/action-plan-guidance.pdf" data-track-options="{&quot;dimension28&quot;:&quot;1&quot;,&quot;dimension29&quot;:&quot;Action plan guidance&quot;}" href="/public/assets/pdf/action-plan-guidance.pdf">Four steps to developing a gender pay gap action plan<span class="visually-hidden"> (pdf)</span></a>
+                <a rel="download track" data-track-category="relatedLinkClicked" data-track-action="1.1 Related content" data-track-label="/public/assets/pdf/action-plan-guidance.pdf" data-track-options="{&quot;dimension28&quot;:&quot;1&quot;,&quot;dimension29&quot;:&quot;Action plan guidance&quot;}" href="/public/assets/pdf/action-plan-guidance.pdf">Four steps to developing a gender pay gap action plan<span class="visually-hidden"> (pdf download - 288 KB)</span></a>
             </div>
             A step by step guide for employers to develop an effective action plan
         </div>


### PR DESCRIPTION
### Context
Screen-readers rely on non-visible text to give more context about elements of the page so visually impaired users can navigate effectively. This link's non-visible text was missing explanation of it being a download, and the download size. 

### Changes
Added "download" and PDF size to visually hidden text for clarification.