### PR TITLE
Gpg 650 manage account content changes

### DIFF
--- a/GenderPayGap.Core/App_Data/CustomErrorMessages.config
+++ b/GenderPayGap.Core/App_Data/CustomErrorMessages.config
@@ -43,7 +43,7 @@
     <CustomErrorMessage code="1121" title="You’ve tried to reset your password too many times" description="You can try again in {remainingTime}" />
     <CustomErrorMessage code="1122" title="Something’s gone wrong" description="There was a problem sending your password reset email. Please try again."  />
     <CustomErrorMessage code="1123" title="You’ve entered the wrong password reset code" description="Please try again using the correct password reset code"/>
-    <CustomErrorMessage code="1124" title="This password reset request is no longer valid" description="This user account no longer exists. You must register again" callToAction="Create a user account" actionUrl="/create-user-account"/>
+    <CustomErrorMessage code="1124" title="This password reset request is no longer valid" description="This user account no longer exists. You must create a new user account." callToAction="Create a user account" actionUrl="/create-user-account"/>
     <CustomErrorMessage code="1125" title="Too many attempts" description="You've attempted this action too many times." callToAction="Please try again in {remainingTime}" actionUrl="#"/>
     <CustomErrorMessage code="1126" title="This password reset request has expired" description="Please request a new password reset email." callToAction="Reset password" actionUrl="/Register/password-reset"/>
     <CustomErrorMessage code="1127" title="Password successfully reset" description="Your new password has been accepted." actionUrl="/manage-organisations" actionText="Sign In"/>

--- a/GenderPayGap.WebUI/Controllers/Account/ChangeEmailController.cs
+++ b/GenderPayGap.WebUI/Controllers/Account/ChangeEmailController.cs
@@ -67,7 +67,7 @@ namespace GenderPayGap.WebUI.Controllers.Account
 
             if (OtherUserWithThisEmailAddressAlreadyExists(viewModel.NewEmailAddress))
             {
-                viewModel.AddErrorFor(m => m.NewEmailAddress, "This email address is already taken by another account");
+                viewModel.AddErrorFor(m => m.NewEmailAddress, "This email address is already taken by another user");
                 return View("ChangeEmail", viewModel);
             }
 

--- a/GenderPayGap.WebUI/Views/ChangeEmail/ChangeEmail.cshtml
+++ b/GenderPayGap.WebUI/Views/ChangeEmail/ChangeEmail.cshtml
@@ -38,17 +38,13 @@
 
         @(Html.GovUkErrorSummary())
 
-        <h2 class="govuk-heading-m">
-            Enter your new email address
-        </h2>
-        
         <form method="post" action="@(Url.Action("ChangeEmailPost", "ChangeEmail"))">
             @(Html.AntiForgeryToken())
 
             @(Html.GovUkTextInputFor(
                 m => m.NewEmailAddress,
                 type: "email",
-                labelOptions: new LabelViewModel { Text = "New email address" },
+                labelOptions: new LabelViewModel { Text = "Enter your new email address" },
                 classes: "govuk-input--width-20",
                 formGroupOptions: new FormGroupViewModel { Classes = "govuk-!-margin-bottom-3" },
                 autocomplete: "email"

--- a/GenderPayGap.WebUI/Views/ChangeEmail/ChangeEmailComplete.cshtml
+++ b/GenderPayGap.WebUI/Views/ChangeEmail/ChangeEmailComplete.cshtml
@@ -22,7 +22,7 @@
         <p class="govuk-body">
             <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                class="govuk-link">
-                Back to Manage Organisations
+                Back to Manage Employers
             </a>
         </p>
         <p class="govuk-body">

--- a/GenderPayGap.WebUI/Views/ChangeEmail/PleaseVerifyNewEmailAddress.cshtml
+++ b/GenderPayGap.WebUI/Views/ChangeEmail/PleaseVerifyNewEmailAddress.cshtml
@@ -24,7 +24,7 @@
         <p class="govuk-body">
             <a href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")"
                class="govuk-link">
-                Back to Manage Organisations
+                Back to Manage Employers
             </a>
         </p>
         <p class="govuk-body">


### PR DESCRIPTION
Content changes for the Manage Account pages. There were also a few areas that weren't included in the pdf document that I have updated in line with those that were (Organisation to Employer)

Only a few changes here, all wording. I've checked that they appear as expected. Note that the change for the Manage Organisation tab to Manage Employer has been done in GPG-632.