### PR TITLE
GPG-588 Fixes screen-reader readout of filter collapses

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
@@ -16,7 +16,7 @@
                 @foreach (OptionSelect item in Model.Metadata)
                 {
                     <label for="@(item.Id)" @(item.Disabled ? "disabled" : string.Empty)>
-                        <input name="@(Model.Group)" @(item.Disabled ? "disabled" : string.Empty) value="@(item.Value)" id="@(item.Id)" type="checkbox" @(queryLookup.Contains(item.Value) ? "checked" : "") aria-label="@(item.Id != "Size0" ? item.Label + " employees" : "Number of employees not provided")"/>
+                        <input name="@(Model.Group)" @(item.Disabled ? "disabled" : string.Empty) value="@(item.Value)" id="@(item.Id)" type="checkbox" @(queryLookup.Contains(item.Value) ? "checked" : "")/>
                         <span class="font-xsmall">@(item.Label)</span>
                     </label>
                 }

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
@@ -16,7 +16,7 @@
                 @foreach (OptionSelect item in Model.Metadata)
                 {
                     <label for="@(item.Id)" @(item.Disabled ? "disabled" : string.Empty)>
-                        <input name="@(Model.Group)" @(item.Disabled ? "disabled" : string.Empty) value="@(item.Value)" id="@(item.Id)" type="checkbox" @(queryLookup.Contains(item.Value) ? "checked" : "") aria-label="@(item.Id)"/>
+                        <input name="@(Model.Group)" @(item.Disabled ? "disabled" : string.Empty) value="@(item.Value)" id="@(item.Id)" type="checkbox" @(queryLookup.Contains(item.Value) ? "checked" : "") aria-label="@(item.Id != "Size0" ? item.Label + " employees" : "Number of employees not provided")"/>
                         <span class="font-xsmall">@(item.Label)</span>
                     </label>
                 }


### PR DESCRIPTION
[GPG-588 JIRA Ticket](https://technologyprogramme.atlassian.net/browse/GPG-588)

Fixes the aria-labelling to give meaningful readout on screen-readers. Previously a screen-reader would read out e.g. "Size1 checkbox not checked" (giving no context to what that size might be) whereas now it reads out "Number of employees not provided checkbox not checked" or "500 to 999 employees checkbox not checked" which explains to the user what the checkbox is actually for 😄 