### PR TITLE
GPG-632 Content and route changes for Add Employer

### DIFF
--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationChooseSectorController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationChooseSectorController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationChooseSectorController : Controller
     {
         
@@ -21,7 +21,7 @@ namespace GenderPayGap.WebUI.Controllers.AddOrganisation
         }
 
 
-        [HttpGet("choose-sector")]
+        [HttpGet("choose-employer-type")]
         public IActionResult ChooseSector(AddOrganisationChooseSectorViewModel viewModel)
         {
             ControllerHelper.ThrowIfUserAccountRetiredOrEmailNotVerified(User, dataRepository);

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationConfirmationController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationConfirmationController.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationConfirmationController : Controller
     {
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationFoundController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationFoundController.cs
@@ -18,7 +18,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationFoundController : Controller
     {
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualAddressController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualAddressController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationManualAddressController : Controller
     {
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualChooseSectorController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualChooseSectorController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationManualChooseSectorController : Controller
     {
         
@@ -21,7 +21,7 @@ namespace GenderPayGap.WebUI.Controllers.AddOrganisation
         }
 
 
-        [HttpGet("manual/choose-sector")]
+        [HttpGet("manual/choose-employer-type")]
         public IActionResult ManualChooseSector(AddOrganisationManualViewModel viewModel)
         {
             ControllerHelper.ThrowIfUserAccountRetiredOrEmailNotVerified(User, dataRepository);

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualConfirmController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualConfirmController.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationManualConfirmController : Controller
     {
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualNameController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualNameController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationManualNameController : Controller
     {
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualSicCodesController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationManualSicCodesController.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationManualSicCodesController : Controller
     {
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationRedirectsController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationRedirectsController.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using GenderPayGap.WebUI.Helpers;
+using GenderPayGap.WebUI.Models.AddOrganisation;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GenderPayGap.WebUI.Controllers.AddOrganisation
+{
+    [Authorize(Roles = LoginRoles.GpgEmployer)]
+    [Route("add-organisation")]
+    public class AddOrganisationRedirectsController : Controller
+    {
+
+        [HttpGet("choose-sector")]
+        public IActionResult ChooseSector()
+        {
+            return RedirectToActionPermanent("ChooseSector", "AddOrganisationChooseSector");
+        }
+
+        [HttpGet("confirmation")]
+        public IActionResult Confirmation()
+        {
+            return RedirectToActionPermanent("Confirmation", "AddOrganisationConfirmation");
+        }
+
+        [HttpGet("found")]
+        public IActionResult FoundGet(AddOrganisationFoundViewModel viewModel)
+        {
+            return RedirectToActionPermanent("FoundGet", "AddOrganisationFound");
+        }
+
+        [HttpPost("found")]
+        [ValidateAntiForgeryToken]
+        public IActionResult FoundPost(AddOrganisationFoundViewModel viewModel)
+        {
+            return RedirectToActionPermanent("FoundPost", "AddOrganisationFound");
+        }
+
+        [HttpGet("manual/address")]
+        public IActionResult ManualAddress(AddOrganisationManualViewModel viewModel)
+        {
+            return RedirectToActionPermanent("ManualAddress", "AddOrganisationManualAddress");
+        }
+
+        [HttpGet("manual/choose-sector")]
+        public IActionResult ManualChooseSector(AddOrganisationManualViewModel viewModel)
+        {
+            return RedirectToActionPermanent("ManualChooseSector", "AddOrganisationManualChooseSector");
+        }
+
+        [HttpGet("manual/confirm")]
+        public IActionResult ManualConfirmGet(AddOrganisationManualViewModel viewModel)
+        {
+            return RedirectToActionPermanent("ManualConfirmGet", "AddOrganisationManualConfirm");
+        }
+
+        [HttpPost("manual/confirm")]
+        [ValidateAntiForgeryToken]
+        public IActionResult ManualConfirmPost(AddOrganisationManualViewModel viewModel)
+        {
+            return RedirectToActionPermanent("ManualConfirmPost", "AddOrganisationManualConfirm");
+        }
+
+        [HttpGet("manual/name")]
+        public IActionResult ManualName(AddOrganisationManualViewModel viewModel)
+        {
+            return RedirectToActionPermanent("ManualName", "AddOrganisationManualName");
+        }
+
+        [HttpGet("manual/sic-codes")]
+        public IActionResult ManualSicCodes(AddOrganisationManualViewModel viewModel)
+        {
+            return RedirectToActionPermanent("ManualSicCodes", "AddOrganisationManualSicCodes");
+        }
+
+        [HttpGet("{sector}/search")]
+        public IActionResult Search(AddOrganisationSearchViewModel viewModel)
+        {
+            return RedirectToActionPermanent("Search", "AddOrganisationSearch");
+        }
+    }
+}

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationSearchController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationSearchController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GenderPayGap.WebUI.Controllers.AddOrganisation
 {
     [Authorize(Roles = LoginRoles.GpgEmployer)]
-    [Route("add-organisation")]
+    [Route("add-employer")]
     public class AddOrganisationSearchController : Controller
     {
 

--- a/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationChooseSectorViewModel.cs
+++ b/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationChooseSectorViewModel.cs
@@ -11,7 +11,7 @@ namespace GenderPayGap.WebUI.Models.AddOrganisation
         //   but we only want to pass the Sector back to the previous page (we haven't specified a value for Validate)
         public bool? Validate { get; set; }
 
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Select which type of organisation you would like to add")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Select which type of employer you would like to add")]
         public AddOrganisationSector? Sector { get; set; }
 
     }

--- a/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationFoundViewModel.cs
+++ b/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationFoundViewModel.cs
@@ -29,7 +29,7 @@ namespace GenderPayGap.WebUI.Models.AddOrganisation
         [BindNever /* Output Only - only used for sending data from the Controller to the View */]
         public List<string> AddressLines { get; set; }
 
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Select yes if this organisation's address (above) is a UK address")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Select if this employer's registered address is a UK address")]
         public AddOrganisationIsUkAddress? IsUkAddress { get; set; }
 
         public bool? GetIsUkAddressAsBoolean()

--- a/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationManualViewModel.cs
+++ b/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationManualViewModel.cs
@@ -26,16 +26,16 @@ namespace GenderPayGap.WebUI.Models.AddOrganisation
         //   but we only want to pass the Sector back to the previous page (we haven't specified a value for Validate)
         public bool? Editing { get; set; }
 
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Choose which type of organisation you would like to add")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Choose which type of employer you would like to add")]
         public AddOrganisationSector? Sector { get; set; }
 
         public string Query { get; set; }
 
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter the name of the organisation")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter the name of the employer")]
         public string OrganisationName { get; set; }
 
         public string PoBox { get; set; }
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter the registered address of the organisation")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Enter the registered address of the employer")]
         public string Address1 { get; set; }
         public string Address2 { get; set; }
         public string Address3 { get; set; }
@@ -43,7 +43,7 @@ namespace GenderPayGap.WebUI.Models.AddOrganisation
         public string County { get; set; }
         public string Country { get; set; }
         public string PostCode { get; set; }
-        [GovUkValidateRequired(ErrorMessageIfMissing = "Select yes if this organisation's address (above) is a UK address")]
+        [GovUkValidateRequired(ErrorMessageIfMissing = "Select if this employer's registered address is a UK address")]
         public AddOrganisationIsUkAddress? IsUkAddress { get; set; }
 
         public List<int> SicCodes { get; set; }

--- a/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationSector.cs
+++ b/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationSector.cs
@@ -3,11 +3,11 @@
 namespace GenderPayGap.WebUI.Models.AddOrganisation {
     public enum AddOrganisationSector
     {
-        // "Public, then Private" is the order we want on the page /add-organisation/choose-sector
-        [GovUkRadioCheckboxLabelText(Text = "Public sector organisation")]
+        // "Public, then Private" is the order we want on the page /add-employer/choose-employer-type
+        [GovUkRadioCheckboxLabelText(Text = "Public authority employer")]
         Public,
 
-        [GovUkRadioCheckboxLabelText(Text = "Private sector organisation")]
+        [GovUkRadioCheckboxLabelText(Text = "Private or voluntary sector employer")]
         Private
     }
 }

--- a/GenderPayGap.WebUI/Views/AddOrganisationChooseSector/ChooseSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationChooseSector/ChooseSector.cshtml
@@ -3,7 +3,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationChooseSectorViewModel
 @{
-    ViewBag.Title = "What type of organisation you would like to add? - Gender pay gap service";
+    ViewBag.Title = "What type of employer do you want to add? - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -30,7 +30,7 @@
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">
-                        What type of organisation you would like to add?
+                        What type of employer you would like to add?
                     </h1>
                 </legend>
 
@@ -62,12 +62,12 @@
                                 Html = @<text>
                                            This includes:
                                            <ul class="govuk-list govuk-list--bullet" style="color: inherit;">
-                                               <li>Most government departments</li>
-                                               <li>The armed forces</li>
-                                               <li>Local authorities</li>
+                                               <li>most government departments</li>
+                                               <li>the armed forces</li>
+                                               <li>local authorities</li>
                                                <li>NHS bodies</li>
-                                               <li>Universities</li>
-                                               <li>Most schools, including academies and multi-academy trusts (except private and independent schools)</li>
+                                               <li>universities</li>
+                                               <li>most schools, including academies and multi-academy trusts (except private and independent schools)</li>
                                            </ul>
                                         </text>
                             }
@@ -79,10 +79,10 @@
                                 Html = @<text>
                                            This includes:
                                            <ul class="govuk-list govuk-list--bullet" style="color: inherit;">
-                                               <li>Limited companies</li>
-                                               <li>Limited liability partnerships</li>
-                                               <li>Charities</li>
-                                               <li>Independent and private schools</li>
+                                               <li>limited companies</li>
+                                               <li>limited liability partnerships</li>
+                                               <li>charities</li>
+                                               <li>independent and private schools</li>
                                            </ul>
                                         </text>
                             }
