### PR TITLE
GPG-646 filters bug

### DIFF
--- a/Documentation/Accounts you will need to develop the service.md
+++ b/Documentation/Accounts you will need to develop the service.md
@@ -7,6 +7,8 @@ The code:
 * Write access to this GitHub repository  
   Normally granted by adding you to the
   [Gender Pay Gap GitHub team](https://github.com/orgs/cabinetoffice/teams/gender-pay-gap)
+* Zoho
+  All the secrets are stored in Zoho in the GPG chamber
 
 Services that the Gender Pay Gap service depends on:
 * [Gov.UK Notify](https://www.notifications.service.gov.uk/)  

--- a/Documentation/Getting the code running.md
+++ b/Documentation/Getting the code running.md
@@ -67,6 +67,7 @@ Populate the database:
   * Fill in the form:
     * Hostname of remote server: `gender-pay-gap-dev.london.cloudapps.digital` (without https://)
     * Passwords: ask an existing developer for these
+    * The database migration password is stored in `appsettings.secrets.json`
   * Click the scary red button
   * Wait for a few minutes whilst the data is imported
   * The database should now be fully populated and ready to use

--- a/Documentation/Software to install.md
+++ b/Documentation/Software to install.md
@@ -6,7 +6,8 @@ Install the following software:
     [licences for Visual Studio](https://swiki.softwire.com/display/Helpdesk/Visual+Studio) and
     [licences for ReSharper](https://swiki.softwire.com/display/Helpdesk/JetBrains+Licence+Keys)
 
-  * [Rider](https://www.jetbrains.com/rider/)  
+  * [Rider](https://www.jetbrains.com/rider/)
+    You may need to install ASP .NET Core Module as well. Please check [here](https://www.jetbrains.com/help/rider/Running_IISExpress.html)
     If you work for Softwire, read Softwire's guide about getting
     [licences for Rider](https://swiki.softwire.com/display/Helpdesk/JetBrains+Licence+Keys)
 

--- a/GenderPayGap.WebUI/Classes/Extensions/HtmlHelpers.cs
+++ b/GenderPayGap.WebUI/Classes/Extensions/HtmlHelpers.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Web;
 using GenderPayGap.Core.Classes.ErrorMessages;
 using GenderPayGap.Extensions;
 using GenderPayGap.WebUI.Classes.Attributes;
@@ -62,10 +63,13 @@ namespace GenderPayGap.WebUI.Classes
         public static string WithQuery(this IUrlHelper helper, string actionName, object routeValues)
         {
             var newRoute = new NameValueCollection();
-            foreach (string key in helper.ActionContext.HttpContext.Request.Query.Keys)
+
+            if (helper.ActionContext.HttpContext.Request.QueryString.HasValue)
             {
-                newRoute[key] = helper.ActionContext.HttpContext.Request.Query[key];
+                var existingRoute = HttpUtility.ParseQueryString(helper.ActionContext.HttpContext.Request.QueryString.Value);
+                newRoute.Add(existingRoute);
             }
+      
 
             foreach (KeyValuePair<string, object> item in new RouteValueDictionary(routeValues))
             {

--- a/GenderPayGap.WebUI/Classes/Extensions/HtmlHelpers.cs
+++ b/GenderPayGap.WebUI/Classes/Extensions/HtmlHelpers.cs
@@ -69,7 +69,6 @@ namespace GenderPayGap.WebUI.Classes
                 var existingRoute = HttpUtility.ParseQueryString(helper.ActionContext.HttpContext.Request.QueryString.Value);
                 newRoute.Add(existingRoute);
             }
-      
 
             foreach (KeyValuePair<string, object> item in new RouteValueDictionary(routeValues))
             {


### PR DESCRIPTION
**Issue:** 
When there were multiple filters of the same type added (eg "sector") the query wasn't built correctly. It was `param=value1,value2` instead of `param=value1&param=value2`

I fixed this by converting the existing query to a `NameValueCollection` - the values will be handled separately.

Also updated the docs as part of this PR