### PR TITLE
GPG-581 Add middleware to add no-cache to headers

### DIFF
--- a/GenderPayGap.WebUI/Helpers/NoCacheMiddleware.cs
+++ b/GenderPayGap.WebUI/Helpers/NoCacheMiddleware.cs
@@ -3,6 +3,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace GenderPayGap.WebUI.Helpers
 {
+    /// <summary>
+    /// Adds the Cache-Control no-store header to all responses to prevent caching in browsers
+    /// GPG-581 We don't want to be caching html content as it may include secure info.
+    /// Assets like css, js, images are still fine to cache
+    /// </summary>
     public class NoCacheMiddleware
     {
         private readonly RequestDelegate _next;
@@ -17,7 +22,7 @@ namespace GenderPayGap.WebUI.Helpers
             httpContext.Response.OnStarting(
                 () =>
                 {
-                    httpContext.Response.Headers["Cache-Control"] = "no-cache";
+                    httpContext.Response.Headers["Cache-Control"] = "no-store";
                     return Task.CompletedTask;
                 });
 

--- a/GenderPayGap.WebUI/Helpers/NoCacheMiddleware.cs
+++ b/GenderPayGap.WebUI/Helpers/NoCacheMiddleware.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace GenderPayGap.WebUI.Helpers
+{
+    public class NoCacheMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public NoCacheMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext httpContext)
+        {
+            httpContext.Response.OnStarting(
+                () =>
+                {
+                    httpContext.Response.Headers["Cache-Control"] = "no-cache";
+                    return Task.CompletedTask;
+                });
+
+            return this._next(httpContext);
+        }
+    }
+}

--- a/GenderPayGap.WebUI/Helpers/NoHtmlCachingMiddleware.cs
+++ b/GenderPayGap.WebUI/Helpers/NoHtmlCachingMiddleware.cs
@@ -8,11 +8,11 @@ namespace GenderPayGap.WebUI.Helpers
     /// GPG-581 We don't want to be caching html content as it may include secure info.
     /// Assets like css, js, images are still fine to cache
     /// </summary>
-    public class NoCacheMiddleware
+    public class NoHtmlCachingMiddleware
     {
         private readonly RequestDelegate _next;
 
-        public NoCacheMiddleware(RequestDelegate next)
+        public NoHtmlCachingMiddleware(RequestDelegate next)
         {
             _next = next;
         }

--- a/GenderPayGap.WebUI/Startup.cs
+++ b/GenderPayGap.WebUI/Startup.cs
@@ -373,7 +373,8 @@ namespace GenderPayGap.WebUI
                 app.UseMiddleware<BasicAuthMiddleware>();
             }
 
-            app.UseMiddleware<NoCacheMiddleware>();
+            // Prevent caching of html responses as they may contain secure info - GPG-581
+            app.UseMiddleware<NoHtmlCachingMiddleware>();
 
             app.UseEndpoints(endpoints =>
             {

--- a/GenderPayGap.WebUI/Startup.cs
+++ b/GenderPayGap.WebUI/Startup.cs
@@ -373,6 +373,8 @@ namespace GenderPayGap.WebUI
                 app.UseMiddleware<BasicAuthMiddleware>();
             }
 
+            app.UseMiddleware<NoCacheMiddleware>();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();


### PR DESCRIPTION
Added middleware to set the Cache-Control header to no-cache for all pages. Css etc. still appear to be cached fine locally after this change. If we decide that we don't want to have the no-cache header for everything, this will probably have to be done differently, probably via ResponseCacheAttributes on the relevant controllers.