### PR TITLE
GPG-606 Fixes accessible autocomplete import and requests

### DIFF
--- a/GenderPayGap.WebUI/wwwroot/styles/components/_accessible-autocomplete.scss
+++ b/GenderPayGap.WebUI/wwwroot/styles/components/_accessible-autocomplete.scss
@@ -1,4 +1,4 @@
-@import "../../assets/stylesheets/accessible-autocomplete.min.css";
+@import "../../assets/stylesheets/accessible-autocomplete.min";
 
 .autocomplete__input {
   background-color: govuk-colour("white");

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -32,7 +32,7 @@ DO $$
                 INSERT INTO "Organisations"
                 ("OrganisationId", "CompanyNumber", "OrganisationName", "SectorTypeId", "StatusId", "StatusDate", "StatusDetails", "Created", "Modified", "OptedOutFromCompaniesHouseUpdate", "EmployerReference")
                 VALUES
-                (STARTING_ID + INDEX, '99999' || CAST(INDEX AS VARCHAR(16)), 'test_' || CAST(INDEX AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX AS VARCHAR(16)));
+                (STARTING_ID + INDEX, '99999' || CAST(INDEX AS VARCHAR(16)), 'test_' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX AS VARCHAR(16)));
 
                 INSERT INTO "OrganisationNames"
                 ("OrganisationNameId", "OrganisationId", "Name", "Source", "Created")

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -44,10 +44,6 @@ class RecordingSimulation extends Simulation {
 		"DNT" -> "1",
 		"Pragma" -> "no-cache")
 
-	val headers_6 = Map(
-		"content-type" -> "text/css"
-	)
-
 	val searchFeeder = Iterator.continually(Map("searchCriteria1" -> "tes", "searchCriteria2" -> s"test_${Random.nextInt(2 * MAX_NUM_USERS) + 1}"))
 	val registrationFeeder = Iterator.continually(Map("email" -> (Random.alphanumeric.take(20).mkString + "@example.com")))
 	val usersOrganisationsFeeder = csv("users_organisations.csv").circular
@@ -70,10 +66,7 @@ class RecordingSimulation extends Simulation {
 					.headers(headers_1),
 				http("Load crest")
 					.get("/public/govuk_template/assets/stylesheets/images/govuk-crest-2x.png")
-					.headers(headers_1),
-				http("Load accessible autocomplete")
-  				.get("/assets/stylesheets/accessible-autocomplete.min.css")
-  				.headers(headers_6)))
+					.headers(headers_1)
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		val search = feed(searchFeeder)

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -43,6 +43,11 @@ class RecordingSimulation extends Simulation {
 	val headers_5 = Map(
 		"DNT" -> "1",
 		"Pragma" -> "no-cache")
+
+	val headers_6 = Map(
+		"content-type" -> "text/css"
+	)
+
 	val searchFeeder = Iterator.continually(Map("searchCriteria1" -> "tes", "searchCriteria2" -> s"test_${Random.nextInt(2 * MAX_NUM_USERS) + 1}"))
 	val registrationFeeder = Iterator.continually(Map("email" -> (Random.alphanumeric.take(20).mkString + "@example.com")))
 	val usersOrganisationsFeeder = csv("users_organisations.csv").circular
@@ -65,7 +70,10 @@ class RecordingSimulation extends Simulation {
 					.headers(headers_1),
 				http("Load crest")
 					.get("/public/govuk_template/assets/stylesheets/images/govuk-crest-2x.png")
-					.headers(headers_1)))
+					.headers(headers_1),
+				http("Load accessible autocomplete")
+  				.get("/assets/stylesheets/accessible-autocomplete.min.css")
+  				.headers(headers_6)))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		val search = feed(searchFeeder)
@@ -330,8 +338,7 @@ class RecordingSimulation extends Simulation {
 			.get("/account/organisations")
 			.headers(headers_0)
 			.check(
-				// TODO: Fix this line - no ManageOrg id available on new design system page
-				css("a[id^='ManageOrg']", "href").find.saveAs("linkToAnOrganisation"),
+				css("a:contains('${organisationName}')", "href").saveAs("linkToAnOrganisation"),
 				regex("Select an organisation")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 


### PR DESCRIPTION
**Load Testing IV: The Fellowship of the Imports**

Updates the import of `accessible-autocomplete.min.css` in code.
`@import` in an SCSS file combines all imports into one file, whereas `@import` in a CSS file performs an HTTP request for each additional CSS file. This can be fixed by removing the `.css` chunk from the end of the import, which I've done here and fixes the 350+ failing requests in the load tests! We're now at 95% successful requests - I think there'll just need to be a final PR to fix the report submission journey 🎉 

Testing:
- Manually checked that updating the import still works as expected
- Ran the load tests after re-build and confirmed increase and successful requests