### PR TITLE
GPG-722 Changed comparison table default year

### DIFF
--- a/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
+++ b/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
@@ -2,13 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using GenderPayGap.Core.Classes;
+using GenderPayGap.Extensions;
 
 namespace GenderPayGap.Core.Helpers
 {
     public static class ReportingYearsHelper
     {
-        public const int DeadlineExtensionFor2020InMonths = 6;
-
         public static List<int> GetReportingYears()
         {
             int firstReportingYear = Global.FirstReportingYear;
@@ -42,6 +41,21 @@ namespace GenderPayGap.Core.Helpers
             }
 
             return deadline;
+        }
+
+        public static int GetTheMostRecentCompletedReportingYear()
+        {
+            int mostRecentReportingYear = Global.FirstReportingYear;
+            foreach (int year in from year in GetReportingYears()
+                let accountingDate = SectorTypes.Private.GetAccountingStartDate(year)
+                where GetDeadlineForAccountingDate(accountingDate) < VirtualDateTime.Now
+                select year)
+            {
+                mostRecentReportingYear = year;
+                break;
+            }
+
+            return mostRecentReportingYear;
         }
 
     }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/CompareControllerTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/CompareControllerTests.cs
@@ -812,7 +812,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
 
         #region CompareEmployers
         [Test]
-        public void CompareController_CompareEmployers_NoYear_DefaultSortFirstYearAsync()
+        public void CompareController_CompareEmployers_NoYear_DefaultSortTheMostRecentCompletedReportingYearAsync()
         {
             // Arrange
             var routeData = new RouteData();
@@ -825,9 +825,9 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             var testUri = new Uri("https://localhost/Viewing/compare-employers");
             controller.AddMockUriHelper(testUri.ToString(), "CompareEmployers");
 
-            var firstReportingYear = Global.FirstReportingYear;
-            var mockOrg = OrganisationHelper.GetOrganisationInScope("MockedOrg", firstReportingYear);
-            DateTime accountingDateTime = mockOrg.SectorType.GetAccountingStartDate(firstReportingYear);
+            var reportingYear = ReportingYearsHelper.GetTheMostRecentCompletedReportingYear();
+            var mockOrg = OrganisationHelper.GetOrganisationInScope("MockedOrg", reportingYear);
+            DateTime accountingDateTime = mockOrg.SectorType.GetAccountingStartDate(reportingYear);
 
             //create the comparison data
             var expectedModel = ViewingServiceHelper.GetCompareTestData(5).ToList();
@@ -855,7 +855,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             var actualModel = result.Model as CompareViewModel;
             Assert.NotNull(actualModel);
             Assert.NotNull(actualModel.CompareReports);
-            Assert.IsTrue(actualModel.CompareReports.All(obj => actualModel.Year == firstReportingYear));
+            Assert.IsTrue(actualModel.CompareReports.All(obj => actualModel.Year == reportingYear));
             actualModel.CompareReports.Compare(expectedModel);
         }
 
@@ -913,7 +913,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
 
         #region DownloadCompareData
         [Test]
-        public void CompareController_DownloadCompareData_NoYear_DefaultSortFirstYearAsync()
+        public void CompareController_DownloadCompareData_NoYear_DefaultSortTheMostRecentCompletedReportingYearAsync()
         {
             // Arrange
             var routeData = new RouteData();
@@ -921,9 +921,9 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             routeData.Values.Add("Controller", "Viewing");
 
             var controller = UiTestHelper.GetController<CompareController>(0, routeData);
-            var firstReportingYear = Global.FirstReportingYear;
-            var mockOrg = OrganisationHelper.GetOrganisationInScope("MockedOrg", firstReportingYear);
-            DateTime accountingDateTime = mockOrg.SectorType.GetAccountingStartDate(firstReportingYear);
+            var reportingYear = ReportingYearsHelper.GetTheMostRecentCompletedReportingYear();
+            var mockOrg = OrganisationHelper.GetOrganisationInScope("MockedOrg", reportingYear);
+            DateTime accountingDateTime = mockOrg.SectorType.GetAccountingStartDate(reportingYear);
 
             //create the comparison data
             var expectedModel = ViewingServiceHelper.GetCompareTestData(5).ToList();
@@ -945,7 +945,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers
 
             // Assert
             //Test the google analytics tracker was executed once on the controller
-            var filename = $"Compared GPG Data {ReportingYearsHelper.FormatYearAsReportingPeriod(firstReportingYear)}.csv";
+            var filename = $"Compared GPG Data {ReportingYearsHelper.FormatYearAsReportingPeriod(reportingYear)}.csv";
             controller.WebTracker.GetMockFromObject().Verify(mock => mock.TrackPageView(It.IsAny<Controller>(), filename, null), Times.Once());
 
             Assert.NotNull(result);

--- a/GenderPayGap.WebUI/Controllers/CompareController.cs
+++ b/GenderPayGap.WebUI/Controllers/CompareController.cs
@@ -238,7 +238,7 @@ namespace GenderPayGap.WebUI.Controllers
             {
                 CompareViewService.SortColumn = null;
                 CompareViewService.SortAscending = true;
-                year = Global.FirstReportingYear;
+                year = ReportingYearsHelper.GetTheMostRecentCompletedReportingYear();
             }
 
             //Load employers from querystring (via shared email)
@@ -324,7 +324,7 @@ namespace GenderPayGap.WebUI.Controllers
         {
             if (year == 0)
             {
-                year = Global.FirstReportingYear;
+                year = ReportingYearsHelper.GetTheMostRecentCompletedReportingYear();
             }
 
             string args = command.AfterFirst(":");
@@ -352,7 +352,7 @@ namespace GenderPayGap.WebUI.Controllers
         {
             if (year == 0)
             {
-                year = Global.FirstReportingYear;
+                year = ReportingYearsHelper.GetTheMostRecentCompletedReportingYear();
             }
 
             var result = CompareEmployers(year) as ViewResult;


### PR DESCRIPTION
Changed the default year on the comparison table to the most recent “completed” year (i.e. its deadline has passed)