### PR TITLE
GPG-728 Fixed decimals rounded in edit mode issue

### DIFF
--- a/GenderPayGap.WebUI/BusinessLogic/Models/Submit/ReturnViewModel.cs
+++ b/GenderPayGap.WebUI/BusinessLogic/Models/Submit/ReturnViewModel.cs
@@ -18,96 +18,96 @@ namespace GenderPayGap.WebUI.BusinessLogic.Models.Submit
         [Display(Name = "Enter the difference in average (mean) hourly pay")]
         [Range(-499.99, 100, ErrorMessage = "Value must be between -499.99 and 100")]
         [RegularExpression(@"^[-]?\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? DiffMeanHourlyPayPercent { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Enter the difference in median hourly pay")]
         [Range(-499.99, 100, ErrorMessage = "Value must be between -499.99 and 100")]
         [RegularExpression(@"^[-]?\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? DiffMedianHourlyPercent { get; set; }
 
         [Display(Name = "Enter the average (mean) gender pay gap using bonus pay")]
         [Range((double) decimal.MinValue, 100, ErrorMessage = "Value must be lower than 100")]
         [RegularExpression(@"^[-]?\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? DiffMeanBonusPercent { get; set; }
 
         [Display(Name = "Enter the median gender pay gap using bonus pay")]
         [Range((double) decimal.MinValue, 100, ErrorMessage = "Value must be lower than 100")]
         [RegularExpression(@"^[-]?\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? DiffMedianBonusPercent { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Percentage of men who were paid a bonus")]
         [Range(0, 100, ErrorMessage = "Value must be between 0 and 100")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? MaleMedianBonusPayPercent { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Percentage of women who were paid a bonus")]
         [Range(0, 100, ErrorMessage = "Value must be between 0 and 100")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? FemaleMedianBonusPayPercent { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Men")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? MaleLowerPayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Women")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? FemaleLowerPayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Men")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? MaleMiddlePayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Women")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? FemaleMiddlePayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Men")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? MaleUpperPayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Women")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? FemaleUpperPayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Men")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? MaleUpperQuartilePayBand { get; set; }
 
         [Required(AllowEmptyStrings = false)]
         [Display(Name = "Women")]
         [Range(0, 200.9, ErrorMessage = "Value must be between 0 and 200.9")]
         [RegularExpression(@"^\d+(\.{0,1}\d)?$", ErrorMessage = "Value can't have more than 1 decimal place")]
-        [DisplayFormat(DataFormatString = "{0:0.#}", ApplyFormatInEditMode = true)]
+        [DisplayFormat(DataFormatString = "{0:0.#}")]
         public decimal? FemaleUpperQuartilePayBand { get; set; }
 
         public long ReturnId { get; set; }

--- a/GenderPayGap.WebUI/Classes/Extensions/HtmlHelpers.cs
+++ b/GenderPayGap.WebUI/Classes/Extensions/HtmlHelpers.cs
@@ -262,6 +262,13 @@ namespace GenderPayGap.WebUI.Classes
         {
             Dictionary<string, object> htmlAttr = CustomAttributesFor(helper, expression, htmlAttributes);
 
+            // By default, decimals are truncated to 2 decimal places in edit mode
+            // On error, this can be confusing as the value displayed is not the user input
+            // As a workaround, we use the String template in order to display the exact same input
+            if (typeof(TProperty).FullName == typeof(decimal).FullName || typeof(TProperty).FullName == typeof(decimal?).FullName)
+            {
+                return helper.EditorFor(expression, "String", new {htmlAttributes = htmlAttr});
+            }
             return helper.EditorFor(expression, null, new {htmlAttributes = htmlAttr});
         }
 


### PR DESCRIPTION
Ticket [GPG-728](https://technologyprogramme.atlassian.net/browse/GPG-728)

The decimals were truncated to 1 decimal place because we applied the format string in both display and edit mode.
Even if we removed this, the decimals would be truncated to 2 decimal places in edit mode because this is the [default behaviour](https://github.com/aspnet/AspNetWebStack/blob/42991b3d2537b702736463f76a10a4fcf2ea44c9/src/System.Web.Mvc/Html/DefaultEditorTemplates.cs#L110).

As a workaround, we can use the "String" editor template. By doing this, on error, the user input is displayed and not a rounded value. User is still not able to submit the form if a figure has more than 1 decimal place. When displayed (on the review report page) the figures have a decimal place as before.