### PR TITLE
GPG-616 Change the Manage Account/Organisation aria roles to tabs

### DIFF
--- a/GenderPayGap.WebUI/Views/Components/Navigation/AccountTabs.cshtml
+++ b/GenderPayGap.WebUI/Views/Components/Navigation/AccountTabs.cshtml
@@ -10,13 +10,13 @@
     <div class="govuk-grid-column-full">
 
         <nav class="account-tabs">
-            <ul>
+            <ul role="tablist">
                 @foreach (var navItem in navEntries)
                 {
                     bool isCurrentPage = (navItem.UrlPath == Context.Request.Path.Value);
 
-                    <li class="@(isCurrentPage ? "account-tab--selected" : null)">
-                        <a href="@(navItem.UrlPath)"
+                    <li role="presentation" class="@(isCurrentPage ? "account-tab--selected" : null)">
+                        <a role="tab" href="@(navItem.UrlPath)"
                            class="govuk-link govuk-link--no-visited-state">
                             @(navItem.Text)
                         </a>


### PR DESCRIPTION
This seems to be the correct setup for tabs after playing around with roles/labels in different places and a bit of googling. The presentation role to hide the list items from the reader and declaring the links as tabs.