### PR TITLE
GPG-466 Fix Homepage Autocomplete

### DIFF
--- a/GenderPayGap.WebUI/Search/AutoCompleteSearchService.cs
+++ b/GenderPayGap.WebUI/Search/AutoCompleteSearchService.cs
@@ -46,7 +46,7 @@ namespace GenderPayGap.WebUI.Search
             bool queryContainsPunctuation)
         {
             return allOrganisations
-                .Where(org => org.Status == OrganisationStatuses.Active || org.Status == OrganisationStatuses.Retired)
+                .Where(org => org.IncludeInViewingService)
                 .Where(org => SearchHelper.CurrentOrPreviousOrganisationNameMatchesSearchTerms(org, searchTerms, queryContainsPunctuation))
                 .ToList();
         }

--- a/GenderPayGap.WebUI/wwwroot/scripts/accessible-autocomplete-gpg.js
+++ b/GenderPayGap.WebUI/wwwroot/scripts/accessible-autocomplete-gpg.js
@@ -2,7 +2,6 @@
     accessibleAutocomplete({
         element: document.querySelector(element),
         id: id,  // To match it to the existing <label>.
-        onConfirm: selectOrganisation,
         source: organisationList,
         name: 'search',
         minLength: 2,
@@ -12,13 +11,6 @@
             suggestion: organisationSuggestionTemplate
         }
     });
-
-    function selectOrganisation(suggestion) {
-        if (suggestion) {
-            var url = '/employer/' + suggestion.Id;
-            window.location.href = url;
-        }
-    }
 
     function organisationList (query, syncResults) {
         var organisationListUrl = '/viewing/suggest-employer-name-js?search=';


### PR DESCRIPTION
[GPG-466 Jira Ticket](https://technologyprogramme.atlassian.net/browse/GPG-466)

### Context
DAC found that when you clicked an autocomplete item it navigated to a new page, which is an accessibility issue in particular for visually impaired users. They recommended replacing this with filling the search box with the search term and requiring either an enter press or clicking the search button to trigger the page change and show the search results. They also noted that clicking enter didn't work in the autocomplete.

After fixing the first issue, I noticed that it was possible to select an autocomplete item which then led to "0 results found" on the search page. This was because the search used for the autocomplete (all active orgs) wasn't the same as the search results (all active orgs that have ever been in scope or presumed in scope). Discussed with Jacob and Claire and agreed to swap the autocomplete to the search results method for consistency, but to follow up with a design review when Claire gets time.
