### PR TITLE
GPG-NONE Content change fixes

### DIFF
--- a/GenderPayGap.WebUI/Views/AddOrganisationChooseSector/ChooseSector.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationChooseSector/ChooseSector.cshtml
@@ -30,7 +30,7 @@
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading">
-                        What type of employer you would like to add?
+                        What type of employer do you want to add?
                     </h1>
                 </legend>
 

--- a/GenderPayGap.WebUI/Views/Organisation/DeclareScope.cshtml
+++ b/GenderPayGap.WebUI/Views/Organisation/DeclareScope.cshtml
@@ -2,6 +2,7 @@
     ViewBag.Title = "We need more information - Gender pay gap reporting service";
 }
 @using GenderPayGap.Core
+@using GenderPayGap.Core.Helpers
 @model GenderPayGap.WebUI.Models.Organisation.DeclareScopeModel
 <div class="grid-row">
     <div class="column-full">
@@ -20,7 +21,7 @@
                 <span class="heading-secondary">@Model.OrganisationName</span>
             </h1>
 
-            <p>Was your employer required to report for the @(Model.SnapshotDate.Year)/@(Model.SnapshotDate.AddYears(1).Year.ToTwoDigitYear()) reporting year?</p>
+            <p>Was your employer required to report for the @ReportingYearsHelper.FormatYearAsReportingPeriod(Model.SnapshotDate.Year) reporting year?</p>
             @Html.ValidationMessageFor(model => model.ScopeStatus, null, new {@class = "error-danger"})
             <div class="form-group @Html.SetErrorClass(model => model.ScopeStatus, "error")">
                 <fieldset>

--- a/GenderPayGap.WebUI/Views/Organisation/RemoveOrganisationCompleted.cshtml
+++ b/GenderPayGap.WebUI/Views/Organisation/RemoveOrganisationCompleted.cshtml
@@ -42,7 +42,7 @@
             This has not deleted the person’s user account, but they will no longer be
             able to:
         </p>
-        <ul class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
             <li>report new gender pay gap information for this employer</li>
             <li>edit or review draft gender pay gap information for this employer</li>
             <li>edit and re-submit existing gender pay gap information for this employer</li>
@@ -55,9 +55,6 @@
         </p>
 
         <div class="govuk-form-group">
-            <p class="govuk-body govuk-!-font-weight-bold">
-                More options
-            </p>
             <p class="govuk-body">
                 <a class="govuk-link" href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")">Return to Manage Employers</a>
             </p>

--- a/GenderPayGap.WebUI/Views/Organisation/ScopeDeclared.cshtml
+++ b/GenderPayGap.WebUI/Views/Organisation/ScopeDeclared.cshtml
@@ -1,18 +1,18 @@
 ﻿@{
     ViewBag.Title = "We need more information - Gender pay gap reporting service";
+    Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
 }
 @using GenderPayGap.Core
+@using GenderPayGap.Core.Helpers
 @using GenderPayGap.WebUI.Models.Shared.Patterns
-@using GovUkDesignSystem
-@using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.Organisation.DeclareScopeModel
 @{
     string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.OrganisationId.ToString());
-    string reportingYearsString = Model.SnapshotDate.Year + "/" + (Model.SnapshotDate.Year + 1).ToString().Substring(2, 2);
-    var breadcrumbModel = new ManageOrganisationBreadcrumbs 
-    { 
-        OrganisationName = Model.OrganisationName, 
-        EncryptedOrganisationId = encryptedOrganisationId, 
+    string reportingYearsString = ReportingYearsHelper.FormatYearAsReportingPeriod(Model.SnapshotDate.Year);
+    var breadcrumbModel = new ManageOrganisationBreadcrumbs
+    {
+        OrganisationName = Model.OrganisationName,
+        EncryptedOrganisationId = encryptedOrganisationId,
         PageText = "Change reporting requirement"
     };
 }
@@ -21,28 +21,28 @@
     <partial name="Patterns/ManageOrganisationBreadcrumbs" model="breadcrumbModel" />
 }
 
