### PR TITLE
Gpg 631 create account content changes

### DIFF
--- a/GenderPayGap.WebUI/Controllers/Account/AccountCreationController.cs
+++ b/GenderPayGap.WebUI/Controllers/Account/AccountCreationController.cs
@@ -44,7 +44,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
 
                 case HaveYouAlreadyCreatedYourUserAccount.No:
                 case HaveYouAlreadyCreatedYourUserAccount.NotSure:
-                    return RedirectToAction("CreateUserAccountGet", new { isPartOfGovUkReportingJourney = true});
+                    return RedirectToAction("CreateUserAccountGet", new { isPartOfGovUkReportingJourney = true });
 
                 case HaveYouAlreadyCreatedYourUserAccount.Unspecified:
                     viewModel.AddErrorFor(
@@ -58,7 +58,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
                     return View("AlreadyCreatedAnAccountQuestion", model);
             }
         }
-        
+
         [HttpGet("/create-user-account")]
         public IActionResult CreateUserAccountGet(bool isPartOfGovUkReportingJourney = false)
         {
@@ -67,7 +67,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
                 return RedirectToAction("ManageOrganisationsGet", "ManageOrganisations");
             }
 
-            return View("CreateUserAccount", new CreateUserAccountViewModel{IsPartOfGovUkReportingJourney = isPartOfGovUkReportingJourney });
+            return View("CreateUserAccount", new CreateUserAccountViewModel { IsPartOfGovUkReportingJourney = isPartOfGovUkReportingJourney });
         }
 
         [HttpPost("/create-user-account")]
@@ -114,7 +114,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
                 {
                     viewModel.AddErrorFor(
                         m => m.EmailAddress,
-                        "This email address is awaiting confirmation. Please check you email inbox or enter a different email"
+                        "This email address is awaiting confirmation. Please check your email inbox or enter a different email"
                         + " address");
                 }
             }
@@ -130,20 +130,20 @@ namespace GenderPayGap.WebUI.Controllers.Account
 
             GenerateAndSendAccountVerificationEmail(newUser);
 
-            var confirmEmailAddressViewModel = new ConfirmEmailAddressViewModel {EmailAddress = viewModel.EmailAddress};
+            var confirmEmailAddressViewModel = new ConfirmEmailAddressViewModel { EmailAddress = viewModel.EmailAddress };
             return View("ConfirmEmailAddress", confirmEmailAddressViewModel);
         }
-        
+
         [HttpGet("/verify-email")]
         public IActionResult VerifyEmail(string code)
         {
             User gpgUser = dataRepository.GetAll<User>().FirstOrDefault(u => u.EmailVerifyHash == code);
-            
+
             if (gpgUser == null)
             {
                 return View("UserNotFoundErrorPage");
             }
-            
+
             if (User.Identity.IsAuthenticated || gpgUser.EmailVerifiedDate != null)
             {
                 return RedirectToAction("ManageOrganisationsGet", "ManageOrganisations");
@@ -152,7 +152,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
             gpgUser.EmailVerifiedDate = VirtualDateTime.Now;
             gpgUser.SetStatus(UserStatuses.Active, gpgUser, "Email verified");
             dataRepository.SaveChanges();
-            
+
             return RedirectToAction("AccountCreationConfirmation");
         }
 
@@ -203,7 +203,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
             string verificationUrl = Url.Action(
                 "VerifyEmail",
                 "AccountCreation",
-                new {code = verificationCode},
+                new { code = verificationCode },
                 "https");
 
             try

--- a/GenderPayGap.WebUI/Controllers/Account/AccountCreationController.cs
+++ b/GenderPayGap.WebUI/Controllers/Account/AccountCreationController.cs
@@ -26,7 +26,9 @@ namespace GenderPayGap.WebUI.Controllers.Account
             this.dataRepository = dataRepository;
             this.emailSendingService = emailSendingService;
         }
