### PR TITLE
GPG-606 Updates load test code for 2020/21 reporting year

### DIFF
--- a/GenderPayGap.WebUI/Views/Components/TaskList/TaskList.cshtml
+++ b/GenderPayGap.WebUI/Views/Components/TaskList/TaskList.cshtml
@@ -33,6 +33,7 @@
                             {
                                 <a href="@(item.Href)"
                                    class="govuk-link"
+                                   loadtest-id="@(item.LoadTestId)"
                                    aria-describedby="@($"status-{sectionIndex}-{itemIndex}")">
                                     @item.Title
                                 </a>

--- a/GenderPayGap.WebUI/Views/Components/TaskList/TaskListViewModel.cs
+++ b/GenderPayGap.WebUI/Views/Components/TaskList/TaskListViewModel.cs
@@ -21,6 +21,8 @@ namespace GenderPayGap.WebUI.Views.Components.TaskList
         public Func<object, object> BodyHtml { get; set; }
         public string Href { get; set; }
         public TaskListStatus Status { get; set; }
+        
+        public string LoadTestId { get; set; }
     }
 
     public enum TaskListStatus

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisations.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisations.cshtml
@@ -71,7 +71,7 @@
                         else
                         {
                             <td class="govuk-table__cell">
-                                <a class="govuk-link loadtest" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = encryptedOrganisationId})">
+                                <a class="govuk-link" loadtest-id="organisation-link" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = encryptedOrganisationId})">
                                     @(userOrganisation.Organisation.OrganisationName.ToUpper())
                                 </a>
                             </td>

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisations.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisations.cshtml
@@ -71,7 +71,7 @@
                         else
                         {
                             <td class="govuk-table__cell">
-                                <a class="govuk-link" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = encryptedOrganisationId})">
+                                <a class="govuk-link loadtest" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = encryptedOrganisationId})">
                                     @(userOrganisation.Organisation.OrganisationName.ToUpper())
                                 </a>
                             </td>

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -52,7 +52,8 @@
                         <div>
                             @if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.NewReportingJourney))
                             {
-                                <a class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-0 create-report-@detailsForYear.ReportingYear"
+                                <a class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                   loadtest-id="create-report-@detailsForYear.ReportingYear"
                                    href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = detailsForYear.ReportingYear})">
                                     @detailsForYear.GetReportButtonText()
                                 </a>

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -52,19 +52,18 @@
                         <div>
                             @if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.NewReportingJourney))
                             {
-                                <a class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-0" 
-                                   href="@Url.Action("ReportOverview", "ReportOverview",
-                                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = detailsForYear.ReportingYear})">
+                                <a class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-0 create-report-@detailsForYear.ReportingYear"
+                                   href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = detailsForYear.ReportingYear})">
                                     @detailsForYear.GetReportButtonText()
                                 </a>
                             }
                             else
                             {
                                 var encryptedRequestParam = Encryption.EncryptAsParams(Model.Organisation.OrganisationId.ToString(), detailsForYear.ReportingYear.ToString(), detailsForYear.DoesReturnOrDraftReturnExistForYear().ToString());
-                                
+
                                 <a role="button"
                                    href="@Url.Action("ReportForOrganisation", "Organisation", new {request = encryptedRequestParam})"
-                                   class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-0">
+                                   class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-0 create-report-@detailsForYear.ReportingYear">
                                     @detailsForYear.GetReportButtonText()
                                 </a>
                             }

--- a/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
+++ b/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
@@ -198,7 +198,8 @@
                     Title = "Person responsible in your organisation",
                     Href = Url.Action("ReportResponsiblePersonGet", "ReportResponsiblePerson",
                         new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                    Status = Model.PersonResponsibleStatus
+                    Status = Model.PersonResponsibleStatus,
+                    LoadTestId = "responsible-person"
                 });
             }
             aboutYourOrganisationSection.Items.Add(new TaskListItemViewModel
@@ -206,7 +207,8 @@
                 Title = "Size of your organisation",
                 Href = Url.Action("ReportSizeOfOrganisationGet", "ReportSizeOfOrganisation",
                     new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                Status = Model.OrganisationSizeStatus
+                Status = Model.OrganisationSizeStatus,
+                LoadTestId = "organisation-size"
             });
             aboutYourOrganisationSection.Items.Add(new TaskListItemViewModel
             {
@@ -216,7 +218,8 @@
                             </text>,
                 Href = Url.Action("ReportLinkToWebsiteGet", "ReportLinkToWebsite",
                     new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                Status = Model.LinkStatus
+                Status = Model.LinkStatus,
+                LoadTestId = "link-to-gpg-information"
             });
 
             var submitSection = new TaskListSectionViewModel
@@ -231,7 +234,8 @@
                             ? Url.Action("ReportReview", "ReportReviewAndSubmit",
                                 new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear})
                             : null,
-                        Status = Model.ReviewAndSubmitStatus
+                        Status = Model.ReviewAndSubmitStatus,
+                        LoadTestId = "review-and-submit"
                     }
                 }
             };

