### PR TITLE
GPG-721 Default order by order added to comparison basket

### DIFF
--- a/GenderPayGap.WebUI/BusinessLogic/Services/OrganisationBusinessLogic.cs
+++ b/GenderPayGap.WebUI/BusinessLogic/Services/OrganisationBusinessLogic.cs
@@ -9,6 +9,7 @@ using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Extensions;
 using GenderPayGap.WebUI.BusinessLogic.Models.Compare;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace GenderPayGap.WebUI.BusinessLogic.Services
 {
@@ -164,8 +165,8 @@ namespace GenderPayGap.WebUI.BusinessLogic.Services
                 return SortCompareReports(compareReports, sortColumn, sortAscending);
             }
 
-            // Return the results
-            return compareReports;
+            // Return the results ordered by the order they were added by default
+            return compareReports.OrderBy(x => encBasketOrgIds.IndexOf(x.EncOrganisationId)).ToList();
         }
 
         public virtual DataTable GetCompareDatatable(IEnumerable<CompareReportModel> data)


### PR DESCRIPTION
Changed the results from the compare to sort by the passed in list of encrypted organisation IDs by default so that they are sorted in the order that they are added to the comparison basket rather than by the numeric organisation IDs from the database.