### PR TITLE
GPG-742 Add redirect from old /register/about-you link

### DIFF
--- a/GenderPayGap.WebUI/Controllers/RegisterController.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.cs
@@ -1,4 +1,5 @@
-﻿using GenderPayGap.Core.Interfaces;
+﻿using System;
+using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Extensions.AspNetCore;
 using GenderPayGap.WebUI.Classes;
 using GenderPayGap.WebUI.Services;
@@ -28,6 +29,15 @@ namespace GenderPayGap.WebUI.Controllers
         {
             this.emailSendingService = emailSendingService;
             this.auditLogger = auditLogger;
+        }
+
+        // This was the old url given out to create a user account that was shared. Since this was changed
+        // they now get a number of user support queries asking for an up to date link. Instead redirect the 
+        // old link to the new address.
+        [HttpGet("about-you")]
+        public IActionResult AboutYou()
+        {
+            return RedirectToActionPermanent("CreateUserAccountGet", "AccountCreation");
         }
     }
 }


### PR DESCRIPTION
Added a permanent redirect (301) from the old /register/about-you address to the new /create-user-account address used to start the account creation process.