### PR TITLE
GPG-467 Fixes unmarked headings on add org page

### DIFF
--- a/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
@@ -196,9 +196,9 @@
                             : $"search-result-coho-{organisation.CompanyNumber}";
                         <li id="@(resultId)">
                             <div>
-                                <span class="govuk-!-font-weight-bold">
+                                <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
                                     @(organisation.OrganisationName)
-                                </span>
+                                </h3>
                                 <br/>
                                 
                                 <span class="govuk-visually-hidden">Address:</span>

--- a/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
@@ -199,8 +199,7 @@
                                 <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
                                     @(organisation.OrganisationName)
                                 </h3>
-                                <br/>
-                                
+
                                 <span class="govuk-visually-hidden">Address:</span>
                                 @(organisation.OrganisationAddress)
                                 


### PR DESCRIPTION
### Context
Users who cannot perceive visually styling rely on correct semantic mark-up in order to identify information and relationships within the page. Currently the company name headings are marked up with a `<span>` rather than headings, which would make it hard for users of screen-readers to filter and efficiently navigate the page.

### Changes
Replaced `<span>` with styled `<h3>` tags