--- a/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
+++ b/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
@@ -164,21 +164,24 @@
                         Title = "Hourly pay",
                         Href = Url.Action("ReportHourlyPayGet", "ReportHourlyPay",
                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                        Status = Model.HourlyPayStatus
+                        Status = Model.HourlyPayStatus,
+                        LoadTestId = "hourly-pay"
                     },
                     new TaskListItemViewModel
                     {
                         Title = "Bonus pay",
                         Href = Url.Action("ReportBonusPayGet", "ReportBonusPay",
                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                        Status = Model.BonusPayStatus
+                        Status = Model.BonusPayStatus,
+                        LoadTestId = "bonus-pay"
                     },
                     new TaskListItemViewModel
                     {
                         Title = "Employees by pay quarter",
                         Href = Url.Action("EmployeesByPayQuartileGet", "ReportEmployeesByPayQuartile",
                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                        Status = Model.EmployessByPayQuartileStatus
+                        Status = Model.EmployessByPayQuartileStatus,
+                        LoadTestId = "employees-by-pay-quarter"
                     }
                 }
             };

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Results.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Results.cshtml
@@ -9,7 +9,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h2>
-                        @Html.ActionLink(employer.Name, "Employer", "Viewing", new {employerIdentifier = employer.OrganisationIdEncrypted}, new {data_name = "ViewLink", data_id = employer.OrganisationIdEncrypted})
+                        @Html.ActionLink(employer.Name, "Employer", "Viewing", new {employerIdentifier = employer.OrganisationIdEncrypted}, new {data_name = "ViewLink", data_id = employer.OrganisationIdEncrypted, data_loadtestid = employer.Name})
                     </h2>
                     @if (string.IsNullOrWhiteSpace(employer.PreviousName) == false)
                     {

--- a/LoadTests/LoadTests.iml
+++ b/LoadTests/LoadTests.iml
@@ -5,6 +5,7 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/scala" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -11,6 +11,7 @@ DO $$
         DELETE FROM "AuditLogs" WHERE "OrganisationId" > STARTING_ID;
         DELETE FROM "UserStatus" WHERE "ByUserId" > STARTING_ID;
         DELETE FROM "OrganisationStatus" WHERE "OrganisationId" > STARTING_ID;
+        DELETE FROM "OrganisationStatus" WHERE "ByUserId" > STARTING_ID;
         DELETE FROM "UserOrganisations" WHERE "UserOrganisations"."OrganisationId" > STARTING_ID;
         DELETE FROM "OrganisationScopes" WHERE "OrganisationScopes"."OrganisationScopeId" > STARTING_ID;
         DELETE FROM "OrganisationNames" WHERE "OrganisationNames"."OrganisationId" > STARTING_ID;
@@ -18,12 +19,12 @@ DO $$
         DELETE FROM "OrganisationAddresses" WHERE "OrganisationAddresses"."AddressId" > STARTING_ID;
         DELETE FROM "Returns" WHERE "Returns"."OrganisationId" > STARTING_ID;
 
-        DELETE FROM "Users" WHERE "Users"."UserId" > STARTING_ID;
-        DELETE FROM "Organisations" WHERE "Organisations"."OrganisationId" > STARTING_ID;
-
         -- Delete users created using registration journey
         DELETE FROM "UserStatus" WHERE "ByUserId" IN (SELECT "UserId" FROM "Users" WHERE "Users"."Firstname" = 'Test' AND "Users"."Lastname" = 'Example' AND "Users"."JobTitle" = 'Tester');
         DELETE FROM "Users" WHERE "Users"."Firstname" = 'Test' AND "Users"."Lastname" = 'Example' AND "Users"."JobTitle" = 'Tester';
+
+        DELETE FROM "Users" WHERE "Users"."UserId" > STARTING_ID;
+        DELETE FROM "Organisations" WHERE "Organisations"."OrganisationId" > STARTING_ID;
 
         WHILE INDEX <= NUM_OF_USERS LOOP
                 -- Create test users
@@ -46,7 +47,7 @@ DO $$
                 INSERT INTO "OrganisationScopes"
                 ("OrganisationScopeId", "OrganisationId", "ScopeStatusId", "ScopeStatusDate", "RegisterStatusId", "RegisterStatusDate", "SnapshotDate", "StatusId")
                 VALUES
-                (STARTING_ID + INDEX, STARTING_ID + INDEX, 1, '01/10/2020 12:26:44', 0, '01/10/2020 12:26:44', '05/04/2019 00:00:00', 3);
+                (STARTING_ID + INDEX, STARTING_ID + INDEX, 1, '01/10/2020 12:26:44', 0, '01/10/2020 12:26:44', '05/04/2020 00:00:00', 3);
 
                 INSERT INTO "OrganisationAddresses"
                 ("AddressId", "OrganisationId", "CreatedByUserId", "Address1", "Country", "PostCode", "StatusId", "StatusDate", "Created", "Source", "IsUkAddress")
@@ -78,7 +79,7 @@ DO $$
                 INSERT INTO "OrganisationScopes"
                 ("OrganisationScopeId", "OrganisationId", "ScopeStatusId", "ScopeStatusDate", "RegisterStatusId", "RegisterStatusDate", "SnapshotDate", "StatusId")
                 VALUES
-                (STARTING_ID + NUM_OF_USERS + INDEX, STARTING_ID + NUM_OF_USERS + INDEX, 1, '01/10/2020 12:26:44', 0, '01/10/2020 12:26:44', '05/04/2019 00:00:00', 3);
+                (STARTING_ID + NUM_OF_USERS + INDEX, STARTING_ID + NUM_OF_USERS + INDEX, 1, '01/10/2020 12:26:44', 0, '01/10/2020 12:26:44', '05/04/2020 00:00:00', 3);
 
                 INSERT INTO "OrganisationAddresses"
                 ("AddressId", "OrganisationId", "CreatedByUserId", "Address1", "Country", "PostCode", "StatusId", "StatusDate", "Created", "Source", "IsUkAddress")

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -9,6 +9,7 @@ DO $$
 -- Remove all test entities
     BEGIN
         DELETE FROM "AuditLogs" WHERE "OrganisationId" > STARTING_ID;
+        DELETE FROM "AuditLogs" WHERE "OriginalUserId" > STARTING_ID;
         DELETE FROM "UserStatus" WHERE "ByUserId" > STARTING_ID;
         DELETE FROM "OrganisationStatus" WHERE "OrganisationId" > STARTING_ID;
         DELETE FROM "OrganisationStatus" WHERE "ByUserId" > STARTING_ID;
@@ -17,6 +18,7 @@ DO $$
         DELETE FROM "OrganisationNames" WHERE "OrganisationNames"."OrganisationId" > STARTING_ID;
         DELETE FROM "OrganisationSicCodes" WHERE "OrganisationSicCodes"."OrganisationId" > STARTING_ID;
         DELETE FROM "OrganisationAddresses" WHERE "OrganisationAddresses"."AddressId" > STARTING_ID;
+        DELETE FROM "ReturnStatus" WHERE "ReturnStatus"."ByUserId" > STARTING_ID;
         DELETE FROM "Returns" WHERE "Returns"."OrganisationId" > STARTING_ID;
 
         -- Delete users created using registration journey

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -1,21 +1,25 @@
 DO $$
 
     DECLARE
+        -- A high starting number to ensure that the IDs don't interfere with any existing data
         STARTING_ID INTEGER := 300000000;
         NUM_OF_USERS INTEGER := 20000;
         INDEX INTEGER := 1;
 
 -- Remove all test entities
     BEGIN
-        DELETE FROM "UserStatus" WHERE "ByUserId" = STARTING_ID + INDEX;
-        DELETE FROM "Users" WHERE "Users"."UserId" > STARTING_ID AND "Users"."UserId" <= STARTING_ID + NUM_OF_USERS;
-        DELETE FROM "Organisations" WHERE "Organisations"."OrganisationId" > STARTING_ID AND "Organisations"."OrganisationId" <= STARTING_ID + 2 * NUM_OF_USERS;
-        DELETE FROM "UserOrganisations" WHERE "UserOrganisations"."OrganisationId" > STARTING_ID AND "UserOrganisations"."OrganisationId" <= STARTING_ID + 2 * NUM_OF_USERS;
-        DELETE FROM "OrganisationScopes" WHERE "OrganisationScopes"."OrganisationScopeId" > STARTING_ID AND "OrganisationScopes"."OrganisationScopeId" <= STARTING_ID + 2* NUM_OF_USERS;
-        DELETE FROM "OrganisationNames" WHERE "OrganisationNames"."OrganisationId" > STARTING_ID AND "OrganisationNames"."OrganisationId" <= STARTING_ID + 2 * NUM_OF_USERS;
-        DELETE FROM "OrganisationSicCodes" WHERE "OrganisationSicCodes"."OrganisationId" > STARTING_ID AND "OrganisationSicCodes"."OrganisationId" <= STARTING_ID + 2 * NUM_OF_USERS;
-        DELETE FROM "OrganisationAddresses" WHERE "OrganisationAddresses"."AddressId" > STARTING_ID AND "OrganisationAddresses"."AddressId" <= STARTING_ID + 2 * NUM_OF_USERS;
-        DELETE FROM "Returns" WHERE "Returns"."OrganisationId" > STARTING_ID AND "Returns"."OrganisationId" <= STARTING_ID + NUM_OF_USERS;
+        DELETE FROM "AuditLogs" WHERE "OrganisationId" > STARTING_ID;
+        DELETE FROM "UserStatus" WHERE "ByUserId" > STARTING_ID;
+        DELETE FROM "OrganisationStatus" WHERE "OrganisationId" > STARTING_ID;
+        DELETE FROM "UserOrganisations" WHERE "UserOrganisations"."OrganisationId" > STARTING_ID;
+        DELETE FROM "OrganisationScopes" WHERE "OrganisationScopes"."OrganisationScopeId" > STARTING_ID;
+        DELETE FROM "OrganisationNames" WHERE "OrganisationNames"."OrganisationId" > STARTING_ID;
+        DELETE FROM "OrganisationSicCodes" WHERE "OrganisationSicCodes"."OrganisationId" > STARTING_ID;
+        DELETE FROM "OrganisationAddresses" WHERE "OrganisationAddresses"."AddressId" > STARTING_ID;
+        DELETE FROM "Returns" WHERE "Returns"."OrganisationId" > STARTING_ID;
+
+        DELETE FROM "Users" WHERE "Users"."UserId" > STARTING_ID;
+        DELETE FROM "Organisations" WHERE "Organisations"."OrganisationId" > STARTING_ID;
 
         -- Delete users created using registration journey
         DELETE FROM "UserStatus" WHERE "ByUserId" IN (SELECT "UserId" FROM "Users" WHERE "Users"."Firstname" = 'Test' AND "Users"."Lastname" = 'Example' AND "Users"."JobTitle" = 'Tester');
@@ -32,7 +36,7 @@ DO $$
                 INSERT INTO "Organisations"
                 ("OrganisationId", "CompanyNumber", "OrganisationName", "SectorTypeId", "StatusId", "StatusDate", "StatusDetails", "Created", "Modified", "OptedOutFromCompaniesHouseUpdate", "EmployerReference")
                 VALUES
-                (STARTING_ID + INDEX, '99999' || CAST(INDEX AS VARCHAR(16)), 'test_' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX AS VARCHAR(16)));
+                (STARTING_ID + INDEX, '99999' || CAST(NUM_OF_USERS + INDEX AS VARCHAR(16)), 'test_' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX AS VARCHAR(16)));
 
                 INSERT INTO "OrganisationNames"
                 ("OrganisationNameId", "OrganisationId", "Name", "Source", "Created")
