### PR TITLE
Gpg 556 open url redirection

### DIFF
--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotAllowHtmlDotRawTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotAllowHtmlDotRawTests.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
+using GenderPayGap.WebUI.Tests.TestHelpers;
 using NUnit.Framework;
 
 namespace GenderPayGap.WebUI.Tests.CodeQualityTests
@@ -27,7 +26,7 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
             };
 
             // Arrange
-            string rootCodeFolder = GetRootCodeFolder();
+            string rootCodeFolder = CodeQualityTestHelpers.GetRootCodeFolder();
 
             // Pre-Act Assert (to check we're running the test on the right folder)
             Assert.That(File.Exists($"{rootCodeFolder}\\GenderPayGap.sln"), $"We expect to find a file [GenderPayGap.sln] in the root folder [{rootCodeFolder}]");
@@ -46,7 +45,7 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
                 string filePath = fileInfo.FullName;
                 string filePathSuffix = filePath.Replace(rootCodeFolder, "");
 
-                if (FileIsExcluded(filePathSuffix, excludedFilesAndFolders))
+                if (CodeQualityTestHelpers.FileIsExcluded(filePathSuffix, excludedFilesAndFolders))
                 {
                     continue;
                 }
@@ -64,28 +63,5 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
                 Assert.Fail($"The following {failedFiles.Count} files contain a call to Html.Raw, which is not allowed:\n- {string.Join("\n- ", failedFiles)}\n");
             }
         }
-
-        private static string GetRootCodeFolder()
-        {
-            string compiledDllFilename = Assembly.GetExecutingAssembly().Location;
-            Console.WriteLine($"compiledDllFilename is [{compiledDllFilename}]");
-            string compiledDllDirectory = new FileInfo(compiledDllFilename).Directory.FullName;
-
-            string rootCodeFolder = new DirectoryInfo($"{compiledDllDirectory}\\..\\..\\..\\..\\..\\").FullName;
-            return rootCodeFolder;
-        }
-
-        private static bool FileIsExcluded(string filePathSuffix, List<string> excludedFilesAndFolders)
-        {
-            foreach (string excludedFilePath in excludedFilesAndFolders)
-            {
-                if (filePathSuffix.StartsWith(excludedFilePath))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
     }
 }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotUseRedirectWithReturnUrls.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotUseRedirectWithReturnUrls.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
+using GenderPayGap.WebUI.Tests.TestHelpers;
 using NUnit.Framework;
 
 namespace GenderPayGap.WebUI.Tests.CodeQualityTests
@@ -22,7 +21,7 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
             };
 
             // Arrange
-            string rootCodeFolder = GetRootCodeFolder();
+            string rootCodeFolder = CodeQualityTestHelpers.GetRootCodeFolder();
 
             // Pre-Act Assert (to check we're running the test on the right folder)
             Assert.That(File.Exists($"{rootCodeFolder}\\GenderPayGap.sln"), $"We expect to find a file [GenderPayGap.sln] in the root folder [{rootCodeFolder}]");
@@ -41,7 +40,7 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
                 string filePath = fileInfo.FullName;
                 string filePathSuffix = filePath.Replace(rootCodeFolder, "");
 
-                if (FileIsExcluded(filePathSuffix, excludedFilesAndFolders))
+                if (CodeQualityTestHelpers.FileIsExcluded(filePathSuffix, excludedFilesAndFolders))
                 {
                     continue;
                 }
@@ -60,28 +59,6 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
             {
                 Assert.Fail($"The following {failedFiles.Count} files contain a call to Redirect with a return url, which is not allowed:\n- {string.Join("\n- ", failedFiles)}\n");
             }
-        }
-
-        private static string GetRootCodeFolder()
-        {
-            string compiledDllFilename = Assembly.GetExecutingAssembly().Location;
-            Console.WriteLine($"compiledDllFilename is [{compiledDllFilename}]");
-            string compiledDllDirectory = new FileInfo(compiledDllFilename).Directory.FullName;
-
-            string rootCodeFolder = new DirectoryInfo($"{compiledDllDirectory}\\..\\..\\..\\..\\..\\").FullName;
-            return rootCodeFolder;
-        }
-
-        private static bool FileIsExcluded(string filePathSuffix, List<string> excludedFilesAndFolders)
-        {
-            foreach (string excludedFilePath in excludedFilesAndFolders)
-            {
-                if (filePathSuffix.StartsWith(excludedFilePath))
-                {
-                    return true;
-                }
-            }
-            return false;
         }
     }
 }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotUseRedirectWithReturnUrls.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotUseRedirectWithReturnUrls.cs
