### PR TITLE
GPG-468 Fixes screen-readability of public-facing employer report headers

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -90,7 +90,7 @@
                         <tbody>
                             <tr>
                                 <td style="border-bottom: none; width: 300px;">
-                                    <span class="heading-small">@report.GetReportingPeriod()</span>
+                                    <h3 class="heading-small govuk-!-margin-top-0">@report.GetReportingPeriod()</h3>
                                 </td>
                                 <td style="border-bottom: none;">
                                     <partial name="EmployerDetails/Parts/_ReportStatusBadge" model="new ReportStatusBadgeViewModel { IsLateSubmission = report.IsLateSubmission, IsVoluntarySubmission = report.IsVoluntarySubmission() }"/>


### PR DESCRIPTION
### Context
On the page there are several separators to separate each section from each other instead of marking up the headings. Screen reader users rely on correct semantic mark-up to be able to identify information and relationships within the page.

### Changes
Replaces `<span>`s with styled h3s