### PR TITLE
GPG-476 Stops double readouts of search options for screenreader users

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/Keywords.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/Keywords.cshtml
@@ -3,7 +3,7 @@
     <fieldset class="inline">
         <legend>
             <h1 class="govuk-heading-xl">
-                Search by <span class="visuallyhidden">either employer name or SIC code</span>
+                Search by 
             </h1>
         </legend>
 

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/Keywords.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/Keywords.cshtml
@@ -1,8 +1,10 @@
 ﻿@model GenderPayGap.WebUI.Models.Search.SearchViewModel
 <div id="SearchByKeywordsGroup" class="form-group" style="position: relative;">
     <fieldset class="inline">
-        <legend class="heading-large">
-            Search by <span class="visuallyhidden">either employer name or SIC code</span>
+        <legend>
+            <h1 class="govuk-heading-xl">
+                Search by <span class="visuallyhidden">either employer name or SIC code</span>
+            </h1>
         </legend>
 
         <div class="multiple-choice">

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/Keywords.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/Keywords.cshtml
@@ -1,11 +1,8 @@
 ﻿@model GenderPayGap.WebUI.Models.Search.SearchViewModel
 <div id="SearchByKeywordsGroup" class="form-group" style="position: relative;">
-    <h1 class="heading-large">
-        Search by <span class="visuallyhidden">either employer name or SIC code</span>
-    </h1>
     <fieldset class="inline">
-        <legend class="visually-hidden">
-            Select how you want to search: either by employer name or by Sector (SIC code)
+        <legend class="heading-large">
+            Search by <span class="visuallyhidden">either employer name or SIC code</span>
         </legend>
 
         <div class="multiple-choice">


### PR DESCRIPTION
[GPG-476 JIRA Ticket](https://technologyprogramme.atlassian.net/browse/GPG-476)

This nests the h1 text inside the legend instead so it's clearly linked to the form for visually impaired users, and doesn't cause a double readout of similar heading and legend.

A suggestion on this ticket was to remove the labels on radio buttons as these also cause a double readout. I don't think that's possible since they're used by sighted users to give context to a radio button - I tried adding `aria-hidden` to each label but that removes all context from the radio buttons, since the labels seem to implicitly give the radio buttons their `name` which is also read out by a screen reader, causing the duplication. Any suggestions appreciated!