@@ -51,7 +51,7 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
                 var lines = File.ReadAllLines(filePath);
                 for (var i = 0; i<lines.Length; i++)
                 {
-                    if (Regex.IsMatch(lines[i], @"(new){0,1}\s+Redirect(Result){0,1}\s*\(\S+\)") && !lines[i-1].Contains("//disable:DoNotUseRedirectWithReturnUrls"))
+                    if (Regex.IsMatch(lines[i], @"(new)?\s+Redirect(Result)?\s*\(\S+\)") && !lines[i-1].Contains("//disable:DoNotUseRedirectWithReturnUrls"))
                     {
                         failedFiles.Add(filePathSuffix);
                     }
@@ -61,7 +61,9 @@ namespace GenderPayGap.WebUI.Tests.CodeQualityTests
             // Assert
             if (failedFiles.Any())
             {
-                Assert.Fail($"The following {failedFiles.Count} files contain a Redirect.\nIf this is to a local url LocalRedirect should be used, otherwise the redirect can be marked to be ignored by this test by adding the \n'//disable:DoNotUseRedirectWithReturnUrls' comment on the preceding line:\n- {string.Join("\n- ", failedFiles.Distinct())}\n");
+                Assert.Fail($"The following {failedFiles.Count} files contain a Redirect.\nIf this is to a local url LocalRedirect should be used, " + 
+                            @"otherwise the redirect can be marked to be ignored by this test by adding the \n'//disable:DoNotUseRedirectWithReturnUrls' " + 
+                            $"comment on the preceding line:\n- {string.Join("\n- ", failedFiles.Distinct())}\n");
             }
         }
     }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotUseRedirectWithReturnUrls.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CodeQualityTests/DoNotUseRedirectWithReturnUrls.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace GenderPayGap.WebUI.Tests.CodeQualityTests
