### PR TITLE
Load test documentation updates

### DIFF
--- a/LoadTests/LoadTests.iml
+++ b/LoadTests/LoadTests.iml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/LoadTests/README.md
+++ b/LoadTests/README.md
@@ -2,16 +2,37 @@
 
 We use [Gatling](https://gatling.io/) for the purpose of Load Testing. Gatling is an open-source load and performance testing framework based on Scala, Akka and Netty.
 
+## What is Load Testing?
+
+Load tests check the performance of a software application whilst being used by a certain number of users simultaneously. 
+They are used to ensure that a system will cope effectively with high load, and to identify bottlenecks which may need further technical work to resolve.
+
+Load tests aim to:
+* Identify the maximum operational capacity of a system
+* Determine whether the infrastructure being used is sufficient to handle the expected system load
+* Determine the scalability of a system
+* Identify bottlenecks within the system which may need technical work
+
+## Why do we want to do it on GPG?
+
+Each year, employers with more than 250 employees are required to report their gender pay gap figures through the [Gender Pay Gap Service](https://gender-pay-gap.service.gov.uk/).
+Employers provide data from a specific reference date (the snapshot date), which is:
+* 31st March for public sector employers
+* 4th April for businesses and charities
+
+Employers are required to publish this data within one year of their respective snapshot date. This means that towards the end of each reporting year, there is a peak in load on the system as a large quantity of employers try to report their figures before the deadline.
+We run load tests to ensure that the system will cope well with expected load at this time, and to identify any technical changes we should prioritise before the reporting peak.
+
 ## Zero to Hero
 
 This module can't be opened in Visual Studio so you'll need another IDE such as IntelliJ.
 
-1. Download and install [IntelliJ](https://www.jetbrains.com/idea/download) (Community edition is fine)
-1. Install **Java** 64bits JDK 8 (not compatible with JDK 12+)
+1. Download and install [IntelliJ IDEA](https://www.jetbrains.com/idea/download) (Community edition is fine)
+1. Install **Java** 64bits JDK 8 (not compatible with JDK 12+) - look on [swiki](https://swiki.softwire.com/display/HelpdeskEmployees/Java+and+Patching) for instructions of how to do this with Amazon Corretto
 1. Set up your JDK if you didn't already - you'll need to see a valid Java 1.8 under File > Project Structure > Project SDKs
 1. Install **Scala** 2.12 (not compatible with Scala 2.11 or Scala 2.13)
 1. Install the Scala plugin for IntelliJ: File > Settings > Plugins > search for Scala and hit Install
-1. Increase the stack size for the Scala compiler so you don't suffer from StackOverflowErrors. Recommended setting Xss to 100M.  (File -> Settings -> Build, Execution, Deployment -> Compiler -> Scala Compiler -> Scala Compile Server -> in the JVM options textbox)
+1. Increase the stack size for the Scala compiler so you don't suffer from StackOverflowErrors. Recommended setting Xss to 100M.  (File -> Settings -> Build, Execution, Deployment -> Compiler -> Scala Compiler -> Scala Compile Server -> in the JVM options textbox). You'll need to expand each item in the sidebar - don't just click on Compiler and try to navigate from there!
 1. Open just this folder (./LoadTests) in IntelliJ
 1. Maven should automatically sync, but if it doesn't, open the Maven window and hit "Reimport all Maven projects" (the "refresh" icon)
 

--- a/LoadTests/README.md
+++ b/LoadTests/README.md
@@ -2,7 +2,7 @@
 
 We use [Gatling](https://gatling.io/) for the purpose of Load Testing. Gatling is an open-source load and performance testing framework based on Scala, Akka and Netty.
 
-## What is Load Testing?
+## What is load testing?
 
 Load tests check the performance of a software application whilst being used by a certain number of users simultaneously. 
 They are used to ensure that a system will cope effectively with high load, and to identify bottlenecks which may need further technical work to resolve.
@@ -28,7 +28,7 @@ We run load tests to ensure that the system will cope well with expected load at
 This module can't be opened in Visual Studio so you'll need another IDE such as IntelliJ.
 
 1. Download and install [IntelliJ IDEA](https://www.jetbrains.com/idea/download) (Community edition is fine)
-1. Install **Java** 64bits JDK 8 (not compatible with JDK 12+) - look on [swiki](https://swiki.softwire.com/display/HelpdeskEmployees/Java+and+Patching) for instructions of how to do this with Amazon Corretto
+1. Install **Java** 64bits JDK 8 (not compatible with JDK 12+)
 1. Set up your JDK if you didn't already - you'll need to see a valid Java 1.8 under File > Project Structure > Project SDKs
 1. Install **Scala** 2.12 (not compatible with Scala 2.11 or Scala 2.13)
 1. Install the Scala plugin for IntelliJ: File > Settings > Plugins > search for Scala and hit Install
@@ -42,9 +42,24 @@ mvn gatling:verify
 ```
 and have it succeed.
 
+## Preparing for a load test
+
+### The Gatling recorder
+
+The scenarios in this project were originally created using the Gatling Recorder which can be downloaded [here](https://gatling.io/open-source/start-testing/). 
+You can run the recorder by finding and running the `recorder.bat` file
+
 ### Creating or modifying a scenario
 
-The scenarios in this project were originally created using the Gatling Recorder. For minor tweaks (e.g. just to a specific page) you can edit `RecordingSimulation.scala` directly, or for a more substantial change you should consider recording a new scenario from scratch. See the [Gatling recorder docs](https://gatling.io/docs/current/quickstart/#using-the-recorder) for more.
+For minor tweaks (e.g. just to a specific page) you can edit `RecordingSimulation.scala` directly, or for a more substantial change you should consider recording a new scenario from scratch. See the [Gatling recorder docs](https://gatling.io/docs/current/quickstart/#using-the-recorder) for more.
+
+To create a new scenario, you will need to:
+1. Open the Gatling Recorder
+1. Set up a proxy - on Windows, go to System Settings > Proxy Settings, and use the manual proxy setup to create a proxy to `localhost:8000`
+1. Set the Gatling recorder to use port 8000, and to output the results to `LoadTests/src/test/scala/default`
+1. Run the service locally - it'll run on port 44371
+1. Press start on the Gatling recorder. Perform all the actions you want to record, and then click Stop when you're finished
+1. The code for your scenario will be saved in the `default` folder
 
 ## Running the load test
 


### PR DESCRIPTION
Just added a few bits and pieces to the load testing README - in particular, a section about setting up the Gatling recorder and getting it to record using the Windows proxy. 