### PR TITLE
Remove extra space on the Create Account page

### DIFF
--- a/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
@@ -34,10 +34,7 @@
         <p class="govuk-body">
             If you already have a user account, please
             <a href="@(Url.Action("ManageOrganisationsGet", "ManageOrganisations"))"
-               class="govuk-link">
-                sign in
-            </a>
-            .
+               class="govuk-link">sign in</a>.
         </p>
 
         <form method="POST" action="@Url.Action("CreateUserAccountPost", "AccountCreation")" class="govuk-!-margin-top-8">


### PR DESCRIPTION
If you have the full stop on the next line down, you automatically get a space between "sign in" and the full stop. But sticking them all on the same line stops that from happening