-        
+
+        // The 'Start Now' page (Global.StartUrl https://www.gov.uk/report-gender-pay-gap-data)
+        // links to this action as the starting point for the reporting journey
         [HttpGet("/already-created-an-account-question")]
         public IActionResult AlreadyCreatedAnAccountQuestionGet(AlreadyCreatedAnAccountViewModel viewModel)
         {
@@ -42,7 +44,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
 
                 case HaveYouAlreadyCreatedYourUserAccount.No:
                 case HaveYouAlreadyCreatedYourUserAccount.NotSure:
-                    return RedirectToAction("CreateUserAccountGet");
+                    return RedirectToAction("CreateUserAccountGet", new { isPartOfGovUkReportingJourney = true});
 
                 case HaveYouAlreadyCreatedYourUserAccount.Unspecified:
                     viewModel.AddErrorFor(
@@ -58,14 +60,14 @@ namespace GenderPayGap.WebUI.Controllers.Account
         }
         
         [HttpGet("/create-user-account")]
-        public IActionResult CreateUserAccountGet()
+        public IActionResult CreateUserAccountGet(bool isPartOfGovUkReportingJourney = false)
         {
             if (User.Identity.IsAuthenticated)
             {
                 return RedirectToAction("ManageOrganisationsGet", "ManageOrganisations");
             }
 
-            return View("CreateUserAccount", new CreateUserAccountViewModel());
+            return View("CreateUserAccount", new CreateUserAccountViewModel{IsPartOfGovUkReportingJourney = isPartOfGovUkReportingJourney });
         }
 
         [HttpPost("/create-user-account")]

--- a/GenderPayGap.WebUI/Models/AccountCreation/AlreadyCreatedAnAccountViewModel.cs
+++ b/GenderPayGap.WebUI/Models/AccountCreation/AlreadyCreatedAnAccountViewModel.cs
@@ -20,7 +20,7 @@ namespace GenderPayGap.WebUI.Models.AccountCreation
         [GovUkRadioCheckboxLabelText(Text = "No, I don't have a user account")]
         No = 1,
 
-        [GovUkRadioCheckboxLabelText(Text = "My organisation has used this service before, but I haven't")]
+        [GovUkRadioCheckboxLabelText(Text = "My employer has used this service before, but I haven't")]
         NotSure = 2,
 
         [GovUkRadioCheckboxLabelText(Text = "Unspecified")]

--- a/GenderPayGap.WebUI/Models/AccountCreation/CreateUserAccountViewModel.cs
+++ b/GenderPayGap.WebUI/Models/AccountCreation/CreateUserAccountViewModel.cs
@@ -39,5 +39,7 @@ namespace GenderPayGap.WebUI.Models.AccountCreation
 
         public bool AllowContact { get; set; }
 
+        public bool IsPartOfGovUkReportingJourney { get; set; }
+
     }
 }

--- a/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
@@ -18,7 +18,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Have you already created a user account?</h1>
+        <h1 class="govuk-heading-xl">Have you previously created a user account?</h1>
     </div>
 </div>
 
@@ -33,17 +33,17 @@
                 @{
                     string error = Model.GetErrorFor(m => m.HaveYouAlreadyCreatedYourUserAccount);
                     ErrorMessageViewModel errorMessageViewModel = error != null
-                        ? new ErrorMessageViewModel {Text = error} : null;
+                        ? new ErrorMessageViewModel { Text = error } : null;
                 }
 
                 @if (Model.HaveYouAlreadyCreatedYourUserAccount == null
-                     || Model.HaveYouAlreadyCreatedYourUserAccount == HaveYouAlreadyCreatedYourUserAccount.Unspecified)
+                   || Model.HaveYouAlreadyCreatedYourUserAccount == HaveYouAlreadyCreatedYourUserAccount.Unspecified)
                 {
                     <input type="radio"
                            name="HaveYouAlreadyCreatedYourUserAccount"
                            value="Unspecified"
                            checked
-                           style="display: none"/>
+                           style="display: none" />
                 }
 
                 @Html.GovUkRadios(new RadiosViewModel
@@ -58,7 +58,7 @@
                             string fieldValue = answer.ToString();
                             string fieldId = $"{fieldName}_{fieldValue}";
 
-                            return (ItemViewModel) new RadioItemViewModel
+                            return (ItemViewModel)new RadioItemViewModel
                             {
                                 Name = fieldName,
                                 Value = fieldValue,
@@ -76,15 +76,21 @@
                 })
 
                 <div class="govuk-inset-text">
-                    You will need to create your own user account even if someone else has previously reported your
-                    organisation's gender pay gap.
+                    You will need to create your own user account even if someone else has
+                    previously reported your employer’s gender pay gap.
                 </div>
 
                 @(Html.GovUkButton(new ButtonViewModel
                 {
                     Text = "Continue"
                 }))
