### PR TITLE
GPG-606 Fixes full reporting journey

### DIFF
--- a/GenderPayGap.WebUI/Views/Components/TaskList/TaskList.cshtml
+++ b/GenderPayGap.WebUI/Views/Components/TaskList/TaskList.cshtml
@@ -33,6 +33,7 @@
                             {
                                 <a href="@(item.Href)"
                                    class="govuk-link"
+                                   loadtest-id="@(item.LoadTestId)"
                                    aria-describedby="@($"status-{sectionIndex}-{itemIndex}")">
                                     @item.Title
                                 </a>

--- a/GenderPayGap.WebUI/Views/Components/TaskList/TaskListViewModel.cs
+++ b/GenderPayGap.WebUI/Views/Components/TaskList/TaskListViewModel.cs
@@ -21,6 +21,8 @@ namespace GenderPayGap.WebUI.Views.Components.TaskList
         public Func<object, object> BodyHtml { get; set; }
         public string Href { get; set; }
         public TaskListStatus Status { get; set; }
+        
+        public string LoadTestId { get; set; }
     }
 
     public enum TaskListStatus

--- a/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
+++ b/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
@@ -198,7 +198,8 @@
                     Title = "Person responsible in your organisation",
                     Href = Url.Action("ReportResponsiblePersonGet", "ReportResponsiblePerson",
                         new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                    Status = Model.PersonResponsibleStatus
+                    Status = Model.PersonResponsibleStatus,
+                    LoadTestId = "responsible-person"
                 });
             }
             aboutYourOrganisationSection.Items.Add(new TaskListItemViewModel
@@ -206,7 +207,8 @@
                 Title = "Size of your organisation",
                 Href = Url.Action("ReportSizeOfOrganisationGet", "ReportSizeOfOrganisation",
                     new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                Status = Model.OrganisationSizeStatus
+                Status = Model.OrganisationSizeStatus,
+                LoadTestId = "organisation-size"
             });
             aboutYourOrganisationSection.Items.Add(new TaskListItemViewModel
             {
@@ -216,7 +218,8 @@
                             </text>,
                 Href = Url.Action("ReportLinkToWebsiteGet", "ReportLinkToWebsite",
                     new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                Status = Model.LinkStatus
+                Status = Model.LinkStatus,
+                LoadTestId = "link-to-gpg-information"
             });
 
             var submitSection = new TaskListSectionViewModel
@@ -231,7 +234,8 @@
                             ? Url.Action("ReportReview", "ReportReviewAndSubmit",
                                 new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear})
                             : null,
-                        Status = Model.ReviewAndSubmitStatus
+                        Status = Model.ReviewAndSubmitStatus,
+                        LoadTestId = "review-and-submit"
                     }
                 }
             };

