### PR TITLE
GPG-680 Update IP Deny README with automated deployment details

### DIFF
--- a/GenderPayGap.WebUI/AzureAttachAutoscalingPolicy.sh
+++ b/GenderPayGap.WebUI/AzureAttachAutoscalingPolicy.sh
@@ -1,0 +1,19 @@
+﻿while getopts ":a:m:M:" opt; do
+    case $opt in
+a) PROTECTED_APP_NAME="$OPTARG"
+    ;;
+m) MIN_COUNT_INSTANCES="$OPTARG"
+    ;;
+M) MAX_COUNT_INSTANCES="$OPTARG"
+    ;;
+\?) echo "Invalid option -$OPTARG" >&2
+    ;;
+esac
+    done
+
+echo "{\"instance_min_count\":${MIN_COUNT_INSTANCES},\"instance_max_count\":${MAX_COUNT_INSTANCES},\"scaling_rules\":[{\"metric_type\":\"throughput\",\"breach_duration_secs\":60,\"threshold\":10,\"operator\":\"<\",\"cool_down_secs\":60,\"adjustment\":\"-1\"},{\"metric_type\":\"throughput\",\"breach_duration_secs\":60,\"threshold\":10,\"operator\":\">=\",\"cool_down_secs\":60,\"adjustment\":\"+1\"}]}" > autoscaling_policy.json
+
+cf install-plugin -f -r CF-Community app-autoscaler-plugin
+cf create-service autoscaler autoscaler-free-plan "scale-${PROTECTED_APP_NAME}"
+cf bind-service "${PROTECTED_APP_NAME}" "scale-${PROTECTED_APP_NAME}"
+cf attach-autoscaling-policy "${PROTECTED_APP_NAME}" autoscaling_policy.json

--- a/GenderPayGap.WebUI/GenderPayGap.WebUI.csproj
+++ b/GenderPayGap.WebUI/GenderPayGap.WebUI.csproj
@@ -108,6 +108,9 @@
     <ProjectReference Include="..\GovUkDesignSystem\GovUkDesignSystem.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="AzureAttachAutoscalingPolicy.sh">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="buildpack.yml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Infrastructure/gpg-ipdeny/AzureDeployIPDeny.sh
+++ b/Infrastructure/gpg-ipdeny/AzureDeployIPDeny.sh
@@ -1,0 +1,36 @@
+﻿while getopts ":a:d:e:f:r:s:m:M:w:" opt; do
+  case $opt in
+    a) PROTECTED_APP_NAME="$OPTARG"
+    ;;
+    d) AGENT_TEMP_DIRECTORY="$OPTARG"
+    ;;
+    e) PROTECTED_APP_SPACE_NAME="$OPTARG"
+    ;;
+    f) DENIED_IPS_FILENAME="$OPTARG"
+    ;;
+    r) ROUTE_SERVICE_APP_NAME="$OPTARG"
+    ;;
+    s) ROUTE_SERVICE_NAME="$OPTARG"
+    ;;
+    m) MIN_COUNT_INSTANCES="$OPTARG"
+    ;;
+    M) MAX_COUNT_INSTANCES="$OPTARG"
+    ;;
+    w) WORKING_DIRECTORY="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+
+# Get the latest version of jq into the working directory
+curl -L -o "${WORKING_DIRECTORY}/GPGIPDeny/jq.exe" https://github.com/stedolan/jq/releases/latest/download/jq-win64.exe
+
+# go into the working directory so that the deployment picks up the nginx.conf
+cd /c/agent/_work/r9/a/GPGIPDeny
+
+# replace the instances of jq in the deploy.sh script with the fully specified path of jq
+sed -i 's+jq+"/c/agent/_work/r9/a/GPGIPDeny/jq.exe"+g' /c/agent/_work/r9/a/GPGIPDeny/deploy.sh
+
+# Run the deployment
+/c/agent/_work/r9/a/GPGIPDeny/deploy.sh -a ${PROTECTED_APP_NAME} -e ${PROTECTED_APP_SPACE_NAME} -f "${AGENT_TEMP_DIRECTORY}/GPG-IP-Denylist.txt" -r ${ROUTE_SERVICE_APP_NAME} -s ${ROUTE_SERVICE_NAME} -m ${MIN_COUNT_INSTANCES} -M ${MAX_COUNT_INSTANCES}

