### PR TITLE
GPG-629 Correct date on Action to close the gap page

### DIFF
--- a/GenderPayGap.WebUI/Views/ActionHub/Sections/Header.cshtml
+++ b/GenderPayGap.WebUI/Views/ActionHub/Sections/Header.cshtml
@@ -13,7 +13,7 @@
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-2">
         <div class="govuk-!-margin-bottom-6">
             <p class="govuk-body-s govuk-!-margin-bottom-0">
-                Published 1 December 2020
+                Published 1 December 2017
             </p>
 
             <p class="govuk-body-s govuk-!-margin-bottom-0">


### PR DESCRIPTION
Noticed an incorrect date when checking over GPG-629 on dev