### PR TITLE
GPG-NONE Add initial organisation address

### DIFF
--- a/GenderPayGap.WebUI/BusinessLogic/Services/UpdateFromCompaniesHouseService.cs
+++ b/GenderPayGap.WebUI/BusinessLogic/Services/UpdateFromCompaniesHouseService.cs
@@ -122,17 +122,19 @@ namespace GenderPayGap.WebUI.BusinessLogic.Services
             OrganisationAddress newOrganisationAddressFromCompaniesHouse =
                 CreateOrganisationAddressFromCompaniesHouseAddress(companiesHouseAddress);
             OrganisationAddress oldOrganisationAddress = organisation.GetLatestAddress();
-            if (oldOrganisationAddress.AddressMatches(newOrganisationAddressFromCompaniesHouse)
-                || IsNewOrganisationAddressNullOrEmpty(newOrganisationAddressFromCompaniesHouse))
+            if (oldOrganisationAddress != null)
             {
-                return;
+                if (oldOrganisationAddress.AddressMatches(newOrganisationAddressFromCompaniesHouse)
+                    || IsNewOrganisationAddressNullOrEmpty(newOrganisationAddressFromCompaniesHouse))
+                {
+                    return;
+                }
+                oldOrganisationAddress.Status = AddressStatuses.Retired;
+                oldOrganisationAddress.StatusDate = VirtualDateTime.Now;
             }
 
             newOrganisationAddressFromCompaniesHouse.OrganisationId = organisation.OrganisationId;
             organisation.OrganisationAddresses.Add(newOrganisationAddressFromCompaniesHouse);
-
-            oldOrganisationAddress.Status = AddressStatuses.Retired;
-            oldOrganisationAddress.StatusDate = VirtualDateTime.Now;
 
             dataRepository.Insert(newOrganisationAddressFromCompaniesHouse);
         }


### PR DESCRIPTION
Companies with no organisation addresses were not fully updated (i.e. the initial address couldn't be added) by the FetchCompaniesHouseData job.