### PR TITLE
GPG-729 Fixed bonus reporting bug

### DIFF
--- a/GenderPayGap.WebUI/BusinessLogic/Models/Submit/ReturnViewModel.cs
+++ b/GenderPayGap.WebUI/BusinessLogic/Models/Submit/ReturnViewModel.cs
@@ -195,17 +195,19 @@ namespace GenderPayGap.WebUI.BusinessLogic.Models.Submit
                                             && FemaleUpperQuartilePayBand.HasValue
                                             && FemaleMoneyFromMeanHourlyRate >= 0
                                             && FemaleMoneyFromMedianHourlyRate >= 0;
+            bool hasValidBonusFigures = MaleMedianBonusPayPercent == 0 ||
+                 DiffMeanBonusPercent.HasValue && DiffMedianBonusPercent.HasValue;
 
             if (SectorType == SectorTypes.Public)
             {
-                return hasEnterCalculationsData;
+                return hasEnterCalculationsData && hasValidBonusFigures;
             }
 
             bool hasPersonResponsibleData = !string.IsNullOrWhiteSpace(JobTitle)
                                             && !string.IsNullOrWhiteSpace(FirstName)
                                             && !string.IsNullOrWhiteSpace(LastName);
 
-            return hasEnterCalculationsData && hasPersonResponsibleData;
+            return hasEnterCalculationsData && hasValidBonusFigures && hasPersonResponsibleData;
         }
 
         public bool HasUserData()

--- a/GenderPayGap.WebUI/Controllers/SubmitController.EnterCalculations.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.EnterCalculations.cs
@@ -77,7 +77,7 @@ namespace GenderPayGap.WebUI.Controllers.Submission
 
             ConfirmPayBandsAddUpToOneHundred(postedReturnViewModel);
 
-            ValidateBonusIntegrity(postedReturnViewModel);
+            ValidateBonusIntegrity(postedReturnViewModel, saveDraft: false);
 
             #region Keep draft file locked to this user
 
@@ -239,7 +239,7 @@ namespace GenderPayGap.WebUI.Controllers.Submission
             }
         }
 
-        private void ValidateBonusIntegrity(ReturnViewModel postedReturnViewModel)
+        private void ValidateBonusIntegrity(ReturnViewModel postedReturnViewModel, bool saveDraft = true)
         {
             // ensure that bonus differences do not exceed 100% when females have a bonus
             if (postedReturnViewModel.FemaleMedianBonusPayPercent > 0)
@@ -266,6 +266,19 @@ namespace GenderPayGap.WebUI.Controllers.Submission
                 if (postedReturnViewModel.DiffMedianBonusPercent.HasValue)
                 {
                     AddModelError(2131, nameof(postedReturnViewModel.DiffMedianBonusPercent));
+                }
+            }
+            
+            if (postedReturnViewModel.MaleMedianBonusPayPercent > 0 && !saveDraft)
+            {
+                if (!postedReturnViewModel.DiffMeanBonusPercent.HasValue)
+                {
+                    AddModelError(2021, nameof(postedReturnViewModel.DiffMeanBonusPercent));
+                }
+
+                if (!postedReturnViewModel.DiffMedianBonusPercent.HasValue)
+                {
+                    AddModelError(2023, nameof(postedReturnViewModel.DiffMedianBonusPercent));
                 }
             }
         }


### PR DESCRIPTION
See ticket [GPG-729](https://technologyprogramme.atlassian.net/browse/GPG-729)

There were custom errors (not used) for this case.

```
<CustomErrorMessage code="2021" displayName="Enter the difference in mean bonus pay" title="There’s a problem with your data entry" description="Please enter your data" />
<CustomErrorMessage code="2023" displayName="Enter the difference in median bonus pay" title="There’s a problem with your data entry" description="Please enter your data" />
  ```
![image](https://user-images.githubusercontent.com/40567916/110619029-009d6e80-81a0-11eb-930f-fa191c6413ac.png)


**Tested locally:**

- If % of men who receive bonus is 0 user is not allowed to enter bonus mean. An error is displayed
- If % of men who receive bonus is 0 user is not allowed to enter bonus median. An error is displayed
- If % of men is greater than 0 user cannot submit report without bonus mean. “Confirm and submit” button is disabled (on 'Review your gender pay gap data' page)
- If % of men is greater than 0 user cannot submit report without bonus median. “Confirm and submit” button is disabled (on 'Review your gender pay gap data' page)
- If % of men is greater than 0 user cannot submit report without bonus mean. Pressing “Continue” results in an error message against bonus mean with request for more information (on 'Enter your gender pay gap data for snapshot date <date>' page)
- If % of men is greater than 0 user cannot submit report without bonus median. Pressing “Continue” results in an error message against bonus median with request for more information (on 'Enter your gender pay gap data for snapshot date <date>' page)
- If % of men is greater than 0 user can save draft without bonus median
- If % of men is greater than 0 user can save draft without bonus mean