### PR TITLE
GPG-624 Fix nullable object access error  in ViewOrganisation view

### DIFF
--- a/GenderPayGap.WebUI/Views/Admin/ViewOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/Admin/ViewOrganisation.cshtml
@@ -297,7 +297,7 @@ else
                 {
                     userStatus = "AWAITING_PIN";
                 }
-                else if (userOrganisation.IsAwaitingActivationPIN())
+                else if (userOrganisation.IsAwaitingRegistrationApproval())
                 {
                     userStatus = "AWAITING_APPROVAL";
                 }


### PR DESCRIPTION
Turns out it was that incorrect 'else if' statement I noticed on Friday that was causing an error when calling .Value on a nullable date since there is no PINConfirmedDate while the user is still pending