### PR TITLE
Gpg 744 updating robots.txt

### DIFF
--- a/GenderPayGap.WebUI/wwwroot/robots.txt
+++ b/GenderPayGap.WebUI/wwwroot/robots.txt
@@ -1,10 +1,5 @@
 User-agent: *
-Disallow: /admin/
-Disallow: /home/
 Disallow: /register/
-Disallow: /submit/
-Disallow: /test/
-Disallow: /scope/
 Disallow: /Viewing/search-results?*
 Disallow: /search-results-js?*
 Disallow: /viewing/employer-details?*
@@ -13,18 +8,15 @@ Disallow: /viewing/add-employer-js/*
 Disallow: /viewing/remove-employer/*
 Disallow: /viewing/remove-employer-js/*
 Disallow: /viewing/clear-employers/*
-Disallow: /viewing/clear-employers-js/*
 Disallow: /viewing/sort-employers/*
 Disallow: /viewing/compare-employers/*
 Disallow: /viewing/suggest-employer-name-js?*
-Disallow: /viewing/suggest-sic-code-js?*
 Disallow: /viewing/search-results-js?*
 Disallow: /viewing/employer-*
 Disallow: /viewing/download-data?*
 Disallow: /viewing/download-compare-data?*
-Disallow: /viewing/help/*
-Disallow: /add-organisation/
-Disallow: /add-employer/
+Disallow: /viewing/azure-uptime-pinger
+Disallow: /viewing/add-search-results-to-compare
 
 User-agent: SemrushBot
 Disallow: /

--- a/GenderPayGap.WebUI/wwwroot/robots.txt
+++ b/GenderPayGap.WebUI/wwwroot/robots.txt
@@ -25,3 +25,9 @@ Disallow: /viewing/download-compare-data?*
 Disallow: /viewing/help/*
 Disallow: /add-organisation/
 Disallow: /add-employer/
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: SemrushBot/2
+Disallow: /


### PR DESCRIPTION
GPG-744: Added the SEMrush user agents to the robots.txt file

GPG-584: 
- Went through and removed the disallowed endpoints that are behind authorisation and a couple that no longer exist.
- /register/ is still there as I've just added the /Register/about-you endpoint to redirect to the new create account page in GPG-742.
- The remaining disallowed endpoints under /viewing/ are all the ones that relate to functionality like the add to compare buttons etc. that should probably remain disallowed as they aren't actual pages. Added a couple of extra ones I found in the viewing controller that weren't previously included in the list of disallowed endpoints, but probably should have been as they fall into the same category.

I think this is still the correct approach to take in terms of allow/disallow, rather than having to specify all the public pages that we do want to get crawled individually.