### PR TITLE
GPG-637 Updates text "organisations" to "employers" in Notify email personalisation

### DIFF
--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/SendReminderEmailsJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/SendReminderEmailsJob.cs
@@ -176,7 +176,7 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
                 return $"{organisations[0].OrganisationName} and {organisations[1].OrganisationName}";
             }
 
-            return $"{organisations[0].OrganisationName} and {organisations.Count - 1} other organisations";
+            return $"{organisations[0].OrganisationName} and {organisations.Count - 1} other employers";
         }
 
         private bool IsAfterEarliestReminder(SectorTypes sectorType)


### PR DESCRIPTION
[GPG-637 JIRA Ticket](https://technologyprogramme.atlassian.net/browse/GPG-637)

The reminder email Notify template uses a personalisation element called `OrganisationNames`, which is set in the code. There are 3 possible structures for this personalisation:

If there is only one Organisation:
- `OrganisationName`

If there are 2 Organisations:
- `OrganisationName1` and `OrganisationName2`

If there are n (where n > 2) Organisations:
- `OrganisationName1` and n-1 other organisations

Since we are now referring to "organisations" as "employers", this PR just updates the 3rd scenario to use consistent terminology.

**Testing:** updated notify email and used test functionality to send check email to testing gmail account.
**Risk:** reminder emails are only sent within the month before the deadline, so changing this now poses no risk - users shouldn't receive inconsistent emails since they won't receive any at all!
**Documentation:** none needed