@@ -60,10 +64,11 @@ DO $$
                 (STARTING_ID + INDEX, STARTING_ID + INDEX, 0, '01/10/2020 12:26:44', '01/10/2020 12:26:44', '01/10/2020 12:26:44');
 
                 -- Create test organisations that are NOT linked to test users
+                -- These have the same names as linked Organisations, so they appear in the search results together
                 INSERT INTO "Organisations"
                 ("OrganisationId", "CompanyNumber", "OrganisationName", "SectorTypeId", "StatusId", "StatusDate", "StatusDetails", "Created", "Modified", "OptedOutFromCompaniesHouseUpdate", "EmployerReference")
                 VALUES
-                (STARTING_ID + NUM_OF_USERS + INDEX, '99999' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)), 'test_' || CAST(INDEX + NUM_OF_USERS  AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)));
+                (STARTING_ID + NUM_OF_USERS + INDEX, '99999' || CAST(INDEX + 2 * NUM_OF_USERS AS VARCHAR(16)), 'test_' || CAST(INDEX + NUM_OF_USERS  AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)));
 
                 INSERT INTO "OrganisationNames"
                 ("OrganisationNameId", "OrganisationId", "Name", "Source", "Created")

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -71,12 +71,12 @@ DO $$
                 INSERT INTO "Organisations"
                 ("OrganisationId", "CompanyNumber", "OrganisationName", "SectorTypeId", "StatusId", "StatusDate", "StatusDetails", "Created", "Modified", "OptedOutFromCompaniesHouseUpdate", "EmployerReference")
                 VALUES