@@ -92,12 +92,12 @@
             </fieldset>
 
             <div class="govuk-inset-text">
-                If you are not sure what type of organisation you are, please read the
-                <a href="https://www.gov.uk/guidance/gender-pay-gap-reporting-overview#public-sector-organisations---who-must-report-and-publish"
+                If you are not sure what type your employer is, please read the guidance on
+                <a href="https://www.gov.uk/guidance/who-needs-to-report-their-gender-pay-gap#public-regulations"
                    target="_blank"
                    rel="noopener"
                    class="govuk-link">
-                    guidance on gender pay gap regulations
+                    who needs to report their gender pay gap
                     <span class="govuk-visually-hidden">(opens in a new tab)</span>
                 </a>
             </div>
@@ -116,7 +116,7 @@
             <p class="govuk-body">
                 <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                    class="govuk-link">
-                    Cancel and return to your organisations
+                    Cancel and return to Manage Employers
                 </a>
             </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationConfirmation/Confirmation.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationConfirmation/Confirmation.cshtml
@@ -46,7 +46,7 @@
                 <li>
                     <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                        class="govuk-link">
-                        Manage your organisations
+                        Manage employers
                     </a>
                 </li>
             </ul>
@@ -98,13 +98,13 @@
                 <li>
                     <a href="@Url.Action("ChooseSector", "AddOrganisationChooseSector")"
                        class="govuk-link">
