### PR TITLE
GPG-739 changed reporting year filter behavior

### DIFF
--- a/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedOrganisation.cs
+++ b/GenderPayGap.WebUI/Search/CachedObjects/SearchCachedOrganisation.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Castle.Core.Internal;
 using GenderPayGap.Core;
+using GenderPayGap.Core.Helpers;
+using GenderPayGap.Extensions;
 
 namespace GenderPayGap.WebUI.Search.CachedObjects
 {
@@ -16,16 +20,75 @@ namespace GenderPayGap.WebUI.Search.CachedObjects
         public string EmployerReference { get; set; }
         public OrganisationStatuses Status { get; set; }
         public int MinEmployees { get; set; }
-        public List<OrganisationSizes> OrganisationSizes { get; set; }
         public List<int> ReportingYears { get; set; }
-        public DateTime DateOfLatestReport { get; set; }
-        public bool ReportedWithCompanyLinkToGpgInfo { get; set; }
-        public bool ReportedLate { get; set; }
         public List<string> SicCodeIds { get; set; }
         public List<char> SicSectionIds { get; set; }
         public List<SearchReadyValue> SicCodeSynonyms { get; set; }
         public bool IncludeInViewingService { get; set; }
         public SectorTypes Sector { get; set; }
+        public Dictionary<int, List<OrganisationSizes>> ReportingYearToOrganisationSizesMap { get; set; }
+        public List<int> ReportedLateYears { get; set; }
+        public List<int> ReportedWithCompanyLinkToGpgInfoYears { get; set; }
+        public Dictionary<int, DateTime> ReportingYearToDateOfLatestReportMap { get; set; }
+        
+        public List<OrganisationSizes> OrganisationSizes(List<int> years)
+        {
+            if (years.IsNullOrEmpty())
+            {
+                years = ReportingYearsHelper.GetReportingYears();
+            }
 
+            var organisationSizes = new List<OrganisationSizes>();
+
+            foreach (var year in years)
+            {
+                if (ReportingYearToOrganisationSizesMap.TryGetValue(year, out List<OrganisationSizes> sizes))
+                {
+                    organisationSizes = organisationSizes.Union(sizes).ToList();
+                }
+            }
+
+            return organisationSizes;
+        }
+
+        public List<DateTime> DatesOfLatestReports(List<int> years)
+        {
+            if (years.IsNullOrEmpty())
+            {
+                years = ReportingYearsHelper.GetReportingYears();
+            }
+
+            var latestReports = new List<DateTime>();
+
+            foreach (var year in years)
+            {
+                if (ReportingYearToDateOfLatestReportMap.TryGetValue(year, out DateTime latestDate))
+                {
+                    latestReports.Add(latestDate);
+                }
+            }
+
+            return latestReports;
+        }
+
+        public bool ReportedWithCompanyLinkToGpgInfo(List<int> years)
+        {
+            if (years.IsNullOrEmpty())
+            {
+                return !ReportedWithCompanyLinkToGpgInfoYears.IsNullOrEmpty();
+            }
+
+            return ReportedWithCompanyLinkToGpgInfoYears.Intersect(years).Any();
+        }
+
+        public bool ReportedLate(List<int> years)
+        {
+            if (years.IsNullOrEmpty())
+            {
+                return !ReportedLateYears.IsNullOrEmpty();
+            }
+
+            return ReportedLateYears.Intersect(years).Any();
+        }
     }
 }

--- a/GenderPayGap.WebUI/Search/ViewingSearchService.cs
+++ b/GenderPayGap.WebUI/Search/ViewingSearchService.cs
@@ -173,10 +173,14 @@ namespace GenderPayGap.WebUI.Search
 
             if (selectedReportingStatuses.Any())
             {
+                var reportingStatusFilteredOrgs = new List<SearchCachedOrganisation>();
+
                 foreach (SearchReportingStatusFilter status in selectedReportingStatuses)
                 {
-                    filteredOrgs = ApplyReportingStatusesFilter(filteredOrgs, status, selectedReportingYears);
+                    reportingStatusFilteredOrgs = reportingStatusFilteredOrgs.Union(ApplyReportingStatusesFilter(filteredOrgs, status, selectedReportingYears)).ToList();
                 }
+
+                filteredOrgs = reportingStatusFilteredOrgs;
             }
 
             


### PR DESCRIPTION
Tickets:
- [GPG-739](https://technologyprogramme.atlassian.net/browse/GPG-739)
- [GPG-740](https://technologyprogramme.atlassian.net/browse/GPG-740)

1. When the organisations are filtered by the reporting year we want to apply the filters at the submission level
2. Reported in the last X days - All the organisations that submitted any report in the last X days