+                @{
+                    // We deal with the feature flag in the controller
+                    var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations");
+                }
+                <a href="@(Global.StartUrl ?? reportingUrl)" class="govuk-button" role="button">Cancel</a>
             </div>
+            
         </form>
     </div>
     @if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.ReportingStepByStep))

--- a/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
@@ -84,10 +84,7 @@
                 {
                     Text = "Continue"
                 }))
-                @{
-                    // We deal with the feature flag in the controller
-                    var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations");
-                }
+                @{ var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations"); }
                 <a href="@(Global.StartUrl ?? reportingUrl)" class="govuk-button" role="button">Cancel</a>
             </div>
             

--- a/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
@@ -85,7 +85,9 @@
                     Text = "Continue"
                 }))
                 @{ var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations"); }
-                <a href="@(Global.StartUrl ?? reportingUrl)" class="govuk-button" role="button">Cancel</a>
+                <p class="govuk-body">
+                    <a href="@(Global.StartUrl ?? reportingUrl)" class="govuk-link" role="button">Cancel</a>
+                </p>
             </div>
             
         </form>

--- a/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/AlreadyCreatedAnAccountQuestion.cshtml
@@ -86,7 +86,7 @@
                 }))
                 @{ var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations"); }
                 <p class="govuk-body">
-                    <a href="@(Global.StartUrl ?? reportingUrl)" class="govuk-link" role="button">Cancel</a>
+                    <a href="@(Global.StartUrl ?? reportingUrl)" class="govuk-link">Cancel</a>
                 </p>
             </div>
             

--- a/GenderPayGap.WebUI/Views/AccountCreation/ConfirmEmailAddress.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/ConfirmEmailAddress.cshtml
@@ -28,12 +28,12 @@
         <p class="govuk-body">
             Follow the instructions in the email to confirm your user account.
         </p>
-        <h2 class="govuk-heading-m">What's next?</h2>
+        <h2 class="govuk-heading-m">Next steps</h2>
         <p class="govuk-body">
-            Once your email address is confirmed you will then be able to add your organisation(s) to your account and 
-            report your gender pay gap data.
+            After your email address is confirmed you will be able to add your
+            employer to your account and report gender pay gap information.
         </p>
-        <h2 class="govuk-heading-m">No email yet?</h2>
+        <h2 class="govuk-heading-m">If you haven’t received the email</h2>
         <p class="govuk-body">
             Our email can take a few minutes to arrive. If you can't see it in a few minutes please check your junk mail 
             folder.

--- a/GenderPayGap.WebUI/Views/AccountCreation/ConfirmationPage.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/ConfirmationPage.cshtml
@@ -26,23 +26,27 @@
     <div class="govuk-grid-column-two-thirds">
         
         <p class="govuk-body">
-            You are now able to add an organisation(s) to your user account and report their gender pay gap data.
+            You are now able to add your employer to your user account and
+            report their gender pay gap information. 
         </p>
         
-        <h2 class="govuk-heading-m">Editing your contact details or closing your account</h2>
+        <h2 class="govuk-heading-m">Editing your contact details or closing your user account</h2>
         
         <p class="govuk-body">
-            You can edit your contact details within Manage My Account.
+            You can edit your contact details within Manage Account.
         </p>
         <p class="govuk-body">
-            You will need to close your user account if:      
+            You will need to close your user account if you:
             <ul class="govuk-list govuk-list--bullet">
-                <li>You created a user account by mistake</li>
-                <li>You no longer work for, or manage the gender pay gap reporting for the organisation added to your account</li>
+                <li>created a user account by mistake</li>
+                <li>
+                    you no longer work for, or manage the gender pay gap reporting for
+                    the employer added to your account
+                </li>
             </ul>
         </p>
         <p class="govuk-body">
-            To complete the process for gender pay gap reporting please continue.
+            To complete the process for gender pay gap reporting please
         </p>
         
         <a class="govuk-button" href="/manage-organisations" role="button">Sign In</a>

--- a/GenderPayGap.WebUI/Views/AccountCreation/ConfirmationPage.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/ConfirmationPage.cshtml
@@ -46,7 +46,7 @@
             </ul>
         </p>
         <p class="govuk-body">
-            To complete the process for gender pay gap reporting please
+            To complete the process for gender pay gap reporting please sign in to your account.
         </p>
         
         <a class="govuk-button" href="/manage-organisations" role="button">Sign In</a>

--- a/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
@@ -164,7 +164,9 @@
                     Classes = "govuk-!-margin-top-9"
                 }))
                 @{ var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations"); }
-                <a href="@(Model.IsPartOfGovUkReportingJourney ? Global.StartUrl ?? reportingUrl : reportingUrl)" class="govuk-button govuk-!-margin-top-9" role="button">Cancel</a>
+                <p class="govuk-body">
+                    <a href="@(Model.IsPartOfGovUkReportingJourney ? Global.StartUrl ?? reportingUrl : reportingUrl)" class="govuk-link govuk-!-margin-top-9" role="button">Cancel</a>
+                </p>
             </div>
             
         </form>

--- a/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
@@ -10,10 +10,16 @@
 
 @if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.ReportingStepByStep))
 {
-@section BeforeMain {
-    @{ await Html.RenderPartialAsync("/Views/ReportingStepByStep/ReportingPageHeader.cshtml"); }
+    @section BeforeMain {
+        @{ await Html.RenderPartialAsync("/Views/ReportingStepByStep/ReportingPageHeader.cshtml"); }
+    }
 }
-}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <a class="govuk-link" href="@Url.Action("LoginGet", "Login")">Back</a>
+    </div>
+</div>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -24,12 +30,12 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <div class="govuk-inset-text">
-            You will need to create your own user account even if someone else has previously reported
-            your organisation's gender pay gap.
+            You will need to create your own user account even if someone else has
+            previously reported your employer’s gender pay gap.
         </div>
         <p class="govuk-body">