-                        Add another organisation to your account
+                        Add another employer to your account
                     </a>
                 </li>
                 <li>
                     <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                        class="govuk-link">
-                        Manage your organisations
+                        Manage employers
                     </a>
                 </li>
             </ul>
@@ -125,7 +125,7 @@
                 What happens next
             </h2>
             <p class="govuk-body">
-                The Government Equalities Office will review your details and email you within 5 working days to confirm your organisation.
+                The Government Equalities Office will review your details and email you within 5 working days to confirm your employer.
             </p>
             <p class="govuk-body">
                 If we need more information to complete this process, we will email you.
@@ -149,13 +149,13 @@
                 <li>
                     <a href="@Url.Action("ChooseSector", "AddOrganisationChooseSector")"
                        class="govuk-link">
-                        Add another organisation to your account
+                        Add another employer to your user account
                     </a>
                 </li>
                 <li>
                     <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                        class="govuk-link">
-                        Manage your organisations
+                        Manage your employers
                     </a>
                 </li>
             </ul>

--- a/GenderPayGap.WebUI/Views/AddOrganisationFound/AlreadyRegistering.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationFound/AlreadyRegistering.cshtml
@@ -56,7 +56,7 @@
                 <li>
                     <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                        class="govuk-link">
-                        Back to your organisations
+                        Back to Manage Employers
                     </a>
                 </li>
             </ul>