-<main id="content" role="main">
-    <div class="grid-row">
-        <div class="column-two-thirds">
-
-            <div class="govuk-box-highlight">
-                <h2 class="bold-large">
-                    You've confirmed your employer is <span> @(Model.ScopeStatus == ScopeStatuses.OutOfScope ? "not " : "")required to report for the @(reportingYearsString) reporting year.</span>
-                </h2>
-            </div>
-            <h1 class="heading-large">
-                <span class="heading-secondary">@Model.OrganisationName</span>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">
+                You've confirmed your employer is <span> @(Model.ScopeStatus == ScopeStatuses.OutOfScope ? "not " : "")required to report for the @(reportingYearsString) reporting year.</span>
             </h1>
-            <p class="govuk-body">
-                You have acknowledged that your employer is subject the gender pay
-                gap regulations for the @(reportingYearsString) reporting year.
-            </p>
+        </div>
+        <h2 class="govuk-heading-m">
+            <span class="heading-secondary">@Model.OrganisationName</span>
+        </h2>
+        <p class="govuk-body">
+            You have acknowledged that your employer is @(Model.ScopeStatus == ScopeStatuses.OutOfScope ? "not " : "")subject the gender pay
+            gap regulations for the @(reportingYearsString) reporting year.
+        </p>
+        @if (Model.ScopeStatus == ScopeStatuses.InScope)
+        {
             <p class="govuk-body">
                 You must report and publish your gender pay gap information at any
                 time up to the reporting deadline, which is a year from your snapshot
                 date.
             </p>
-            <ul class="govuk-list">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>
                     most public authority employers must use a snapshot date of 31
                     March and report and publish gender pay gap information by 30
@@ -54,12 +54,13 @@
                     information by 30 March of the following year.
                 </li>
             </ul>
-            <p class="govuk-body">
-                <a class="button" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = encryptedOrganisationId})" role="button">Return to @Model.OrganisationName</a>
-            </p>
-            <p class="govuk-body">
-                <a class="button" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = ViewContext.RouteData.Values["Id"]})" role="button">Return to Manage Employers</a>
-            </p>
-        </div>
+        }
+
+        <p class="govuk-body">
+            <a class="button" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = encryptedOrganisationId})" role="button">Return to @Model.OrganisationName</a>
+        </p>
+        <p class="govuk-body">
+            <a class="button" href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId = ViewContext.RouteData.Values["Id"]})" role="button">Return to Manage Employers</a>
+        </p>
     </div>
-</main>
+</div>

--- a/GenderPayGap.WebUI/Views/Scope/FinishOutOfScopeJourney.cshtml
+++ b/GenderPayGap.WebUI/Views/Scope/FinishOutOfScopeJourney.cshtml
@@ -1,6 +1,7 @@
 ﻿@using GenderPayGap.WebUI.Models.ScopeNew
 @using GenderPayGap.WebUI.Classes.Formatters
 @using GenderPayGap.WebUI.Models.Shared.Patterns
+@using GenderPayGap.Core.Helpers
 @model GenderPayGap.WebUI.Models.ScopeNew.ScopeViewModel
 
 @{
@@ -10,7 +11,7 @@
 
 @{
     string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
-    string reportingYearsString = Model.ReportingYear.Year + "/" + (Model.ReportingYear.Year + 1).ToString().Substring(2, 2);
+    string reportingYearsString = ReportingYearsHelper.FormatYearAsReportingPeriod(Model.ReportingYear.Year);
     string reason = Model.WhyOutOfScope == WhyOutOfScope.Under250
         ? "My organisation had fewer than 250 employees on " + new GDSDateFormatter(Model.ReportingYear).FullStartDate
         : Model.WhyOutOfScopeDetails;
@@ -34,11 +35,11 @@
             </h1>
         </div>
 
-        <h1 class="heading-large">
-            <span class="heading-secondary">@Model.Organisation.OrganisationName</span>
-        </h1>
+        <h2 class="govuk-heading-m">
+            @Model.Organisation.OrganisationName
+        </h2>
         <p class="govuk-body">
-            You have acknowledged that your employer is subject the gender pay
+            You have acknowledged that your employer is not subject the gender pay
             gap regulations for the @(reportingYearsString) reporting year.
         </p>
 


### PR DESCRIPTION
Content change fixes for:
ChooseSector.cshtml h1 text 'What type of employer do you want to add?'
No bullets + "more options" should be removed (remove user)
Scope confirmation header font
"Was your employer required to report for the 2019/20 reporting year?" to XXXX-XX
Declare scope confirmation via newly created organisations being broken (it was using a different layout page)

Also swapped a couple of places I noticed where the reporting year helper wasn't used

Checked these ones in Chome/Firefox (none were browser specific errors)