### PR TITLE
Gpg 732 update reporting deadline 2020

### DIFF
--- a/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
+++ b/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
@@ -36,7 +36,8 @@ namespace GenderPayGap.Core.Helpers
             DateTime deadline = accountingDate.AddYears(1).AddDays(-1);
             if (reportingYear == 2020)
             {
-                deadline = deadline.AddMonths(DeadlineExtensionFor2020InMonths);
+                // Reporting deadline for 2020 was changed to 2021/10/05 for both public and private
+                deadline = new DateTime(2021,10,5);
             }
 
             return deadline;

--- a/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
+++ b/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
@@ -30,6 +30,7 @@ namespace GenderPayGap.Core.Helpers
             return formattedYear;
         }
 
+        //The deadline date is the final date on which returns are not considered late
         public static DateTime GetDeadlineForAccountingDate(DateTime accountingDate)
         {
             int reportingYear = accountingDate.Year;

--- a/GenderPayGap.Database/Models/Extensions/Return.cs
+++ b/GenderPayGap.Database/Models/Extensions/Return.cs
@@ -285,6 +285,9 @@ namespace GenderPayGap.Database
             return $"{AccountingDate.ToString("yyyy")}/{AccountingDate.AddYears(1).ToString("yy")}";
         }
 
+        // The deadline date is the final day that a return can be submitted without being considered late
+        // The due date is a day later, the point at which a return is considered late
+        // i.e. if the deadline date is 2021/04/01, submissions on that day are not late, any after 2021/04/02 00:00:00 are
         private DateTime GetDueDate()
         {
             return ReportingYearsHelper.GetDeadlineForAccountingDate(AccountingDate).AddDays(1);

--- a/GenderPayGap.WebUI/Services/DraftReturnService.cs
+++ b/GenderPayGap.WebUI/Services/DraftReturnService.cs
@@ -180,8 +180,12 @@ namespace GenderPayGap.WebUI.Services
             int reportingYear = draftReturn.SnapshotYear;
 
             DateTime snapshotDate = organisation.SectorType.GetAccountingStartDate(reportingYear);
-            DateTime deadlineDate = ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate).AddDays(1);
-            bool isLate = VirtualDateTime.Now > deadlineDate;
+
+            // The deadline date is the final day that a return can be submitted without being considered late
+            // The due date is a day later, the point at which a return is considered late
+            // i.e. if the deadline date is 2021/04/01, submissions on that day are not late, any after 2021/04/02 00:00:00 are
+            DateTime dueDate = ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate).AddDays(1);
+            bool isLate = VirtualDateTime.Now > dueDate;
             bool isMandatory = draftReturn.OrganisationSize != OrganisationSizes.Employees0To249;
             bool isInScope = organisation.GetScopeForYear(reportingYear).IsInScopeVariant();
             bool yearIsNotExcluded = !Global.ReportingStartYearsToExcludeFromLateFlagEnforcement.Contains(reportingYear);

--- a/GenderPayGap.WebUI/Services/DraftReturnService.cs
+++ b/GenderPayGap.WebUI/Services/DraftReturnService.cs
@@ -180,7 +180,7 @@ namespace GenderPayGap.WebUI.Services
             int reportingYear = draftReturn.SnapshotYear;
 
             DateTime snapshotDate = organisation.SectorType.GetAccountingStartDate(reportingYear);
-            DateTime deadlineDate = ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate);
+            DateTime deadlineDate = ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate).AddDays(1);
             bool isLate = VirtualDateTime.Now > deadlineDate;
             bool isMandatory = draftReturn.OrganisationSize != OrganisationSizes.Employees0To249;
             bool isInScope = organisation.GetScopeForYear(reportingYear).IsInScopeVariant();

--- a/GenderPayGap.WebUI/Services/DraftReturnService.cs
+++ b/GenderPayGap.WebUI/Services/DraftReturnService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using GenderPayGap.Core;
 using GenderPayGap.Core.Classes;
+using GenderPayGap.Core.Helpers;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Database.Models;
@@ -179,8 +180,8 @@ namespace GenderPayGap.WebUI.Services
             int reportingYear = draftReturn.SnapshotYear;
 
             DateTime snapshotDate = organisation.SectorType.GetAccountingStartDate(reportingYear);
-
-            bool isLate = VirtualDateTime.Now > snapshotDate.AddYears(1);
+            DateTime deadlineDate = ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate);
+            bool isLate = VirtualDateTime.Now > deadlineDate;
             bool isMandatory = draftReturn.OrganisationSize != OrganisationSizes.Employees0To249;
             bool isInScope = organisation.GetScopeForYear(reportingYear).IsInScopeVariant();
             bool yearIsNotExcluded = !Global.ReportingStartYearsToExcludeFromLateFlagEnforcement.Contains(reportingYear);


### PR DESCRIPTION
Changed the 2020 deadline date to 05/10/2021 (for both public and private)

Also updated the draft return deadline checking so that it checks whether it is late using the new deadline helper method. This wouldn't affect 2020 as it has been added to the late flag list so the overall method will still evaluate to false. I've also added some comments around the confusing deadline vs due date naming we have so that it should be clearer why we are doing things like adding days

Checked that it displays 5th October as expected for public/private and that the logic will work consistently for deciding if a submission is late.

(I had some trouble with git not adding all the files I wanted to the commit, so I've ended up with some weird ones)