@@ -112,13 +112,13 @@
                 <li>
                     <a href="@Url.Action("ChooseSector", "AddOrganisationChooseSector")"
                        class="govuk-link">
-                        Add another organisation to your account
+                        Add another employer to your account
                     </a>
                 </li>
                 <li>
                     <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                        class="govuk-link">
-                        Manage your organisations
+                        Manage Employers
                     </a>
                 </li>
             </ul>
@@ -139,7 +139,7 @@
                 What happens next
             </h2>
             <p class="govuk-body">
-                The Government Equalities Office will review your details and email you within 5 working days to confirm your organisation.
+                The Government Equalities Office will review your details and email you within 5 working days to confirm your employer.
             </p>
             <p class="govuk-body">
                 If we need more information to complete this process, we will email you.
@@ -163,13 +163,13 @@
                 <li>
                     <a href="@Url.Action("ChooseSector", "AddOrganisationChooseSector")"
                        class="govuk-link">
-                        Add another organisation to your account
+                        Add another employer to your account
                     </a>
                 </li>
                 <li>
                     <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                        class="govuk-link">
-                        Manage your organisations
+                        Manage Employers
                     </a>
                 </li>
             </ul>

--- a/GenderPayGap.WebUI/Views/AddOrganisationFound/Found.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationFound/Found.cshtml
@@ -4,7 +4,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationFoundViewModel
 @{
-    ViewBag.Title = "Confirm your organisation's details - Gender pay gap service";
+    ViewBag.Title = "Confirm your employer's details - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -36,13 +36,13 @@
         @(Html.GovUkErrorSummary())
 
         <h1 class="govuk-heading-xl">
-            Confirm your organisation's details
+            Confirm your employer's details
         </h1>
 
         <table class="govuk-table">
             <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__header">Organisation name</th>
+                    <th scope="row" class="govuk-table__header">Employer name</th>
                     <td class="govuk-table__cell">@(Model.Name)</td>
                 </tr>
                 <tr class="govuk-table__row">
@@ -119,7 +119,7 @@
             <p class="govuk-body">
                 <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                    class="govuk-link">
-                    Cancel and return to your organisations
+                    Cancel and return to Manage Employers
                 </a>
             </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationManualAddress/ManualAddress.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationManualAddress/ManualAddress.cshtml
@@ -2,7 +2,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationManualViewModel
 @{
-    ViewBag.Title = "What is the registered address of the organisation? - Gender pay gap service";
+    ViewBag.Title = "Registered address of employer - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -57,7 +57,7 @@
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
                     <h1 class="govuk-fieldset__heading">
-                        What is the registered address of the organisation?
+                        Registered address of employer
                     </h1>
                 </legend>
 
@@ -142,7 +142,7 @@
             <p class="govuk-body">
                 <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                    class="govuk-link">
-                    Cancel and return to your organisations
+                    Cancel and return to Manage Employers
                 </a>
             </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationManualChooseSector/ManualChooseSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationManualChooseSector/ManualChooseSector.cshtml
@@ -3,7 +3,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationManualViewModel
 @{
-    ViewBag.Title = "What type of organisation you would like to add? - Gender pay gap service";
+    ViewBag.Title = "What type of employer do you want to add? - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -56,7 +56,7 @@
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">
-                        What type of organisation you would like to add?
+                        What type of employer do you want to add?
                     </h1>
                 </legend>
 
@@ -88,12 +88,12 @@
                                 Html = @<text>
                                            This includes:
                                            <ul class="govuk-list govuk-list--bullet" style="color: inherit;">
-                                               <li>Most government departments</li>
-                                               <li>The armed forces</li>
-                                               <li>Local authorities</li>
+                                               <li>most government departments</li>
+                                               <li>the armed forces</li>
+                                               <li>local authorities</li>
                                                <li>NHS bodies</li>
-                                               <li>Universities</li>
-                                               <li>Most schools, including academies and multi-academy trusts (except private and independent schools)</li>
+                                               <li>universities</li>
+                                               <li>most schools, including academies and multi-academy trusts (except private and independent schools)</li>
                                            </ul>
                                         </text>
                             }
@@ -105,10 +105,10 @@
                                 Html = @<text>
                                            This includes:
                                            <ul class="govuk-list govuk-list--bullet" style="color: inherit;">
-                                               <li>Limited companies</li>
-                                               <li>Limited liability partnerships</li>
-                                               <li>Charities</li>
-                                               <li>Independent and private schools</li>
+                                               <li>limited companies</li>
+                                               <li>limited liability partnerships</li>
+                                               <li>charities</li>
+                                               <li>independent and private schools</li>
                                            </ul>
                                         </text>
                             }
@@ -118,12 +118,12 @@
             </fieldset>
 
             <div class="govuk-inset-text">
-                If you are not sure what type of organisation you are, please read the
-                <a href="https://www.gov.uk/guidance/gender-pay-gap-reporting-overview#public-sector-organisations---who-must-report-and-publish"
+                If you are not sure what type your employer is, please read the guidance on
+                <a href="https://www.gov.uk/guidance/who-needs-to-report-their-gender-pay-gap#public-regulations"
                    target="_blank"
                    rel="noopener"
                    class="govuk-link">
-                    guidance on gender pay gap regulations
+                    who needs to report their gender pay gap
                     <span class="govuk-visually-hidden">(opens in a new tab)</span>
                 </a>
             </div>
@@ -137,7 +137,7 @@
             <p class="govuk-body">
                 <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                    class="govuk-link">
-                    Cancel and return to your organisations
+                    Cancel and return to Manage Employers
                 </a>
             </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationManualConfirm/ManualConfirm.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationManualConfirm/ManualConfirm.cshtml
@@ -4,7 +4,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationManualViewModel
 @{
-    ViewBag.Title = "Confirm your organisation's details - Gender pay gap service";
+    ViewBag.Title = "Confirm your employer's details - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -45,7 +45,7 @@
         @(Html.GovUkErrorSummary())
 
         <h1 class="govuk-heading-xl">
-            Confirm your organisation's details
+            Confirm your employer's details
         </h1>
 
         <table class="govuk-table">
@@ -56,7 +56,7 @@
                         @(Model.HasErrorFor(m => m.OrganisationName)
                             ? "add-organisation-manual-confirm-error"
                             : "")">
-                        Organisation name
+                        Employer name
                     </th>
                     <td class="govuk-table__cell">
                         @if (Model.HasErrorFor(m => m.OrganisationName))
@@ -83,7 +83,7 @@
                         <a href="@(Url.Action("ManualName", "AddOrganisationManualName", Model))"
                            class="govuk-link">
                             edit
-                            <span class="govuk-visually-hidden">organisation name</span>
+                            <span class="govuk-visually-hidden">employer name</span>
                         </a>
                     </td>
                 </tr>
@@ -168,7 +168,7 @@
                         @(Model.HasErrorFor(m => m.Sector)
                             ? "add-organisation-manual-confirm-error"
                             : "")">
-                        Sector
+                        Employer type
                     </th>
                     <td class="govuk-table__cell">
                         @if (Model.HasErrorFor(m => m.Sector))
@@ -180,11 +180,11 @@
                         }
                         @if (Model.Sector.HasValue)
                         {
-                            @(Model.Sector.Value)
+                            @(Model.Sector.Value == AddOrganisationSector.Private ? "Private or voluntary sector" : "Public authority")
                         }
                         else
                         {
-                            <span class="govuk-caption-m">Sector missing</span>
+                            <span class="govuk-caption-m">Employer type missing</span>
                         }
                     </td>
                     <td class="govuk-table__cell">
@@ -275,7 +275,7 @@
         <p class="govuk-body">
             <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                class="govuk-link">
-                Cancel and return to your organisations
+                Cancel and return to Manage Employers
             </a>
         </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationManualName/ManualName.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationManualName/ManualName.cshtml
@@ -2,7 +2,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationManualViewModel
 @{
-    ViewBag.Title = "What is the name of the organisation? - Gender pay gap service";
+    ViewBag.Title = "Employer name - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -71,7 +71,7 @@
                 m => m.OrganisationName,
                 labelOptions: new LabelViewModel
                 {
-                    Text = "What is the name of the organisation?",
+                    Text = "Employer name",
                     IsPageHeading = true,
                     Classes = "govuk-label--xl"
                 },
@@ -87,7 +87,7 @@
             <p class="govuk-body">
                 <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                    class="govuk-link">
-                    Cancel and return to your organisations
+                    Cancel and return to Manage Employers
                 </a>
             </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationManualSicCodes/ManualSicCodes.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationManualSicCodes/ManualSicCodes.cshtml
@@ -3,7 +3,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationManualViewModel
 @{
-    ViewBag.Title = "Add a sector code to your organisation - Gender pay gap service";
+    ViewBag.Title = "Add a sector code to your employer - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -44,10 +44,10 @@
         @(Html.GovUkErrorSummary())
 
         <h1 class="govuk-heading-xl">
-            Add a sector code to your organisation
+            Add a sector code to your employer
         </h1>
         <p class="govuk-body">
-            Your organisation will be reported as "Private sector".
+            Your employer will be reported as "Private or voluntary sector".
         </p>
         <p class="govuk-body">
             You can also be reported under other business sectors by adding one or more Standard Industrial Classification (SIC) codes.
@@ -57,10 +57,10 @@
         </p>
         <ul class="govuk-list govuk-list--bullet">
             <li>
-                ensure your organisation is classified in the correct sector
+                ensure your employer is classified in the correct sector
             </li>
             <li>
-                allow for sector comparisons between other organisations
+                allow for sector comparisons between other employers
             </li>
         </ul>
         <p class="govuk-body">
@@ -184,7 +184,7 @@
             <p class="govuk-body">
                 <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                    class="govuk-link">
-                    Cancel and return to your organisations
+                    Cancel and return to Manage Employers
                 </a>
             </p>
 

--- a/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
@@ -3,7 +3,7 @@
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.AddOrganisation.AddOrganisationSearchViewModel
 @{
-    ViewBag.Title = "Find organisation - Gender pay gap service";
+    ViewBag.Title = "Find employer - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 
@@ -30,12 +30,12 @@
             <details class="govuk-details" data-module="govuk-details">
                 <summary class="govuk-details__summary">
                     <span class="govuk-details__summary-text">
-                        Can't find your organisation?
+                        Can't find your employer?
                     </span>
                 </summary>
                 <div class="govuk-details__text">
                     <p class="govuk-body">
-                        If your organisation is not listed, you can tell us the details of the organisation you want to add.
+                        If your employer is not listed, you can tell us the details of the employer you want to add.
                     </p>
                     <p class="govuk-body">
                         <a href="@Url.Action("ManualName", "AddOrganisationManualName",
@@ -45,7 +45,7 @@
                                          Query = Model.Query
                                      })"
                            class="govuk-link">
-                            Provide details of the organisation
+                            Provide employer details
                         </a>
                     </p>
                 </div>
@@ -62,28 +62,24 @@
             <div class="govuk-form-group">
                 <h1 class="govuk-label-wrapper">
                     <label class="govuk-label govuk-label--xl" for="query">
-                        Find your organisation
-                        <br/>
-                        <span class="govuk-!-font-size-36">
-                            (@(Model.Sector == AddOrganisationSector.Public ? "public sector" : "private sector"))
-                        </span>
+                        Find your employer
                     </label>
                 </h1>
 
                 @if (Model.Sector == AddOrganisationSector.Private)
                 {
                     <div id="query-hint" class="govuk-hint">
-                        You can search for an organisation by:
+                        You can search for private or voluntary sector employers by:
                         <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1" style="color: inherit;">
-                            <li>registered name</li>
-                            <li>Companies House number</li>
+                            <li>the registered name</li>
+                            <li>the Companies House number</li>
                         </ul>
                     </div>
                 }
                 else
                 {
                     <div id="query-hint" class="govuk-hint">
-                        You can search for an organisation by their registered name
+                        Enter the public authority's registered name
                     </div>
                 }
 
@@ -107,8 +103,16 @@
             @if (Model.Sector == AddOrganisationSector.Private)
             {
                 <div class="govuk-inset-text govuk-!-margin-top-0">
-                    The registered name is sometimes different to the commonly-known brand name
-                    (e.g. for <i>Currys PC World</i>, you would search for the registered name of the company, <i>DSG Retail Limited</i>)
+                    The registered name of an employer is sometimes different to what
+                    they are commonly known as. For example, if you were searching for
+                    Currys PC World, you would need to search by their registered name
+                    of DSG Retail Limited.
+                </div>
+            }
+            else
+            {
+                <div class="govuk-inset-text govuk-!-margin-top-0">
+                    The registered name of an employer is sometimes different to what they are commonly known as.
                 </div>
             }
         }
@@ -128,23 +132,25 @@
                     <span class="govuk-!-font-weight-bold">
                         @(Model.Query)
                     </span>
-                    did not match any organisations
+                    did not match any employers
                 </p>
 
                 <div class="govuk-inset-text">
                     Suggestions:
 
                     <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1" style="color: inherit;">
-                        <li>Check the spelling of the organisation name</li>
+                        <li>Check the spelling of the employer name</li>
                         @if (Model.Sector == AddOrganisationSector.Private)
                         {
                             <li>
                                 Check you are searching for the
                                 <span class="govuk-!-font-weight-bold">registered name</span>
-                                of the organisation.
+                                of the employer.
                                 <br />
-                                The registered name is sometimes different to the commonly-known brand name
-                                (e.g. to add Currys PC World, you would search for the registered name of the company, DSG Retail Limited)
+                                The registered name of an employer is sometimes different to what
+                                they are commonly known as. For example, if you were searching for
+                                Currys PC World, you would need to search by their registered name
+                                of DSG Retail Limited.
                             </li>
                         }
                     </ul>
@@ -164,7 +170,7 @@
                         @(Model.SearchResults.TooManyResults ? "more than" : "")
                         @(Model.SearchResults.SearchResults.Count)
                     </span>
-                    organisation@(Model.SearchResults.SearchResults.Count == 1 ? "" : "s")
+                    employer@(Model.SearchResults.SearchResults.Count == 1 ? "" : "s")
                 </p>
 
                 @if (Model.SearchResults.TooManyResults)
@@ -176,14 +182,14 @@
                             <li>Try refining your search</li>
                             @if (Model.Sector == AddOrganisationSector.Private)
                             {
-                                <li>Try searching by your organisation's Companies House number</li>
+                                <li>Try searching by your employer's Companies House number</li>
                             }
                         </ul>
                     </div>
                 }
 
                 <p class="govuk-body">
