### PR TITLE
GPG-706 Change health check timeout to 60s for all envs

### DIFF
--- a/GenderPayGap.WebUI/manifest-gpg-dev.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-dev.yml
@@ -8,3 +8,4 @@ applications:
    command: dotnet GenderPayGap.WebUI.dll
    health-check-http-endpoint: /health-check
    health-check-type: http
+   timeout: 60

--- a/GenderPayGap.WebUI/manifest-gpg-loadtest.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-loadtest.yml
@@ -8,3 +8,4 @@ applications:
    command: dotnet GenderPayGap.WebUI.dll
    health-check-http-endpoint: /health-check
    health-check-type: http
+   timeout: 60

--- a/GenderPayGap.WebUI/manifest-gpg-preprod.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-preprod.yml
@@ -8,3 +8,4 @@ applications:
    command: dotnet GenderPayGap.WebUI.dll
    health-check-http-endpoint: /health-check
    health-check-type: http
+   timeout: 60

--- a/GenderPayGap.WebUI/manifest-gpg-prod.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-prod.yml
@@ -8,3 +8,4 @@ applications:
    command: dotnet GenderPayGap.WebUI.dll
    health-check-http-endpoint: /health-check
    health-check-type: http
+   timeout: 60

--- a/GenderPayGap.WebUI/manifest-gpg-test.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-test.yml
@@ -8,3 +8,4 @@ applications:
    command: dotnet GenderPayGap.WebUI.dll
    health-check-http-endpoint: /health-check
    health-check-type: http
+   timeout: 60


### PR DESCRIPTION
Increased the timeout to 60s for all environments using the manifest files. [Cloud Foundry documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#timeout) says you can set it this way, but we may find out that it creates an error if it is bigger than cc.maximum_health_check_timeout (default 180) if our cloud foundry operator has overwritten that value to less than 60.

I've tested the environment manifest files deploy successfully for dev with the merging of the pull request for GPG-677, but won't be able to confirm this change has worked until this is merged and successfully updates the dev timeout (currently 1s)