--- a/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
+++ b/GenderPayGap.WebUI/Views/ReportOverview/ReportOverview.cshtml
@@ -164,21 +164,24 @@
                         Title = "Hourly pay",
                         Href = Url.Action("ReportHourlyPayGet", "ReportHourlyPay",
                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                        Status = Model.HourlyPayStatus
+                        Status = Model.HourlyPayStatus,
+                        LoadTestId = "hourly-pay"
                     },
                     new TaskListItemViewModel
                     {
                         Title = "Bonus pay",
                         Href = Url.Action("ReportBonusPayGet", "ReportBonusPay",
                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                        Status = Model.BonusPayStatus
+                        Status = Model.BonusPayStatus,
+                        LoadTestId = "bonus-pay"
                     },
                     new TaskListItemViewModel
                     {
                         Title = "Employees by pay quarter",
                         Href = Url.Action("EmployeesByPayQuartileGet", "ReportEmployeesByPayQuartile",
                             new {encryptedOrganisationId = encryptedOrganisationId, reportingYear = Model.ReportingYear}),
-                        Status = Model.EmployessByPayQuartileStatus
+                        Status = Model.EmployessByPayQuartileStatus,
+                        LoadTestId = "employees-by-pay-quarter"
                     }
                 }
             };

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -448,7 +448,110 @@ class RecordingSimulation extends Simulation {
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
 				regex("for reporting year 2020-21"),
-				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
+				css("a[loadtest-id='responsible-person']", "href").find.saveAs("linkToResponsiblePersonPage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitResponsiblePersonPage = exec(http("Visit responsible person page")
+			.get("${linkToResponsiblePersonPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Person responsible in your organisation")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterResponsiblePersonDetails = exec(http("Enter responsible person details")
+			.post("${linkToResponsiblePersonPage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_ResponsiblePersonFirstName", "FirstName")
+			.formParam("GovUk_Text_ResponsiblePersonLastName", "LastName")
+			.formParam("GovUk_Text_ResponsiblePersonJobTitle", "Tester")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='organisation-size']", "href").find.saveAs("linkToOrganisationSizePage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitOrganisationSizePage = exec(http("Visit organisation size page")
+			.get("${linkToOrganisationSizePage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Size of your organisation")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterOrganisationSizeDetails = exec(http("Enter organisation size details")
+			.post("${linkToOrganisationSizePage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Radio_SizeOfOrganisation", "Employees250To499")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='link-to-gpg-information']", "href").find.saveAs("linkToLinkToGpgInformationPage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitLinkToGpgInformationPage = exec(http("Visit link to GPG information page")
+			.get("${linkToLinkToGpgInformationPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Link to your gender pay gap information")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterLinkToGpgInformationDetails = exec(http("Enter link to GPG information details")
+			.post("${linkToLinkToGpgInformationPage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_LinkToOrganisationWebsite", "http://test-employer-information.com/gpg")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='review-and-submit']", "href").find.saveAs("linkToReviewAndSubmitPage")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val visitReviewAndSubmitPage = exec(http("Visit review and submit page")
+			.get("${linkToReviewAndSubmitPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Review your gender pay gap report")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val reviewAndSubmitReport = exec(http("Review and submit report")
+			.post("${linkToReviewAndSubmitPage}")
+			.headers(headers_0)
+			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.check(
+				status.is(200),
+				regex("You've reported your gender pay gap data"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
@@ -608,6 +711,14 @@ class RecordingSimulation extends Simulation {
 		ReportGenderPayGap.enterBonusPayDetails,
 		ReportGenderPayGap.visitEmployeesByPayQuarterPage,
 		ReportGenderPayGap.enterEmployeesByPayQuarterDetails,
+		ReportGenderPayGap.visitResponsiblePersonPage,
+		ReportGenderPayGap.enterResponsiblePersonDetails,
+		ReportGenderPayGap.visitOrganisationSizePage,
+		ReportGenderPayGap.enterOrganisationSizeDetails,
+		ReportGenderPayGap.visitLinkToGpgInformationPage,
+		ReportGenderPayGap.enterLinkToGpgInformationDetails,
+		ReportGenderPayGap.visitReviewAndSubmitPage,
+		ReportGenderPayGap.reviewAndSubmitReport,
 		ManageAccount.visit,
 		ManageAccount.visitChangeEmailAddressPage,
 		ManageAccount.changeEmailAddress,

--- a/LoadTests/src/test/scala/default/RecordingSimulation.scala
+++ b/LoadTests/src/test/scala/default/RecordingSimulation.scala
@@ -346,217 +346,110 @@ class RecordingSimulation extends Simulation {
 			.check(
 				status.is(200),
 				regex("Manage your organisation's reporting"),
-        regex("for ${organisationName}"),
+				regex("for ${organisationName}"),
 				css("a[loadtest-id='create-report-2020']", "href").find.saveAs("linkToTheLatestReport")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val visitEnterReport = exec(http("Visit report start page")
+		val visitReportOverviewPage = exec(http("Visit report overview page")
 			.get("${linkToTheLatestReport}")
 			.headers(headers_0)
 			.check(
 				regex("Report your gender pay gap"),
 				regex("for ${organisationName}"),
 				regex("for reporting year 2020-21"),
-				css("")
+				css("a[loadtest-id='hourly-pay']", "href").find.saveAs("linkToHourlyPayPage")
 			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterCalculation = exec(http("Enter calculation")
-			.post("/Submit/enter-calculations")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("FirstName", "")
-			.formParam("JobTitle", "")
-			.formParam("LastName", "")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "NotProvided")
-			.formParam("CompanyLinkToGPGInfo", "")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("DiffMeanHourlyPayPercent", "1")
-			.formParam("DiffMedianHourlyPercent", "1")
-			.formParam("MaleMedianBonusPayPercent", "1")
-			.formParam("FemaleMedianBonusPayPercent", "1")
-			.formParam("DiffMeanBonusPercent", "1")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("MaleUpperQuartilePayBand", "50")
-			.formParam("FemaleUpperQuartilePayBand", "50")
-			.formParam("MaleUpperPayBand", "50")
-			.formParam("FemaleUpperPayBand", "50")
-			.formParam("MaleMiddlePayBand", "50")
-			.formParam("FemaleMiddlePayBand", "50")
-			.formParam("MaleLowerPayBand", "50")
-			.formParam("FemaleLowerPayBand", "50")
-			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+		val visitHourlyPayPage = exec(http("Visit hourly pay page")
+			.get("${linkToHourlyPayPage}")
+			.headers(headers_0)
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Person responsible in your organisation")))
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Hourly pay")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterResponsiblePerson = exec(http("Enter responsible person")
-			.post("/Submit/person-responsible")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "NotProvided")
-			.formParam("CompanyLinkToGPGInfo", "")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
+		val enterHourlyPayDetails = exec(http("Enter hourly pay details")
+			.post("${linkToHourlyPayPage}")
+			.headers(headers_0)
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_DiffMeanHourlyPayPercent", "50")
+			.formParam("GovUk_Text_DiffMedianHourlyPercent", "50")
+			.formParam("Action", "SaveAndContinue")
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Size of your organisation")))
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='bonus-pay']", "href").find.saveAs("linkToBonusPayPage")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterSizeOfOrganisation = exec(http("Enter size of organisation")
-			.post("/Submit/organisation-size")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "2")
-			.formParam("CompanyLinkToGPGInfo", "")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
-			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+		val visitBonusPayPage = exec(http("Visit bonus pay page")
+			.get("${linkToBonusPayPage}")
+			.headers(headers_0)
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Link to your gender pay gap information")))
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Percentage of employees who received bonus pay"),
+				regex("Bonus pay")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val enterWebAddress = exec(http("Enter web address")
-			.post("/Submit/employer-website")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "Employees250To499")
-			.formParam("CompanyLinkToGPGInfo", "http://example.com/")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
+		val enterBonusPayDetails = exec(http("Enter bonus pay details")
+			.post("${linkToBonusPayPage}")
+			.headers(headers_0)
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
+			.formParam("GovUk_Text_FemaleBonusPayPercent", "50")
+			.formParam("GovUk_Text_MaleBonusPayPercent", "50")
+			.formParam("GovUk_Text_DiffMeanBonusPercent", "0")
+			.formParam("GovUk_Text_DiffMedianBonusPercent", "0")
+			.formParam("Action", "SaveAndContinue")
 			.check(
-				css("input[name='__RequestVerificationToken']", "value").saveAs("requestVerificationToken"),
-				css("input[name='OrganisationId']", "value").saveAs("organisationId"),
-				css("input[name='EncryptedOrganisationId']", "value").saveAs("encryptedOrganisationId"),
-				regex("Review your gender pay gap data")))
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 
-		val confirmGenderPayGapData = exec(http("Confirm gender pay gap data")
-			.post("/Submit/check-data")
-			.headers(headers_3)
-			.formParam("ReturnId", "0")
-			.formParam("OrganisationId", "${organisationId}")
-			.formParam("EncryptedOrganisationId", "${encryptedOrganisationId}")
-			.formParam("ShouldProvideLateReason", "False")
-			.formParam("ReportInfo.Draft", "GenderPayGap.BusinessLogic.Classes.Draft")
-			.formParam("ReportInfo.ReportModifiedDate", "")
-			.formParam("ReportInfo.ReportingStartDate", "05/04/2019 00:00:00")
-			.formParam("DiffMeanBonusPercent", "1.0")
-			.formParam("DiffMeanHourlyPayPercent", "1.0")
-			.formParam("DiffMedianBonusPercent", "")
-			.formParam("DiffMedianHourlyPercent", "1.0")
-			.formParam("FemaleLowerPayBand", "50.0")
-			.formParam("FemaleMedianBonusPayPercent", "1.0")
-			.formParam("FemaleMiddlePayBand", "50.0")
-			.formParam("FemaleUpperPayBand", "50.0")
-			.formParam("FemaleUpperQuartilePayBand", "50.0")
-			.formParam("MaleLowerPayBand", "50.0")
-			.formParam("MaleMedianBonusPayPercent", "1.0")
-			.formParam("MaleMiddlePayBand", "50.0")
-			.formParam("MaleUpperPayBand", "50.0")
-			.formParam("MaleUpperQuartilePayBand", "50.0")
-			.formParam("AccountingDate", "05/04/2019 00:00:00")
-			.formParam("SectorType", "Private")
-			.formParam("OrganisationSize", "Employees250To499")
-			.formParam("CompanyLinkToGPGInfo", "http://example.com/")
-			.formParam("EHRCResponse", "")
-			.formParam("LateReason", "")
-			.formParam("FirstName", "test")
-			.formParam("LastName", "test")
-			.formParam("JobTitle", "test")
+		val visitEmployeesByPayQuarterPage = exec(http("Visit employees by pay quarter page")
+			.get("${linkToEmployeesByPayQuarterPage}")
+			.headers(headers_0)
+			.check(
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				regex("Employees by pay quarter")
+			))
+			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
+
+		val enterEmployeesByPayQuarterDetails = exec(http("Enter employees by pay quarter details")
+			.post("${linkToEmployeesByPayQuarterPage}")
+			.headers(headers_0)
 			.formParam("__RequestVerificationToken", "${requestVerificationToken}")
-			.check(regex("You've submitted your gender pay gap data for 2019 to 2020")))
+			.formParam("GovUk_Text_MaleUpperPayBand", "50")
+			.formParam("GovUk_Text_FemaleUpperPayBand", "50")
+			.formParam("GovUk_Text_MaleUpperMiddlePayBand", "50")
+			.formParam("GovUk_Text_FemaleUpperMiddlePayBand", "50")
+			.formParam("GovUk_Text_MaleLowerMiddlePayBand", "50")
+			.formParam("GovUk_Text_FemaleLowerMiddlePayBand", "50")
+			.formParam("GovUk_Text_MaleLowerPayBand", "50")
+			.formParam("GovUk_Text_FemaleLowerPayBand", "50")
+			.formParam("Action", "SaveAndContinue")
+			.check(
+				status.is(200),
+				regex("Report your gender pay gap"),
+				regex("for ${organisationName}"),
+				regex("for reporting year 2020-21"),
+				css("a[loadtest-id='employees-by-pay-quarter']", "href").find.saveAs("linkToEmployeesByPayQuarterPage")
+			))
 			.pause(PAUSE_MIN_DUR, PAUSE_MAX_DUR)
 	}
 
@@ -708,12 +601,13 @@ class RecordingSimulation extends Simulation {
 		SelectExistingOrganisation.confirmOrganisationChoice,
 		ReportGenderPayGap.visitManageOrganisation,
 		ReportGenderPayGap.visitOrganisation,
-		ReportGenderPayGap.visitEnterReport,
-		ReportGenderPayGap.enterCalculation,
-		ReportGenderPayGap.enterResponsiblePerson,
-		ReportGenderPayGap.enterSizeOfOrganisation,
-		ReportGenderPayGap.enterWebAddress,
-		ReportGenderPayGap.confirmGenderPayGapData,
+		ReportGenderPayGap.visitReportOverviewPage,
+		ReportGenderPayGap.visitHourlyPayPage,
+		ReportGenderPayGap.enterHourlyPayDetails,
+		ReportGenderPayGap.visitBonusPayPage,
+		ReportGenderPayGap.enterBonusPayDetails,
+		ReportGenderPayGap.visitEmployeesByPayQuarterPage,
+		ReportGenderPayGap.enterEmployeesByPayQuarterDetails,
 		ManageAccount.visit,
 		ManageAccount.visitChangeEmailAddressPage,
 		ManageAccount.changeEmailAddress,


### PR DESCRIPTION
[GPG-606 JIRA Ticket](https://technologyprogramme.atlassian.net/browse/GPG-606)

The reporting journey has changed significantly over the past year - it used to be one long page, whereas now there is an overview page with 7 shorter form pages linked from it. This PR updates the load test code to follow the new reporting journey. Some minor changes have been made to `ReportOverview.cshtml` so elements can be selected and their hrefs saved in the load tests.

Testing: built project after changes with no errors, and ran load tests - all relevant requests pass, which means we're now at 99% passes!

Risk: very low

Documentation: clearly named new property `LoadTestId` on `TaskListItemViewModel`s so its function is clear for future maintenance