-                (STARTING_ID + NUM_OF_USERS + INDEX, '99999' || CAST(INDEX + 2 * NUM_OF_USERS AS VARCHAR(16)), 'test_' || CAST(INDEX + NUM_OF_USERS  AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)));
+                (STARTING_ID + NUM_OF_USERS + INDEX, '99999' || CAST(2 * NUM_OF_USERS + INDEX AS VARCHAR(16)), 'test_' || CAST(NUM_OF_USERS * 2 + INDEX AS VARCHAR(16)), 1, 3, '01/10/2020 12:26:44', 'PIN Confirmed', '01/10/2020 12:26:44', '01/10/2020 12:26:44', true, 'ABCDE' || CAST(2 * NUM_OF_USERS + INDEX AS VARCHAR(16)));
 
                 INSERT INTO "OrganisationNames"
                 ("OrganisationNameId", "OrganisationId", "Name", "Source", "Created")
                 VALUES
-                (STARTING_ID + NUM_OF_USERS + INDEX, STARTING_ID + NUM_OF_USERS + INDEX, 'test_' || CAST(INDEX + NUM_OF_USERS AS VARCHAR(16)), 'User', '01/10/2020 12:26:44');
+                (STARTING_ID + NUM_OF_USERS + INDEX, STARTING_ID + NUM_OF_USERS + INDEX, 'test_' || CAST(NUM_OF_USERS * 2 + INDEX AS VARCHAR(16)), 'User', '01/10/2020 12:26:44');
 
                 INSERT INTO "OrganisationScopes"
                 ("OrganisationScopeId", "OrganisationId", "ScopeStatusId", "ScopeStatusDate", "RegisterStatusId", "RegisterStatusDate", "SnapshotDate", "StatusId")

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -21,7 +21,6 @@ DO $$
 
         -- Delete users created using registration journey
         DELETE FROM "UserStatus" WHERE "ByUserId" IN (SELECT "UserId" FROM "Users" WHERE "Users"."Firstname" = 'Test' AND "Users"."Lastname" = 'Example' AND "Users"."JobTitle" = 'Tester');
-        DELETE FROM "Users" WHERE "Users"."Firstname" = 'Test' AND "Users"."Lastname" = 'Example' AND "Users"."JobTitle" = 'Tester';
 
         DELETE FROM "Users" WHERE "Users"."UserId" > STARTING_ID;
         DELETE FROM "Organisations" WHERE "Organisations"."OrganisationId" > STARTING_ID;

--- a/LoadTests/SET_UP_TEST_ENTITIES.sql
+++ b/LoadTests/SET_UP_TEST_ENTITIES.sql
@@ -47,7 +47,8 @@ DO $$
                 INSERT INTO "OrganisationScopes"
                 ("OrganisationScopeId", "OrganisationId", "ScopeStatusId", "ScopeStatusDate", "RegisterStatusId", "RegisterStatusDate", "SnapshotDate", "StatusId")
                 VALUES
