### PR TITLE
GPG-573 Change password reset code to Crypto string

### DIFF
--- a/GenderPayGap.Core/Extensions/Crypto.cs
+++ b/GenderPayGap.Core/Extensions/Crypto.cs
@@ -48,7 +48,7 @@ namespace GenderPayGap.Extensions
 
         public static string GeneratePasscode(char[] charset, int passcodeLength)
         {
-            //Ensure characters are distict and mixed up
+            //Ensure characters are distinct and mixed up
             charset = charset.Distinct().ToList().Randomise().ToArray();
 
             var chars = new char[passcodeLength];
@@ -60,7 +60,7 @@ namespace GenderPayGap.Extensions
                 generator.GetBytes(randomData);
             }
 
-            //use the randome number to pick from the character set
+            //use the random number to pick from the character set
             for (int i = 0; i < chars.Length; i++)
             {
                 chars[i] = charset[randomData[i] % charset.Length];

--- a/GenderPayGap.WebUI/Controllers/Account/PasswordResetController.cs
+++ b/GenderPayGap.WebUI/Controllers/Account/PasswordResetController.cs
@@ -95,11 +95,11 @@ namespace GenderPayGap.WebUI.Controllers.Account
                    && (VirtualDateTime.Now - userForPasswordReset.ResetSendDate.Value).TotalMinutes < Global.MinPasswordResetMinutes;
         }
 
-        // Generates and stores a GUID to act as a password reset code
+        // Generates and stores a string to act as a password reset code
         private void SendPasswordResetEmail(User userForPasswordReset)
         {
-            // Generate a random GUID as a unique identifier for the password reset
-            string resetCode = Guid.NewGuid().ToString("N");
+            // Generate a random string as a unique identifier for the password reset
+            string resetCode = Convert.ToBase64String(Crypto.GetSalt());
 
             // Store the reset code on the user entity for verification
             userForPasswordReset.PasswordResetCode = resetCode;


### PR DESCRIPTION
Changed the SendPasswordResetEmail method to use the Crypto.GetSalt method to produce a base64 string instead of Guid.NewGuid. 