### PR TITLE
GPG-719 Update proxy_pass_buffer size

### DIFF
--- a/Infrastructure/gpg-ipdeny/nginx.conf
+++ b/Infrastructure/gpg-ipdeny/nginx.conf
@@ -92,6 +92,7 @@ http {
       }
  
       proxy_http_version 1.1;
+      proxy_buffer_size  8k;
       proxy_ssl_server_name on;
       proxy_ssl_protocols TLSv1.2;
       proxy_set_header Connection "";


### PR DESCRIPTION
This issue was caused by the combination of the IP Deny app and cookies being accepted on a given environment.

If a user has accepted cookies, then the add to compare button attempts to set a cookie containing the compare string using the set-cookie header.
By default the nginx IP Deny app has a proxy_buffer_size of 4KB, which if the upstream app attempts to return greater than this amount in the headers, then it throws a 502 Bad Gateway. With 443 employers being added to the compare, the total response headers size is around 5.5KB.

Increased the value to 8KB to avoid this issue, this should be sufficiently large given the maximum that can be put in the compare is 500.

Tested by deploying this branch to the loadtest environment as we currently aren't using it, I can successfully get back my 5.5KB response headers from the endpoint when adding the group of employers that was previously causing the error.