+{
+    [TestFixture]
+    public class DoNotUseRedirectWithReturnUrls
+    {
+
+        [Test]
+        public void DoNotAllowRedirectWithReturnUrlInCode()
+        {
+            var excludedFilesAndFolders = new List<string>
+            {
+                @"GenderPayGap.UnitTests\GenderPayGap.WebUI.Tests\CodeQualityTests\DoNotUseRedirectWithReturnUrls.cs", // This file!
+                @"GenderPayGap.WebUI\bin", // Output folder
+                @"GenderPayGap.WebUI\obj" // Output folder
+            };
+
+            // Arrange
+            string rootCodeFolder = GetRootCodeFolder();
+
+            // Pre-Act Assert (to check we're running the test on the right folder)
+            Assert.That(File.Exists($"{rootCodeFolder}\\GenderPayGap.sln"), $"We expect to find a file [GenderPayGap.sln] in the root folder [{rootCodeFolder}]");
+
+            // More Arrange
+            string searchPattern = "*.cs*" /* We want to find .cs and .cshtml files */;
+            FileInfo[] files = new DirectoryInfo(rootCodeFolder).GetFiles(searchPattern, SearchOption.AllDirectories);
+
+            // Pre-Act Assert (to check again that we're running the test on the right folder)
+            Assert.Greater(files.Length, 1000, "We expect there to be >1000 .cs/.cshtml files");
+
+            // Act
+            var failedFiles = new List<string>();
+            foreach (FileInfo fileInfo in files)
+            {
+                string filePath = fileInfo.FullName;
+                string filePathSuffix = filePath.Replace(rootCodeFolder, "");
+
+                if (FileIsExcluded(filePathSuffix, excludedFilesAndFolders))
+                {
+                    continue;
+                }
+
+                string fileText = File.ReadAllText(filePath);
+                // There are a couple of actions on controllers Redirect() that wrap a RedirectToAction,
+                // we want to exclude these from the check as we are only concerned about redirecting with a url parameter
+                if (fileText.Contains(" Redirect(") && !fileText.Contains(" Redirect()"))
+                {
+                    failedFiles.Add(filePathSuffix);
+                }
+            }
+
+            // Assert
+            if (failedFiles.Any())
+            {
+                Assert.Fail($"The following {failedFiles.Count} files contain a call to Redirect with a return url, which is not allowed:\n- {string.Join("\n- ", failedFiles)}\n");
+            }
+        }
+
+        private static string GetRootCodeFolder()
+        {
+            string compiledDllFilename = Assembly.GetExecutingAssembly().Location;
+            Console.WriteLine($"compiledDllFilename is [{compiledDllFilename}]");
+            string compiledDllDirectory = new FileInfo(compiledDllFilename).Directory.FullName;
+
+            string rootCodeFolder = new DirectoryInfo($"{compiledDllDirectory}\\..\\..\\..\\..\\..\\").FullName;
+            return rootCodeFolder;
+        }
+
+        private static bool FileIsExcluded(string filePathSuffix, List<string> excludedFilesAndFolders)
+        {
+            foreach (string excludedFilePath in excludedFilesAndFolders)
+            {
+                if (filePathSuffix.StartsWith(excludedFilePath))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/CompareControllerTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/CompareControllerTests.cs
@@ -163,7 +163,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             };
 
             // Act
-            var result = controller.AddEmployer(employerIdentifier, returnUrl) as RedirectResult;
+            var result = controller.AddEmployer(employerIdentifier, returnUrl) as LocalRedirectResult;
 
             // Assert
             Assert.NotNull(result);
@@ -486,7 +486,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             controller.CompareViewService.AddToBasket(employerIdentifier);
 
             // Act
-            var result = controller.RemoveEmployer(employerIdentifier, returnUrl) as RedirectResult;
+            var result = controller.RemoveEmployer(employerIdentifier, returnUrl) as LocalRedirectResult;
 
             // Assert
             Assert.NotNull(result);
@@ -691,7 +691,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             controller.CompareViewService.AddToBasket(organisationId);
 
             // Act
-            var result = controller.ClearEmployers(returnUrl) as RedirectResult;
+            var result = controller.ClearEmployers(returnUrl) as LocalRedirectResult;
 
             // Assert
             Assert.NotNull(result);
@@ -750,7 +750,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             string returnUrl = @"\viewing\search-results";
 
             // Act
-            var result = controller.SortEmployers(column, returnUrl) as RedirectResult;
+            var result = controller.SortEmployers(column, returnUrl) as LocalRedirectResult;
 
             // Assert
             //Test the google analytics tracker was executed once on the controller
@@ -774,7 +774,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             controller.CompareViewService.SortAscending = true;
 
             // Act
-            var result = controller.SortEmployers(column, returnUrl) as RedirectResult;
+            var result = controller.SortEmployers(column, returnUrl) as LocalRedirectResult;
 
             // Assert
             Assert.NotNull(result);
@@ -795,7 +795,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             controller.CompareViewService.SortAscending = false;
 
             // Act
-            var result = controller.SortEmployers(column, returnUrl) as RedirectResult;
+            var result = controller.SortEmployers(column, returnUrl) as LocalRedirectResult;
 
             // Assert
             //Test the google analytics tracker was executed once on the controller

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/TestHelpers/CodeQualityTestHelpers.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/TestHelpers/CodeQualityTestHelpers.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace GenderPayGap.WebUI.Tests.TestHelpers
+{
+    public static class CodeQualityTestHelpers
+    {
+        public static string GetRootCodeFolder()
+        {
+            string compiledDllFilename = Assembly.GetExecutingAssembly().Location;
+            Console.WriteLine($"compiledDllFilename is [{compiledDllFilename}]");
+            string compiledDllDirectory = new FileInfo(compiledDllFilename).Directory.FullName;
+
+            string rootCodeFolder = new DirectoryInfo($"{compiledDllDirectory}\\..\\..\\..\\..\\..\\").FullName;
+            return rootCodeFolder;
+        }
+
+        public static bool FileIsExcluded(string filePathSuffix, List<string> excludedFilesAndFolders)
+        {
+            foreach (string excludedFilePath in excludedFilesAndFolders)
+            {
+                if (filePathSuffix.StartsWith(excludedFilePath))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/GenderPayGap.WebUI/Controllers/CompareController.cs
+++ b/GenderPayGap.WebUI/Controllers/CompareController.cs
@@ -63,7 +63,7 @@ namespace GenderPayGap.WebUI.Controllers
             CompareViewService.SaveComparedEmployersToCookie(Request);
 
             //Redirect the user to the original page
-            return Redirect(returnUrl);
+            return LocalRedirect(returnUrl);
         }
 
         [HttpGet("add-employer-js/{employerIdentifier}")]
@@ -131,7 +131,7 @@ namespace GenderPayGap.WebUI.Controllers
             //Save the compared employers to the cookie
             CompareViewService.SaveComparedEmployersToCookie(Request);
 
-            return Redirect(returnUrl);
+            return LocalRedirect(returnUrl);
         }
 
         [HttpGet("remove-employer-js/{employerIdentifier}")]
@@ -190,7 +190,7 @@ namespace GenderPayGap.WebUI.Controllers
             //Save the compared employers to the cookie
             CompareViewService.SaveComparedEmployersToCookie(Request);
 
-            return Redirect(returnUrl);
+            return LocalRedirect(returnUrl);
         }
 
         [HttpGet("sort-employers/{column}")]
@@ -227,7 +227,7 @@ namespace GenderPayGap.WebUI.Controllers
                 CompareViewService.SortColumn = column;
             }
 
-            return Redirect(returnUrl);
+            return LocalRedirect(returnUrl);
         }
 
         [HttpGet("~/compare-employers/{year:int=0}")]

--- a/GenderPayGap.WebUI/Controllers/GoController.cs
+++ b/GenderPayGap.WebUI/Controllers/GoController.cs
@@ -18,28 +18,32 @@ namespace GenderPayGap.WebUI.Controllers
         public IActionResult Register()
         {
             webTracker.TrackPageView(this);
-            return new RedirectResult("https://www.gov.uk/report-gender-pay-gap-data");
+            //disable:DoNotUseRedirectWithReturnUrls
+            return Redirect("https://www.gov.uk/report-gender-pay-gap-data");
         }
 
         [HttpGet("guidance")]
         public IActionResult Guidance()
         {
             webTracker.TrackPageView(this);
-            return new RedirectResult("https://www.gov.uk/guidance/gender-pay-gap-who-needs-to-report");
+            //disable:DoNotUseRedirectWithReturnUrls
+            return Redirect("https://www.gov.uk/guidance/gender-pay-gap-who-needs-to-report");
         }
 
         [HttpGet("report")]
         public IActionResult Report()
         {
             webTracker.TrackPageView(this);
-            return new RedirectResult("https://www.gov.uk/report-gender-pay-gap-data");
+            //disable:DoNotUseRedirectWithReturnUrls
+            return Redirect("https://www.gov.uk/report-gender-pay-gap-data");
         }
 
         [HttpGet("actions")]
         public IActionResult Actions()
         {
             webTracker.TrackPageView(this);
-            return new RedirectResult("https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/664017/Gender_pay_gap_-_actions_for_employers.pdf");
+            //disable:DoNotUseRedirectWithReturnUrls
+            return Redirect("https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/664017/Gender_pay_gap_-_actions_for_employers.pdf");
         }
 
     }

--- a/GenderPayGap.WebUI/Controllers/Login/LoginController.cs
+++ b/GenderPayGap.WebUI/Controllers/Login/LoginController.cs
@@ -7,6 +7,7 @@ using GenderPayGap.WebUI.Models.Login;
 using GovUkDesignSystem;
 using GovUkDesignSystem.Parsers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 namespace GenderPayGap.WebUI.Controllers.Login
 {
@@ -75,7 +76,7 @@ namespace GenderPayGap.WebUI.Controllers.Login
 
             if (ReturnUrlIsAllowed(viewModel.ReturnUrl))
             {
-                return Redirect(viewModel.ReturnUrl);
+                return new RedirectResult(viewModel.ReturnUrl);
             }
             else if (user.IsAdministrator())
             {
@@ -109,7 +110,7 @@ namespace GenderPayGap.WebUI.Controllers.Login
             IActionResult suggestedResult;
             if (ReturnUrlIsAllowed(redirectUrl))
             {
-                suggestedResult = Redirect(redirectUrl);
+                suggestedResult = new RedirectResult(redirectUrl);
             }
             else
             {

--- a/GenderPayGap.WebUI/Controllers/Login/LoginController.cs
+++ b/GenderPayGap.WebUI/Controllers/Login/LoginController.cs
@@ -75,6 +75,8 @@ namespace GenderPayGap.WebUI.Controllers.Login
 
             if (ReturnUrlIsAllowed(viewModel.ReturnUrl))
             {
+                // Above condition prevents invalid return urls
+                //disable:DoNotUseRedirectWithReturnUrls
                 return Redirect(viewModel.ReturnUrl);
             }
             else if (user.IsAdministrator())
@@ -109,6 +111,8 @@ namespace GenderPayGap.WebUI.Controllers.Login
             IActionResult suggestedResult;
             if (ReturnUrlIsAllowed(redirectUrl))
             {
+                // Above condition prevents invalid return urls
+                //disable:DoNotUseRedirectWithReturnUrls
                 suggestedResult = Redirect(redirectUrl);
             }
             else

--- a/GenderPayGap.WebUI/Controllers/Login/LoginController.cs
+++ b/GenderPayGap.WebUI/Controllers/Login/LoginController.cs
@@ -7,7 +7,6 @@ using GenderPayGap.WebUI.Models.Login;
 using GovUkDesignSystem;
 using GovUkDesignSystem.Parsers;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 
 namespace GenderPayGap.WebUI.Controllers.Login
 {
@@ -76,7 +75,7 @@ namespace GenderPayGap.WebUI.Controllers.Login
 
             if (ReturnUrlIsAllowed(viewModel.ReturnUrl))
             {
-                return new RedirectResult(viewModel.ReturnUrl);
+                return Redirect(viewModel.ReturnUrl);
             }
             else if (user.IsAdministrator())
             {
@@ -110,7 +109,7 @@ namespace GenderPayGap.WebUI.Controllers.Login
             IActionResult suggestedResult;
             if (ReturnUrlIsAllowed(redirectUrl))
             {
-                suggestedResult = new RedirectResult(redirectUrl);
+                suggestedResult = Redirect(redirectUrl);
             }
             else
             {

--- a/GenderPayGap.WebUI/Controllers/Report/ReportCompleteFinishAndSignOutController.cs
+++ b/GenderPayGap.WebUI/Controllers/Report/ReportCompleteFinishAndSignOutController.cs
@@ -19,7 +19,7 @@ namespace GenderPayGap.WebUI.Controllers.Report
                 ?? // Or, if we don't have a "done URL", take them to the homepage
                 Url.Action("Index", "Viewing", null, "https");
 
-            IActionResult suggestedResult = new RedirectResult(nextPageUrl);
+            IActionResult suggestedResult = Redirect(nextPageUrl);
 
             return LoginHelper.Logout(HttpContext, suggestedResult);
         }

--- a/GenderPayGap.WebUI/Controllers/Report/ReportCompleteFinishAndSignOutController.cs
+++ b/GenderPayGap.WebUI/Controllers/Report/ReportCompleteFinishAndSignOutController.cs
@@ -19,6 +19,8 @@ namespace GenderPayGap.WebUI.Controllers.Report
                 ?? // Or, if we don't have a "done URL", take them to the homepage
                 Url.Action("Index", "Viewing", null, "https");
 
+            // Global.Done url is not local
+            //disable:DoNotUseRedirectWithReturnUrls
             IActionResult suggestedResult = Redirect(nextPageUrl);
 
             return LoginHelper.Logout(HttpContext, suggestedResult);

--- a/GenderPayGap.WebUI/Controllers/Report/ReportCompleteFinishAndSignOutController.cs
+++ b/GenderPayGap.WebUI/Controllers/Report/ReportCompleteFinishAndSignOutController.cs
@@ -19,7 +19,7 @@ namespace GenderPayGap.WebUI.Controllers.Report
                 ?? // Or, if we don't have a "done URL", take them to the homepage
                 Url.Action("Index", "Viewing", null, "https");
 
-            IActionResult suggestedResult = Redirect(nextPageUrl);
+            IActionResult suggestedResult = new RedirectResult(nextPageUrl);
 
             return LoginHelper.Logout(HttpContext, suggestedResult);
         }

--- a/GenderPayGap.WebUI/Controllers/SubmitController.DraftComplete.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.DraftComplete.cs
@@ -47,7 +47,7 @@ namespace GenderPayGap.WebUI.Controllers.Submission
         {
             string doneUrl = Global.DoneUrl ?? Url.Action("Index", "Viewing", null, "https");
 
-            return new RedirectResult(doneUrl);
+            return Redirect(doneUrl);
         }
 
         #endregion

--- a/GenderPayGap.WebUI/Controllers/SubmitController.DraftComplete.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.DraftComplete.cs
@@ -47,7 +47,7 @@ namespace GenderPayGap.WebUI.Controllers.Submission
         {
             string doneUrl = Global.DoneUrl ?? Url.Action("Index", "Viewing", null, "https");
 
-            return Redirect(doneUrl);
+            return new RedirectResult(doneUrl);
         }
 
         #endregion

--- a/GenderPayGap.WebUI/Controllers/SubmitController.DraftComplete.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.DraftComplete.cs
@@ -47,6 +47,8 @@ namespace GenderPayGap.WebUI.Controllers.Submission
         {
             string doneUrl = Global.DoneUrl ?? Url.Action("Index", "Viewing", null, "https");
 
+            // Global.Done url is not local
+            //disable:DoNotUseRedirectWithReturnUrls
             return Redirect(doneUrl);
         }
 

--- a/GenderPayGap.WebUI/Controllers/SubmitController.SubmissionComplete.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.SubmissionComplete.cs
@@ -48,6 +48,9 @@ namespace GenderPayGap.WebUI.Controllers.Submission
         public IActionResult SubmissionCompletePost(string command)
         {
             string doneUrl = Global.DoneUrl ?? Url.Action("Index", "Viewing", null, "https");
+
+            // Global.Done url is not local
+            //disable:DoNotUseRedirectWithReturnUrls
             IActionResult suggestedResult = Redirect(doneUrl);
 
             return LoginHelper.Logout(HttpContext, suggestedResult);

--- a/GenderPayGap.WebUI/Controllers/SubmitController.SubmissionComplete.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.SubmissionComplete.cs
@@ -48,7 +48,7 @@ namespace GenderPayGap.WebUI.Controllers.Submission
         public IActionResult SubmissionCompletePost(string command)
         {
             string doneUrl = Global.DoneUrl ?? Url.Action("Index", "Viewing", null, "https");
-            IActionResult suggestedResult = Redirect(doneUrl);
+            IActionResult suggestedResult = new RedirectResult(doneUrl);
 
             return LoginHelper.Logout(HttpContext, suggestedResult);
         }

--- a/GenderPayGap.WebUI/Controllers/SubmitController.SubmissionComplete.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.SubmissionComplete.cs
@@ -48,7 +48,7 @@ namespace GenderPayGap.WebUI.Controllers.Submission
         public IActionResult SubmissionCompletePost(string command)
         {
             string doneUrl = Global.DoneUrl ?? Url.Action("Index", "Viewing", null, "https");
-            IActionResult suggestedResult = new RedirectResult(doneUrl);
+            IActionResult suggestedResult = Redirect(doneUrl);
 
             return LoginHelper.Logout(HttpContext, suggestedResult);
         }


### PR DESCRIPTION
Updated calls that were Redirect(returnUrl) to LocalRedirect(returnUrl) and the corresponding unit tests.

return Redirect(url) and return new RedirectResult(url) look to be equivalent, so I've changed those using Redirect to return a RedirectResult to simplify the new unit test I've added that searches for instances of ' Redirect(' in the code (similarly to the Html.Raw one). This probably reduces code consistency overall, as we seem to mostly be using Controller methods in returns rather than returning new ActionResult objects, but they are all consistent with each other now i.e. all non-local Redirects are using return new RedirectResult. I did it this way as it makes the condition we are looking for in the new unit test simpler.