-            Once your email address is confirmed you will then be able to sign-in and add an organisation(s) to your
-            account and report your gender pay gap data.
+            After your email address is confirmed you will be able to sign in and add
+            employers to your account and report your gender pay gap information.
         </p>
         <p class="govuk-body">
             If you already have a user account, please
@@ -64,7 +70,6 @@
                         classes: "govuk-input--width-20",
                         autocomplete: "email"
                         ))
-
                     @(Html.GovUkTextInputFor(
                         m => m.ConfirmEmailAddress,
                         new LabelViewModel {Text = "Confirm your email address"},
@@ -85,14 +90,12 @@
                         classes: "govuk-input--width-20",
                         autocomplete: "given-name"
                         ))
-
                     @(Html.GovUkTextInputFor(
                         m => m.LastName,
                         new LabelViewModel {Text = "Last name"},
                         classes: "govuk-input--width-20",
                         autocomplete: "family-name"
                         ))
-
                     @(Html.GovUkTextInputFor(
                         m => m.JobTitle,
                         new LabelViewModel {Text = "Job title"},
@@ -132,7 +135,6 @@
                         classes: "govuk-input--width-20",
                         autocomplete: "new-password"
                         ))
-
                     @(Html.GovUkTextInputFor(
                         m => m.ConfirmPassword,
                         new LabelViewModel {Text = "Confirm your password"},
@@ -149,29 +151,27 @@
 
                 @(Html.GovUkCheckboxItemFor(m => m.SendUpdates,
                     new LabelViewModel {Text = "I would like to receive information about webinars, events, and new guidance"}))
-
                 @(Html.GovUkCheckboxItemFor(m => m.AllowContact,
                     new LabelViewModel {Text = "I'm happy to be contacted for feedback on this service and take part in gender pay gap surveys"}))
-
-
                 @(Html.GovUkButton(new ButtonViewModel
                 {
-                    Text = "Continue",
+                    Text = "Save and Continue",
                     Classes = "govuk-!-margin-top-9"
                 }))
-
+                <a href="@Url.Action("LoginGet", "Login")" class="govuk-button govuk-!-margin-top-9" role="button">Cancel</a>
             </div>
+            
         </form>
     </div>
     @if (FeatureFlagHelper.IsFeatureEnabled(FeatureFlag.ReportingStepByStep))
     {
         <div class="govuk-grid-column-one-third">
             @{ await Html.RenderPartialAsync("/Views/ReportingStepByStep/ReportingSidebar.cshtml",
-                   new ReportingStepsViewModel
-                   {
-                       CurrentStep = 3,
-                       CurrentTask = 0
-                   }); }
+                    new ReportingStepsViewModel
+                    {
+                        CurrentStep = 3,
+                        CurrentTask = 0
+                    }); }
         </div>
     }
 </div>

