### PR TITLE
GPG-603 Updates command used to set environment variables

### DIFF
--- a/SetEnvironmentVariablesInGovPaaS/Program.cs
+++ b/SetEnvironmentVariablesInGovPaaS/Program.cs
@@ -119,7 +119,7 @@ namespace SetEnvironmentVariablesInGovPaaS
 
         private static void SetPaasEnvironmentVariable(string appName, string variableName, string variableValue)
         {
-            CommandLineHelper.RunCommandAndPrintOutputToConsole("cf", $"v3-set-env {appName} \"{variableName}\" \"{variableValue}\"");
+            CommandLineHelper.RunCommandAndPrintOutputToConsole("cf", $"set-env {appName} \"{variableName}\" \"{variableValue}\"");
         }
 
     }

--- a/SetEnvironmentVariablesInGovPaaS/Program.cs
+++ b/SetEnvironmentVariablesInGovPaaS/Program.cs
@@ -46,7 +46,7 @@ namespace SetEnvironmentVariablesInGovPaaS
 
         private static List<string> GetAllCurrentPaasEnvironmentVariables(string appName)
         {
-            List<string> commandOutput = CommandLineHelper.RunCommandAndGetOutput("cf", $"v3-env {appName}");
+            List<string> commandOutput = CommandLineHelper.RunCommandAndGetOutput("cf", $"env {appName}");
 
             var possiblePaasEnvironmentVariables = new List<string>();
 
@@ -67,7 +67,7 @@ namespace SetEnvironmentVariablesInGovPaaS
 
         private static void UnsetPaasEnvironmentVariable(string appName, string variableName)
         {
-            CommandLineHelper.RunCommandAndPrintOutputToConsole("cf", $"v3-unset-env {appName} {variableName}");
+            CommandLineHelper.RunCommandAndPrintOutputToConsole("cf", $"unset-env {appName} {variableName}");
         }
 
         private static void SetNewPaasEnvironmentVaribales(string appName)


### PR DESCRIPTION
After creating the new load testing environment and deploying to it, I noticed that the environment variables from the Azure pipelines don't appear to be being set on PaaS. It's not caused any problems recently because we haven't updated any of them, and they were already set on all the existing environments so the apps functioned as normal.

Since the new load test environment didn't have existing values of these environment variables, they weren't set at all and hence the app failed to connect to the database - the lack of the `ASPNETCORE_ENVIRONMENT` variable meant that the app didn't use TLS for the connection, assuming it was to a local db. After manually fixing that and successfully deploying, other elements of the app failed to work where an environment variable had not been provided.

The Program.cs file sets these environment variables, but the `v3-env`, `v3-set-env` and `v3-unset-env` commands used in this file are deprecated in CF7. I've updated the file to use the corresponding CF7 commands, which I imagine will fix the problem.

**Testing:** Once merged, I will test this by deploying to the gpg-loadtest environment and seeing whether sections of the app which rely on the environment variables (e.g. EmailSendingService) function as expected
**Risk:** Some risk of this breaking the setting of environment variables in deployment, but this can be easily identified and the changes can be rolled back if necessary
**Documentation:** @Binney suggested adding this as a common error in the Postgres setup of the [alphagov/paas-tech-docs](https://github.com/alphagov/paas-tech-docs) repo - will do this once PR is merged and fully tested on our load test environment