-                    Choose your organisation from the list below
+                    Choose your employer from the list below
                 </p>
 
                 @(cantFindYourOrganisationSection)
@@ -202,11 +208,11 @@
 
                                 <span class="govuk-visually-hidden">Address:</span>
                                 @(organisation.OrganisationAddress)
-                                
+
                                 <span class="govuk-!-font-size-16">
                                     @foreach (AddOrganisationSearchResultOrganisationIdentifier identifier in organisation.Identifiers)
                                     {
-                                        <br/>
+                                        <br />
                                         // ":" is a special character in C# Razor
                                         // To show an actual ":", we need to write "@::"
                                         @(identifier.IdentifierType)@:: @(identifier.Identifier)
@@ -216,8 +222,8 @@
                             <div class="add-organisation-add-button">
                                 @{
                                     object foundParams = organisation.EncryptedOrganisationId != null
-                                        ? (object) new {id = organisation.EncryptedOrganisationId, query = Model.Query, sector = Model.Sector}
-                                        : (object) new {companyNumber = organisation.CompanyNumber, query = Model.Query, sector = Model.Sector};
+                                        ? (object)new { id = organisation.EncryptedOrganisationId, query = Model.Query, sector = Model.Sector }
+                                        : (object)new { companyNumber = organisation.CompanyNumber, query = Model.Query, sector = Model.Sector };
                                 }
                                 <a href="@Url.Action("FoundGet", "AddOrganisationFound", foundParams)"
                                    class="govuk-link govuk-!-padding-2">
@@ -249,7 +255,7 @@
         <p class="govuk-body">
             <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                class="govuk-link">
-                Cancel and return to your organisations
+                Cancel and return to Manage Employers
             </a>
         </p>
 

--- a/GenderPayGap.WebUI/Views/Components/Navigation/AccountTabs.cshtml
+++ b/GenderPayGap.WebUI/Views/Components/Navigation/AccountTabs.cshtml
@@ -1,7 +1,7 @@
 ﻿@{
     var navEntries = new[]
     {
-        new {Text = "Manage Organisations", UrlPath = Url.Action("ManageOrganisationsGet", "ManageOrganisations")},
+        new {Text = "Manage Employers", UrlPath = Url.Action("ManageOrganisationsGet", "ManageOrganisations")},
         new {Text = "Manage Account", UrlPath = Url.Action("ManageAccountGet", "ManageAccount")}
     };
 }

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisations.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisations.cshtml
@@ -23,23 +23,23 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl">
-            Add or select an organisation you're reporting for
+            Add or select an employer you're reporting for
         </h1>
         
         <p class="govuk-body">
-            Add or select an organisation so you can:
+            Add or select an employer so you can:
         </p>
         
         <ul class="govuk-list govuk-list--bullet">
-            <li>Enter gender pay gap data and save it as a draft for publication at a later date</li>
-            <li>Publish your data on the <a class="govuk-link" href="@Url.Action("Index", "Viewing")">gender pay gap service</a></li>
-            <li>Declare whether your organisation is required to report for each reporting year</li>
+            <li>enter gender pay gap information and save a draft for publication at a later date</li>
+            <li>report your gender pay gap information</li>
+            <li>change whether your employer is required to report for each reporting year</li>
         </ul>
         
         <table class="govuk-table">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header">Organisation name</th>
+                    <th scope="col" class="govuk-table__header">Employer name</th>
                     <th scope="col" class="govuk-table__header">Registration status</th>
                 </tr>
             </thead>
@@ -86,7 +86,7 @@
         
         @(Html.GovUkButton(new ButtonViewModel
         {
-            Text = "Add organisation",
+            Text = "Add employer",
             Classes = "govuk-!-margin-bottom-8",
             Href = Url.Action("ChooseSector", "AddOrganisationChooseSector")
         }))

--- a/GenderPayGap.WebUI/wwwroot/robots.txt
+++ b/GenderPayGap.WebUI/wwwroot/robots.txt
@@ -24,3 +24,4 @@ Disallow: /viewing/download-data?*
 Disallow: /viewing/download-compare-data?*
 Disallow: /viewing/help/*
 Disallow: /add-organisation/
+Disallow: /add-employer/


### PR DESCRIPTION
Content changes for the Add Employer journey. As part of this work I've also changed the routes from /add-organisation/ to /add-employer/ for all of these pages. This means that we have a new controller containing all the redirects for the old urls, in case they were bookmarked or linked from somewhere external for example (unlikely since it is all in the account protected area).

I've gone through the journey a few times and it all seems fine, and I didn't find anywhere that was linking to these pages with a none generated link, so everything should be fine.