--- a/Infrastructure/gpg-ipdeny/README.md
+++ b/Infrastructure/gpg-ipdeny/README.md
@@ -4,7 +4,7 @@ gpg-ipdeny is an IP denylisting nginx application based upon the IP allowing ver
 
 It is designed to allow access to the Gender Pay Gap Service to all IP addresses except those specifically set, returning a 403 response to those banned IPs.
 
-## Deployment
+## Manual Deployment
 
 Since the list of banned IPs should not update particularly frequently, the application is deployed manually via the Deploy.sh script.
 
@@ -28,10 +28,18 @@ The deployment script takes the following parameters:
 
 For example to set up ip denylisting on the dev space, if you've created/placed the denylist file in the same directory as the deployment script, the command could be run (using the gitbash window set up with jq earlier) as 
 ```
-./deploy.sh -e gpg-dev -r gpg-dev-ipdeny -s gpg-dev-ipdeny-service -a gender-pay-gap-dev -f "GPG IP Denylist.txt"
+./deploy.sh -e gpg-dev -r gpg-dev-ipdeny -s gpg-dev-ipdeny-service -a gender-pay-gap-dev -f "GPG-IP-Denylist.txt" -m 1 -M 2
 ```
 
-The file listing banned IPs can be found in Zoho, and is called "GPG IP Denylist.txt". This should not be checked into source control, and that filename has been added to the .gitignore. Since the script accepts any file for the denylist, IP denylisting can be tested by providing a different file. Take care not to accidentally check in any differently name denylist file.
+The file listing banned IPs can be found in Zoho, and is called "GPG-IP-Denylist.txt". This should not be checked into source control, and that filename has been added to the .gitignore. Since the script accepts any file for the denylist, IP denylisting can be tested by providing a different file. Take care not to accidentally check in any differently name denylist file.
 
 When updating this list, each IP should be listed on a new line.
-If there are any errors when starting the app, these are most likely to have been caused by a syntax error in the list of IPs to deny. By checking the environment variables that have been set on the environment, it should be possible to tell where the issue is in the provided list of IPs
+If there are any errors when starting the app, these are most likely to have been caused by a syntax error in the list of IPs to deny. By checking the environment variables that have been set on the environment, it should be possible to tell where the issue is in the provided list of IPs.
+There is also a copy of the GPG-IP-Denylist.txt file stored in the Library - Secure Files of Azure. If the list of IPs is updated, this should be updated along with the version in Zoho.
+
+## Automated deployment
+The IP deny app is deployed via the same Azure release pipelines using a Bash step in the Deploy to PaaS (push) task group
+
+This relies on the copy of the GPG-IP-Denylist.txt file stored in the Library - Secure Files of Azure. If the list of IPs is updated, this should be updated along with the version in Zoho.
+
+The deployment is run via the same deploy script as the manual deployments, so changes to the deployment script may break the automated deployments. Due to the scripts reliance on jq, we need to have this available. There doesn't appear to be a simple way to do this in Azure, so the bash step that run the deployment handles adding a version and making sure the deployment script can access it.


### PR DESCRIPTION
Updated the readme for the automated deployments of the IP deny app.

I've made changes to:

- the build all branches job to include and IP Deny Artifact
- the Deploy to PaaS (prepare) task group to include getting this new aritifact
- the Deploy to PaaS (push) task group to get the new secret file and deploy the IP Deny app
- Added a bunch of variables to the Deploy to PaaS/DEV release pipeline

Both the task groups are version 2.\*, so when we are ready to promote these to other environments, we should just need to add the new variables to the relevant releases and update the 2 task groups from version 1.\* to 2.*

I've also attempted to fix the automated deployment to dev when main is updated, which was broken by the change from main to master, but that may not have worked (the manually triggered deployments still work though if that hasn't worked).

I've tested that the deployments work, and deploy the IP deny app successfully given that the dev IP Deny app was not the same as the one that was subsequently deployed to loadtest (no autoscaling), so it should work, but I cant be sure until we deploy it to to an environment that doesn't yet have it (e.g. preprod)

(edited to fix accidental styling)