-                (STARTING_ID + INDEX, STARTING_ID + INDEX, 1, '01/10/2020 12:26:44', 0, '01/10/2020 12:26:44', '05/04/2020 00:00:00', 3);
+                (STARTING_ID + INDEX, STARTING_ID + INDEX, 1, '01/10/2020 12:26:44', 0, '01/10/2020 12:26:44', '05/04/2020 00:00:00', 3),
+                (STARTING_ID + 2 * NUM_OF_USERS + INDEX, STARTING_ID + INDEX, 1, '01/10/2019 12:26:44', 0, '01/10/2019 12:26:44', '05/04/2019 00:00:00', 3);
 
                 INSERT INTO "OrganisationAddresses"
                 ("AddressId", "OrganisationId", "CreatedByUserId", "Address1", "Country", "PostCode", "StatusId", "StatusDate", "Created", "Source", "IsUkAddress")

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -448,7 +448,110 @@ class RecordingSimulation extends Simulation {
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
 				regex("for reporting year 2020-21"),
-				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
+				css("a[loadtest-id='responsible-person']", "href").find.saveAs("linkToResponsiblePersonPage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitResponsiblePersonPage = exec(http("Visit responsible person page")
+			.get("${linkToResponsiblePersonPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Person responsible in your organisation")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterResponsiblePersonDetails = exec(http("Enter responsible person details")
+			.post("${linkToResponsiblePersonPage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_ResponsiblePersonFirstName", "FirstName")
+			.formParam("GovUk_Text_ResponsiblePersonLastName", "LastName")
+			.formParam("GovUk_Text_ResponsiblePersonJobTitle", "Tester")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='organisation-size']", "href").find.saveAs("linkToOrganisationSizePage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitOrganisationSizePage = exec(http("Visit organisation size page")
+			.get("${linkToOrganisationSizePage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Size of your organisation")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterOrganisationSizeDetails = exec(http("Enter organisation size details")
+			.post("${linkToOrganisationSizePage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Radio_SizeOfOrganisation", "Employees250To499")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='link-to-gpg-information']", "href").find.saveAs("linkToLinkToGpgInformationPage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitLinkToGpgInformationPage = exec(http("Visit link to GPG information page")
+			.get("${linkToLinkToGpgInformationPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Link to your gender pay gap information")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterLinkToGpgInformationDetails = exec(http("Enter link to GPG information details")
+			.post("${linkToLinkToGpgInformationPage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_LinkToOrganisationWebsite", "http://test-employer-information.com/gpg")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='review-and-submit']", "href").find.saveAs("linkToReviewAndSubmitPage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitReviewAndSubmitPage = exec(http("Visit review and submit page")
+			.get("${linkToReviewAndSubmitPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Review your gender pay gap report")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val reviewAndSubmitReport = exec(http("Review and submit report")
+			.post("${linkToReviewAndSubmitPage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.check(
+				status.is(200),
+				regex("You've reported your gender pay gap data"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
@@ -608,6 +711,14 @@ class RecordingSimulation extends Simulation {
 		ReportGenderPayGap.enterBonusPayDetails,
 		ReportGenderPayGap.visitEmployeesByPayQuarterPage,
 		ReportGenderPayGap.enterEmployeesByPayQuarterDetails,
+		ReportGenderPayGap.visitResponsiblePersonPage,
+		ReportGenderPayGap.enterResponsiblePersonDetails,
+		ReportGenderPayGap.visitOrganisationSizePage,
+		ReportGenderPayGap.enterOrganisationSizeDetails,
+		ReportGenderPayGap.visitLinkToGpgInformationPage,
+		ReportGenderPayGap.enterLinkToGpgInformationDetails,
+		ReportGenderPayGap.visitReviewAndSubmitPage,
+		ReportGenderPayGap.reviewAndSubmitReport,
 		ManageAccount.visit,
 		ManageAccount.visitChangeEmailAddressPage,
 		ManageAccount.changeEmailAddress,

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -44,7 +44,7 @@ class RecordingSimulation extends Simulation {
 		"DNT" -> "1",
 		"Pragma" -> "no-cache")
 
-	val searchFeeder = Iterator.continually(Map("searchCriteria1" -> "tes", "searchCriteria2" -> s"test_${Random.nextInt(2 * MAX_NUM_USERS) + 1}"))
+	val searchFeeder = Iterator.continually(Map("searchCriteria1" -> "tes", "searchCriteria2" -> s"test_${MAX_NUM_USERS + Random.nextInt(MAX_NUM_USERS) + 1}"))
 	val registrationFeeder = Iterator.continually(Map("email" -> (Random.alphanumeric.take(20).mkString + "@example.com")))
 	val usersOrganisationsFeeder = csv("users_organisations.csv").circular
 
@@ -66,7 +66,7 @@ class RecordingSimulation extends Simulation {
 					.headers(headers_1),
 				http("Load crest")
 					.get("/public/govuk_template/assets/stylesheets/images/govuk-crest-2x.png")
-					.headers(headers_1)
+					.headers(headers_1)))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		val search = feed(searchFeeder)

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -336,7 +336,7 @@ class RecordingSimulation extends Simulation {
 			.headers(headers_0)
 			.check(
 				regex("Add or select an organisation you're reporting for"),
-				css("a.loadtest", "href").find.saveAs("linkToAnOrganisation")
+				css("a[loadtest-id='organisation-link']", "href").find.saveAs("linkToAnOrganisation")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
@@ -347,7 +347,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Manage your organisation's reporting"),
         regex("for ${organisationName}"),
-				css("a.create-report-2020", "href").find.saveAs("linkToTheLatestReport")
+				css("a[loadtest-id='create-report-2020']", "href").find.saveAs("linkToTheLatestReport")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
@@ -361,10 +361,6 @@ class RecordingSimulation extends Simulation {
 				css("")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
-
-		val visitHourlyPayPage = exec(http("Visit hourly pay figures page")
-			.get()
-		)
 
 		val enterCalculation = exec(http("Enter calculation")
 			.post("/Submit/enter-calculations")

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -13,6 +13,8 @@ class RecordingSimulation extends Simulation {
 	val PAUSE_MIN_DUR = 1 seconds
 	val PAUSE_MAX_DUR = 10 seconds
 
+	val CURRENT_YEAR = "2020-21"
+
 	val httpProtocol = http
 		.baseUrl("https://wa-t1pp-gpg.azurewebsites.net")
 		.inferHtmlResources()

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -346,217 +346,110 @@ class RecordingSimulation extends Simulation {
 			.check(
 				status.is(200),
 				regex("Manage your organisation's reporting"),
-        regex("for ${organisationName}"),
+				regex("for ${organisationName}"),
 				css("a[loadtest-id='create-report-2020']", "href").find.saveAs("linkToTheLatestReport")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val visitEnterReport = exec(http("Visit report start page")
+		val visitReportOverviewPage = exec(http("Visit report overview page")
 			.get("${linkToTheLatestReport}")
 			.headers(headers_0)
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
 				regex("for reporting year 2020-21"),
-				css("")
+				css("a[loadtest-id='hourly-pay']", "href").find.saveAs("linkToHourlyPayPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterCalculation = exec(http("Enter calculation")
-			.post("/Submit/enter-calculations")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("FirstName", "")
-			.formParam("JobTitle", "")
-			.formParam("LastName", "")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "NotProvided")
-			.formParam("CompanyLinkToGPGInfo", "")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("DiffMeanHourlyPayPercent", "1")
-			.formParam("DiffMedianHourlyPercent", "1")
-			.formParam("MaleMedianBonusPayPercent", "1")
-			.formParam("FemaleMedianBonusPayPercent", "1")
-			.formParam("DiffMeanBonusPercent", "1")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("MaleUpperQuartilePayBand", "50")
-			.formParam("FemaleUpperQuartilePayBand", "50")
-			.formParam("MaleUpperPayBand", "50")
-			.formParam("FemaleUpperPayBand", "50")
-			.formParam("MaleMiddlePayBand", "50")
-			.formParam("FemaleMiddlePayBand", "50")
-			.formParam("MaleLowerPayBand", "50")
-			.formParam("FemaleLowerPayBand", "50")
-			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+		val visitHourlyPayPage = exec(http("Visit hourly pay page")
+			.get("${linkToHourlyPayPage}")
+			.headers(headers_0)
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Person responsible in your organisation")))
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Hourly pay")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterResponsiblePerson = exec(http("Enter responsible person")
-			.post("/Submit/person-responsible")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "NotProvided")
-			.formParam("CompanyLinkToGPGInfo", "")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
+		val enterHourlyPayDetails = exec(http("Enter hourly pay details")
+			.post("${linkToHourlyPayPage}")
+			.headers(headers_0)
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_DiffMeanHourlyPayPercent", "50")
+			.formParam("GovUk_Text_DiffMedianHourlyPercent", "50")
+			.formParam("Action", "SaveAndContinue")
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Size of your organisation")))
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='bonus-pay']", "href").find.saveAs("linkToBonusPayPage")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterSizeOfOrganisation = exec(http("Enter size of organisation")
-			.post("/Submit/organisation-size")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "2")
-			.formParam("CompanyLinkToGPGInfo", "")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
-			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+		val visitBonusPayPage = exec(http("Visit bonus pay page")
+			.get("${linkToBonusPayPage}")
+			.headers(headers_0)
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Link to your gender pay gap information")))
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Percentage of employees who received bonus pay"),
+				regex("Bonus pay")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterWebAddress = exec(http("Enter web address")
-			.post("/Submit/employer-website")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "Employees250To499")
-			.formParam("CompanyLinkToGPGInfo", "http://example.com/")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
+		val enterBonusPayDetails = exec(http("Enter bonus pay details")
+			.post("${linkToBonusPayPage}")
+			.headers(headers_0)
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_FemaleBonusPayPercent", "50")
+			.formParam("GovUk_Text_MaleBonusPayPercent", "50")
+			.formParam("GovUk_Text_DiffMeanBonusPercent", "0")
+			.formParam("GovUk_Text_DiffMedianBonusPercent", "0")
+			.formParam("Action", "SaveAndContinue")
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Review your gender pay gap data")))
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val confirmGenderPayGapData = exec(http("Confirm gender pay gap data")
-			.post("/Submit/check-data")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.Draft", "GenderPayGap.BusinessLogic.Classes.Draft")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "Employees250To499")
-			.formParam("CompanyLinkToGPGInfo", "http://example.com/")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
+		val visitEmployeesByPayQuarterPage = exec(http("Visit employees by pay quarter page")
+			.get("${linkToEmployeesByPayQuarterPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Employees by pay quarter")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterEmployeesByPayQuarterDetails = exec(http("Enter employees by pay quarter details")
+			.post("${linkToEmployeesByPayQuarterPage}")
+			.headers(headers_0)
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
-			.check(regex("You've submitted your gender pay gap data for 2019 to 2020")))
+			.formParam("GovUk_Text_MaleUpperPayBand", "50")
+			.formParam("GovUk_Text_FemaleUpperPayBand", "50")
+			.formParam("GovUk_Text_MaleUpperMiddlePayBand", "50")
+			.formParam("GovUk_Text_FemaleUpperMiddlePayBand", "50")
+			.formParam("GovUk_Text_MaleLowerMiddlePayBand", "50")
+			.formParam("GovUk_Text_FemaleLowerMiddlePayBand", "50")
+			.formParam("GovUk_Text_MaleLowerPayBand", "50")
+			.formParam("GovUk_Text_FemaleLowerPayBand", "50")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
 
@@ -708,12 +601,13 @@ class RecordingSimulation extends Simulation {
 		SelectExistingOrganisation.confirmOrganisationChoice,
 		ReportGenderPayGap.visitManageOrganisation,
 		ReportGenderPayGap.visitOrganisation,
-		ReportGenderPayGap.visitEnterReport,
-		ReportGenderPayGap.enterCalculation,
-		ReportGenderPayGap.enterResponsiblePerson,
-		ReportGenderPayGap.enterSizeOfOrganisation,
-		ReportGenderPayGap.enterWebAddress,
-		ReportGenderPayGap.confirmGenderPayGapData,
+		ReportGenderPayGap.visitReportOverviewPage,
+		ReportGenderPayGap.visitHourlyPayPage,
+		ReportGenderPayGap.enterHourlyPayDetails,
+		ReportGenderPayGap.visitBonusPayPage,
+		ReportGenderPayGap.enterBonusPayDetails,
+		ReportGenderPayGap.visitEmployeesByPayQuarterPage,
+		ReportGenderPayGap.enterEmployeesByPayQuarterDetails,
 		ManageAccount.visit,
 		ManageAccount.visitChangeEmailAddressPage,
 		ManageAccount.changeEmailAddress,

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -46,7 +46,7 @@ class RecordingSimulation extends Simulation {
 		"DNT" -> "1",
 		"Pragma" -> "no-cache")
 
-	val searchFeeder = Iterator.continually(Map("searchCriterion" -> s"test_${MAX_NUM_USERS + Random.nextInt(MAX_NUM_USERS)}"))
+	val searchFeeder = Iterator.continually(Map("searchCriterion" -> s"test_${Random.nextInt(MAX_NUM_USERS) + 1}"))
 	val registrationFeeder = Iterator.continually(Map("email" -> (Random.alphanumeric.take(20).mkString + "@example.com")))
 	val usersOrganisationsFeeder = csv("users_organisations.csv").circular
 
@@ -85,7 +85,7 @@ class RecordingSimulation extends Simulation {
 			.headers(headers_0)
 			.check(
 				status.is(200),
-				regex("${searchCriterion}")))
+				regex("Gender pay gap reports")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
 

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -93,7 +93,7 @@ class RecordingSimulation extends Simulation {
 
 	object SignInPage {
 		val visit = exec(http("Visit sign in page")
-			.get("/login?ReturnUrl=${returnUrl}")
+			.get("/login")
 			.headers(headers_0)
 			.check(
 				status.in(200, 302),
@@ -113,20 +113,24 @@ class RecordingSimulation extends Simulation {
 
 		val signIn = feed(usersOrganisationsFeeder)
 			.exec(http("Sign in")
-			.post("/account/sign-in")
+			.post("/login")
 			.headers(headers_3)
 			.formParam("GovUk_Text_EmailAddress", "${email}")
 			.formParam("GovUk_Text_Password", "Genderpaygap1")
 			.formParam("ReturnUrl", "${returnUrl}")
 			.formParam("button", "login")
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.check(
+				status.in(200, 302),
+				regex("Privacy Policy"),
+				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"))
 			)
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
 
 	object RegistrationPage {
 		val visit = exec(http("Load registration page")
-			.get("create-user-account")
+			.get("/create-user-account")
 			.headers(headers_0)
 			.check(
 				status.is(200),
@@ -135,8 +139,8 @@ class RecordingSimulation extends Simulation {
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		val register = feed(registrationFeeder)
-			.exec(http("Register")
-			.post("create-user-account")
+			.exec(http("Register an account")
+			.post("/create-user-account")
 			.headers(headers_3)
 			.formParam("GovUk_Text_EmailAddress", "${email}")
 			.formParam("GovUk_Text_ConfirmEmailAddress", "${email}")
@@ -555,7 +559,9 @@ class RecordingSimulation extends Simulation {
 		val visit = exec(http("Visit manage account")
 			.get("/manage-account")
 			.headers(headers_0)
-			.check(regex("Manage your account")))
+			.check(
+				status.is(200),
+				regex("Manage your account")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		// TODO: Update these - change personal details is now multiple pages

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -569,27 +569,84 @@ class RecordingSimulation extends Simulation {
 				regex("Manage your account")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		// TODO: Update these - change personal details is now multiple pages
-		val visitChangePersonalDetails = exec(http("Visit change personal details")
-			.get("/manage-account/change-details")
+		val visitChangeEmailAddressPage = exec(http("Visit change email address page")
+			.get("/manage-account/change-email")
 			.headers(headers_0)
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				regex("Change your personal details")))
+				status.is(200),
+				regex("Change email address")))
+  		.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val changeEmailAddress = exec(http("Change email address")
+			.post("/manage-account/change-email")
+			.headers(headers_3)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_NewEmailAddress", "newemail@example.com")
+			.check(
+				status.is(200),
+				regex("We have sent a verification email to your new email address")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val changePersonalDetails = exec(http("Change personal details")
-			.post("/manage-account/change-details")
+		val visitChangePasswordPage = exec(http("Visit change password page")
+			.get("/manage-account/change-password-new")
+			.headers(headers_0)
+			.check(
+				status.is(200),
+				regex("Change your password")))
+  		.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val changePassword = exec(http("Change password")
+			.post("/manage-account/change-password-new")
 			.headers(headers_3)
-			.formParam("FirstName", "test user")
-			.formParam("LastName", "test user")
-			.formParam("JobTitle", "test job")
-			.formParam("ContactPhoneNumber", "")
-			.formParam("AllowContact", "true")
-			.formParam("SendUpdates", "false")
-			.formParam("AllowContact", "false")
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
-				.check(regex("Your details have been updated successfully")))
+			.formParam("GovUk_Text_CurrentPassword", "Genderpaygap1")
+			.formParam("GovUk_Text_NewPassword", "Genderpaygap2")
+			.formParam("GovUk_Text_ConfirmNewPassword", "Genderpaygap2")
+			.check(
+				status.is(200),
+				regex("Your password has been changed successfully")))
+  		.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitChangePersonalDetailsPage = exec(http("Visit change personal details page")
+			.get("/manage-account/change-personal-details")
+			.headers(headers_0)
+			.check(
+				status.is(200),
+				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
+				regex("Change your personal details")))
+  		.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val changePersonalDetails = exec(http("Change personal details")
+			.post("/manage-account/change-personal-details")
+			.headers(headers_3)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_FirstName", "testing")
+			.formParam("GovUk_Text_LastName", "testing")
+			.formParam("GovUk_Text_JobTitle", "tester")
+			.formParam("GovUk_Text_ContactPhoneNumber", "")
+			.check(
+				status.is(200),
+				regex("Saved changes to personal details")))
+  		.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitChangeContactPreferencesPage = exec(http("Visit change contact preferences page")
+			.get("/manage-account/change-contact-preferences")
+			.headers(headers_0)
+			.check(
+				status.is(200),
+				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
+				regex("Change your contact preferences")))
+  		.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val changeContactPreferences = exec(http("Change contact preferences")
+			.post("/manage-account/change-contact-preferences")
+			.headers(headers_3)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("SendUpdates", "True")
+			.formParam("AllowContact", "True")
+			.check(
+				status.is(200),
+				regex("Saved changes to contact preferences")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
 
@@ -658,8 +715,15 @@ class RecordingSimulation extends Simulation {
 		ReportGenderPayGap.enterWebAddress,
 		ReportGenderPayGap.confirmGenderPayGapData,
 		ManageAccount.visit,
-		ManageAccount.visitChangePersonalDetails,
+		ManageAccount.visitChangeEmailAddressPage,
+		ManageAccount.changeEmailAddress,
+		ManageAccount.visit,
+		ManageAccount.visitChangePasswordPage,
+		ManageAccount.changePassword,
+		ManageAccount.visitChangePersonalDetailsPage,
 		ManageAccount.changePersonalDetails,
+		ManageAccount.visitChangeContactPreferencesPage,
+		ManageAccount.changeContactPreferences,
 		Feedback.visit,
 		Feedback.submit)
 

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -92,7 +92,7 @@ class RecordingSimulation extends Simulation {
 			.get("/login")
 			.headers(headers_0)
 			.check(
-				status.in(200, 302),
+				status.in(200),
 				regex("Sign in"),
 				regex("If you have a user account, enter your email address and password"),
 				css("input[name='ReturnUrl'","value").saveAs("returnUrl"),
@@ -116,7 +116,7 @@ class RecordingSimulation extends Simulation {
 			.formParam("button", "login")
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
 			.check(
-				status.in(200, 302),
+				status.in(200),
 				regex("Privacy Policy"),
 				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"))
 			)
@@ -342,7 +342,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Manage your organisation's reporting"),
 				regex("for ${organisationName}"),
-				css("a[loadtest-id='create-report-2020']", "href").find.saveAs("linkToTheLatestReport")
+				css(s"a[loadtest-id='create-report-${CURRENT_YEAR.substring(0, 4)}']", "href").find.saveAs("linkToTheLatestReport")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
@@ -352,7 +352,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='hourly-pay']", "href").find.saveAs("linkToHourlyPayPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -363,7 +363,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Hourly pay")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -379,7 +379,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='bonus-pay']", "href").find.saveAs("linkToBonusPayPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -390,7 +390,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Percentage of employees who received bonus pay"),
 				regex("Bonus pay")
 			))
@@ -409,7 +409,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -420,7 +420,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Employees by pay quarter")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -442,7 +442,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='responsible-person']", "href").find.saveAs("linkToResponsiblePersonPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -453,7 +453,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Person responsible in your organisation")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -470,7 +470,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='organisation-size']", "href").find.saveAs("linkToOrganisationSizePage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -481,7 +481,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Size of your organisation")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -496,7 +496,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='link-to-gpg-information']", "href").find.saveAs("linkToLinkToGpgInformationPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -507,7 +507,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Link to your gender pay gap information")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -522,7 +522,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				css("a[loadtest-id='review-and-submit']", "href").find.saveAs("linkToReviewAndSubmitPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -533,7 +533,7 @@ class RecordingSimulation extends Simulation {
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21"),
+				regex(s"for reporting year ${CURRENT_YEAR}"),
 				regex("Review your gender pay gap report")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
@@ -546,7 +546,7 @@ class RecordingSimulation extends Simulation {
 				status.is(200),
 				regex("You've reported your gender pay gap data"),
 				regex("for ${organisationName}"),
-				regex("for reporting year 2020-21")
+				regex(s"for reporting year ${CURRENT_YEAR}")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -335,16 +335,19 @@ class RecordingSimulation extends Simulation {
 			.get("/account/organisations")
 			.headers(headers_0)
 			.check(
-				css(session => "a:contains('" + session("organisationName").as[String].toUpperCase() + "')", "href").saveAs("linkToAnOrganisation"),
-				regex("Select an organisation")))
+				regex("Add or select an organisation you're reporting for"),
+				css("a.loadtest", "href").find.saveAs("linkToAnOrganisation")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		val visitOrganisation = exec(http("Visit an organisation page")
 			.get("${linkToAnOrganisation}")
 			.headers(headers_0)
 			.check(
-				css("a[id^='NewReport2019']", "href").find.saveAs("linkToTheLatestReport"),
-				regex("Manage your organisation's reporting")))
+				regex("Manage your organisation's reporting"),
+        regex("for ${organisationName}"),
+				css("a.create-report-2020", "href").find.saveAs("linkToTheLatestReport")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
 		val visitEnterReport = exec(http("Visit enter report page")

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -331,7 +331,7 @@ class RecordingSimulation extends Simulation {
 			.get("/account/organisations")
 			.headers(headers_0)
 			.check(
-				css("a:contains('${organisationName}')", "href").saveAs("linkToAnOrganisation"),
+				css(session => "a:contains('" + session("organisationName").as[String].toUpperCase() + "')", "href").saveAs("linkToAnOrganisation"),
 				regex("Select an organisation")))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -344,21 +344,27 @@ class RecordingSimulation extends Simulation {
 			.get("${linkToAnOrganisation}")
 			.headers(headers_0)
 			.check(
+				status.is(200),
 				regex("Manage your organisation's reporting"),
         regex("for ${organisationName}"),
 				css("a.create-report-2020", "href").find.saveAs("linkToTheLatestReport")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val visitEnterReport = exec(http("Visit enter report page")
+		val visitEnterReport = exec(http("Visit report start page")
 			.get("${linkToTheLatestReport}")
 			.headers(headers_0)
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Enter your gender pay gap data for snapshot date")))
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitHourlyPayPage = exec(http("Visit hourly pay figures page")
+			.get()
+		)
 
 		val enterCalculation = exec(http("Enter calculation")
 			.post("/Submit/enter-calculations")


### PR DESCRIPTION
[GPG-606 JIRA Ticket](https://technologyprogramme.atlassian.net/browse/GPG-606)

Fixes `__RequestVerificationToken` chaining which sorts errors on search, sign in, privacy policy and initial reporting pages. Also updates regex checks on Manage Organisations, Manage Organisation and Report Overview pages - there's also a few changes to the non-load test code to add classes for css selectors.

I'll create a separate PR for the actual calculation pages - since last year the format has changed significantly, so I'd prefer to do it in two chunks than all here.