--- a/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
@@ -15,11 +15,16 @@
     }
 }
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <a class="govuk-link" href="@Url.Action("LoginGet", "Login")">Back</a>
+@if (Model.IsPartOfGovUkReportingJourney)
+{
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">
+                <a class="govuk-link" href="@Url.Action("AlreadyCreatedAnAccountQuestionGet", "AccountCreation")">Back</a>
+            </p>
+        </div>
     </div>
-</div>
+}
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -158,7 +163,8 @@
                     Text = "Save and Continue",
                     Classes = "govuk-!-margin-top-9"
                 }))
-                <a href="@Url.Action("LoginGet", "Login")" class="govuk-button govuk-!-margin-top-9" role="button">Cancel</a>
+                @{ var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations"); }
+                <a href="@(Model.IsPartOfGovUkReportingJourney ? Global.StartUrl ?? reportingUrl : reportingUrl)" class="govuk-button govuk-!-margin-top-9" role="button">Cancel</a>
             </div>
             
         </form>

--- a/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/CreateUserAccount.cshtml
@@ -165,7 +165,7 @@
                 }))
                 @{ var reportingUrl = Url.Action("ManageOrganisationsGet", "ManageOrganisations"); }
                 <p class="govuk-body">
-                    <a href="@(Model.IsPartOfGovUkReportingJourney ? Global.StartUrl ?? reportingUrl : reportingUrl)" class="govuk-link govuk-!-margin-top-9" role="button">Cancel</a>
+                    <a href="@(Model.IsPartOfGovUkReportingJourney ? Global.StartUrl ?? reportingUrl : reportingUrl)" class="govuk-link govuk-!-margin-top-9">Cancel</a>
                 </p>
             </div>
             

--- a/GenderPayGap.WebUI/Views/AccountCreation/UserNotFoundErrorPage.cshtml
+++ b/GenderPayGap.WebUI/Views/AccountCreation/UserNotFoundErrorPage.cshtml
@@ -31,7 +31,8 @@
             </li>
         </ul>
         <p class="govuk-body">
-            If you created your account over 7 days ago, you will need to create a new account.
+            If you created your user account over 7 days ago, you will need to create
+            a new account.
         </p>
         <p class="govuk-body">
             <a href=@(Url.Action("CreateUserAccountGet", "AccountCreation")) class="govuk-link">Create a new account</a>

--- a/GenderPayGap.WebUI/Views/Login/Login.cshtml
+++ b/GenderPayGap.WebUI/Views/Login/Login.cshtml
@@ -18,15 +18,16 @@
         @(Html.GovUkErrorSummary())
         
         <p class="govuk-body">
-            If you have a user account, enter your email address and password. After signing into your 
-            account you can add an organisation or manage your existing organisations.
+            If you have a user account, enter your email address and password. After
+            signing in to your account you can add an employer or manage your
+            existing employers.
         </p>
         
         <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
-                If you add an organisation to your account it may take up to three weeks to verify
+                If you add an employer to your user account it may take up to three weeks to verify
             </strong>
         </div>
         
@@ -69,8 +70,8 @@
         <h2 class="govuk-heading-m">Don't have a user account?</h2>
         
         <p class="govuk-body">
-            If you're new to the service you will need to create an account.
-            This will allow you to add organisations or manage existing ones.
+            If you’re new to the service you will need to create a user account. This will
+            allow you to add employer or manage existing ones.
         </p>
 
         <p class="govuk-body">
@@ -81,8 +82,8 @@
         </p>
         
         <div class="govuk-inset-text">
-            You will need to create your own user account even if someone else
-            has previously reported your organisation's gender pay gap.
+            You will need to create your own user account even if someone else has
+            previously reported your employer’s gender pay gap.
         </div>
         
     </div>


### PR DESCRIPTION
Content changes and the new back/cancel buttons/links on the account creation screens.

I've gone through the site locally and made sure that the back/cancel links direct to the correct pages as expected when you are within the journey that starts at /already-created-an-account-question (linked from the Gov UK pages) or when you have accessed the create account page from an alternate route, e.g. the login page.

In the journey: 
- /already-created-an-account-question cancel links to the Gov UK StartUrl page (that links to it)
- /create-user-account back link takes you back to the /already-created-an-account-question page
- /create-user-account cancel links back to the Gov UK StartUrl page

Outside the journey:
- /create-user-account cancel links back to the ManageOrganisations endpoint (which if you aren't signed in takes you to the login page) and the back link doesn't display