### PR TITLE
GPG-617 Updates Accessibility Statement Copy

### DIFF
--- a/GenderPayGap.WebUI/Views/StaticPages/AccessibilityStatement.cshtml
+++ b/GenderPayGap.WebUI/Views/StaticPages/AccessibilityStatement.cshtml
@@ -114,42 +114,44 @@
         <h3 class="govuk-heading-m">
             Non-compliance with the accessibility regulations
         </h3>
+        <p class="govuk-body">
+            The following elements do not comply with accessibility regulations:
+        </p>
         <ul class="govuk-list govuk-list--bullet">
             <li>
-                the highlighted yellow colour of text boxes has the incorrect colour ratio and is hard to see.
-                This fails WCAG 2.1 success criterion 1.4.11 ‘Non-text Contrast’.
+                the highlighted yellow colour of text boxes has the incorrect colour ratio and is hard to see. 
+                This fails WCAG 2.1 success criterion 1.4.11
             </li>
             <li>
-                some links do not have accompanying descriptive text. This fails WCAG 2.1 success 
-                criteria 2.4.4, 2.4.9 and 3.2.5
-            </li>
-            <li>
-                on some pages, content has not been semantically marked-up so that information and relationships
+                on some pages, content has not been semantically marked-up so that information and relationships 
                 are programmatically determinable. This fails WCAG 2.1 success criterion 1.3.1
+            </li>
+            <li>
+                the search button is slightly pixelated on magnification. This fails WCAG 2.1 success criterion 1.1.1
             </li>   
             <li>
-                the search button is slightly pixelated on magnification. This fails WCAG 2.1
-                success criterion 1.1.1
-            </li>
-            <li>
-                there are links on the page that visually look like tabs but have not been marked
+                there are links on the ‘compare employers’ page that visually look like tabs but have not been marked
                 up in this way. This fails WCAG 2.1 success criteria 2.4.3 and 4.1.2
             </li>
             <li>
-                there are nested buttons meaning accordions on some pages can be tabbed to twice.
-                This fails WCAG 2.1 success criterion 2.4.3
+                the layout and structure of some elements on the ‘employer report’ page are difficult for screen 
+                readers to understand. This fails WCAG 2.1 success criterion 1.3.1
             </li>
             <li>
-                there are some pages that are difficult for screen readers to read. This fails
-                WCAG 2.1 success criterion 2.4.6
+                the status message on the search results page is not announced to users that rely on audio
+                feedback. This fails WCAG 2.1 success criterion 4.1.3
             </li>
             <li>
-                the status message on the search results page is not announced to users that rely on 
-                audio feedback. This fails WCAG 2.1 success criterion 4.1.3
+                most older PDF documents that are linked to from this website are not fully accessible 
+                to screen reader software
+            </li>
+            <li>
+                the ‘compare employers’ page has a number of additional accessibility issues and is not
+                fully accessible to screen reader software
             </li>
         </ul>
         <p class="govuk-body">
-            We aim to fix these issues by the end of 2020.
+            We have recorded these issues in our backlog and will be handling them as part of our normal workflow.
         </p>
         <h3 class="govuk-heading-m">
             Disproportionate burden
@@ -172,7 +174,6 @@
         </h3>
         <p class="govuk-body">
             We have recorded these issues in our backlog and will be handling them as part of our normal workflow.
-            The website will be fully accessible by December 2020.
         </p>
     </div>
 </div>


### PR DESCRIPTION
[GPG-617 JIRA Ticket](https://technologyprogramme.atlassian.net/browse/GPG-617)

Updates the accessibility statement to reflect recent updates to the service.
I added the, "The following elements do not comply with accessibility regulations:" line to the copy myself, to match with the [guidelines](https://design-system.service.gov.uk/styles/typography/#lists) on the GOV.UK Design System about bullet lists requiring a lead-in line ending in a colon.