### PR TITLE
Gpg 738 set up ga tracking for filters

### DIFF
--- a/GenderPayGap.WebUI/Models/Search/SearchViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Search/SearchViewModel.cs
@@ -107,7 +107,7 @@ namespace GenderPayGap.WebUI.Models.Search
                 return _sizeFilterInfo;
             }
         }
-
+        
         public List<string> ReportingYearFilterInfo
         {
             get
@@ -134,6 +134,68 @@ namespace GenderPayGap.WebUI.Models.Search
             }
         }
 
+        public FilterGroup SectorFilterGroup
+        {
+            get
+            {
+                return new FilterGroup
+                {
+                    Id = "SectorFilter",
+                    Group = "s",
+                    Label = "Sector",
+                    Expanded = false,
+                    Metadata = SectorOptions,
+                    MaxHeight = "300px"
+                };
+            }
+        }
+
+
+        public FilterGroup SizeFilterGroup
+        {
+            get
+            {
+                return new FilterGroup
+                {
+                    Id = "SizeFilter",
+                    Group = "es",
+                    Label = "Employer size",
+                    Expanded = false,
+                    Metadata = SizeOptions
+                };
+            }
+        }
+        
+        public FilterGroup ReportingYearFilterGroup
+        {
+            get
+            {
+                return new FilterGroup
+                {
+                    Id = "ReportingYearFilter",
+                    Group = "y",
+                    Label = "Reporting year",
+                    Expanded = false,
+                    Metadata = ReportingYearOptions
+                };
+            }
+        }
+        
+        public FilterGroup ReportingStatusFilterGroup
+        {
+            get
+            {
+                return new FilterGroup
+                {
+                    Id = "ReportingStatusFilter",
+                    Group = "st",
+                    Label = "Reporting status",
+                    Expanded = false,
+                    Metadata = ReportingStatusOptions
+                };
+            }
+        }
+
         public EmployerSearchModel GetEmployer(string employerIdentifier)
         {
             //Get the employer from the last search results
@@ -149,6 +211,5 @@ namespace GenderPayGap.WebUI.Models.Search
             public string Description { get; set; }
 
         }
-
     }
 }

--- a/GenderPayGap.WebUI/Scripts/Application/LiveSearch.js
+++ b/GenderPayGap.WebUI/Scripts/Application/LiveSearch.js
@@ -232,7 +232,7 @@
     };
     
     LiveSearch.prototype.getFilterLabelFromGroup = function getFilterLabelFromGroup(filter, filterGroup) {
-        return  filterGroup.Metadata.find(
+        return filterGroup.Metadata.find(
             availableFilter => availableFilter.Value === filter.value
         ).Label
     };

--- a/GenderPayGap.WebUI/Scripts/Application/LiveSearch.js
+++ b/GenderPayGap.WebUI/Scripts/Application/LiveSearch.js
@@ -95,30 +95,23 @@
 
     LiveSearch.prototype.updateResults = function updateResults() {
         var searchState = $.param(this.state);
-        //var cachedResultData = this.cache(searchState);
         var liveSearch = this;
-        //if (typeof cachedResultData === 'undefined') {
-            this.showLoadingIndicator();
+        this.showLoadingIndicator();
         if (this.GATrackFilters) 
         {
             this.sendFilterEventToGA();
         }
-            return $.ajax({
-                url: this.action,
-                data: this.state,
-                searchState: searchState
-            }).done(function (response) {
-                liveSearch.cache($.param(liveSearch.state), response);
-                liveSearch.displayResults(response, this.searchState);
-                liveSearch.clearLoadingIndicator();
-            }).error(function () {
-                window.location = '/error/1146';
-            });
-        //} else {
-            //this.displayResults(cachedResultData, searchState);
-            //var out = new $.Deferred()
-            //return out.resolve();
-        //}
+        return $.ajax({
+            url: this.action,
+            data: this.state,
+            searchState: searchState
+        }).done(function (response) {
+            liveSearch.cache($.param(liveSearch.state), response);
+            liveSearch.displayResults(response, this.searchState);
+            liveSearch.clearLoadingIndicator();
+        }).error(function () {
+            window.location = '/error/1146';
+        });
     };
 
     LiveSearch.prototype.showLoadingIndicator = function showLoadingIndicator() {
@@ -137,9 +130,6 @@
         if (action == $.param(this.state)) {
             this.clearLoadingIndicator();
             this.$resultsBlock.html(results);
-            //this.$resultsBlock.mustache('finders/_results', results);
-            //this.$loadingBlock.mustache('finders/_result_count', results);
-            //this.$atomAutodiscoveryLink.attr('href', results.atom_url);
         }
     };
 

--- a/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
@@ -42,8 +42,13 @@
         ga('govuk_shared.send', 'pageview');
     }
     
-    function sendGpgEvent(Event) {      
-        ga('send', Event);
+    function sendGpgEvent(Event) {
+        Event.hitType = 'event';
+        
+        // Only send GA event if required fields present
+        if (Event.eventCategory && Event.eventAction) {
+            ga('send', Event);
+        }
     }
 
     function deleteGoogleAnalyticsCookies() {

--- a/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
@@ -41,6 +41,10 @@
         // Track the current page view using the GDS Google Analytics shared tracking account
         ga('govuk_shared.send', 'pageview');
     }
+    
+    function sendGpgEvent(Event) {      
+        ga('send', Event);
+    }
 
     function deleteGoogleAnalyticsCookies() {
         function deleteCookie(cookieName) {
@@ -51,7 +55,7 @@
         deleteCookie('_gid');
         deleteCookie('_gat');
     }
-
+    
     @if (cookieSettings.GoogleAnalyticsGpg || cookieSettings.GoogleAnalyticsGovUk)
     {
         @:initialiseGoogleAnalytics();

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Filter.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Filter.cshtml
@@ -1,43 +1,5 @@
 ﻿@using GenderPayGap.WebUI.Models.Search
 @model GenderPayGap.WebUI.Models.Search.SearchViewModel
-@{
-    var size = new FilterGroup
-    {
-        Id = "SizeFilter",
-        Group = "es",
-        Label = "Employer size",
-        Expanded = false,
-        Metadata = Model.SizeOptions
-    };
-
-    var sectors = new FilterGroup
-    {
-        Id = "SectorFilter",
-        Group = "s",
-        Label = "Sector",
-        Expanded = false,
-        Metadata = Model.SectorOptions,
-        MaxHeight = "300px"
-    };
-
-    var years = new FilterGroup
-    {
-        Id = "ReportingYearFilter",
-        Group = "y",
-        Label = "Reporting year",
-        Expanded = false,
-        Metadata = Model.ReportingYearOptions
-    };
-
-    var statuses = new FilterGroup
-    {
-        Id = "ReportingStatusFilter",
-        Group = "st",
-        Label = "Reporting status",
-        Expanded = false,
-        Metadata = Model.ReportingStatusOptions
-    };
-}
 
 <a id="ClearFilters" href="search-results?search=@(Model.search)">Clear all filters</a>
 
@@ -45,19 +7,19 @@
 
 <div class="filter-divider"></div>
 
-<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="size"/>
+<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="Model.SizeFilterGroup"/>
 
 <div class="filter-divider"></div>
 
-<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="sectors"/>
+<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="Model.SectorFilterGroup"/>
 
 <div class="filter-divider"></div>
 
-<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="years"/>
+<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="Model.ReportingYearFilterGroup"/>
 
 <div class="filter-divider"></div>
 
-<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="statuses"/>
+<partial name="~/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml" model="Model.ReportingStatusFilterGroup"/>
 
 <div class="filter-divider"></div>
 

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -64,6 +64,15 @@
                 //$atomAutodiscoveryLink: $atomAutodiscoveryLink,
                 onRefresh: function () {
                     $("#AddAllOrgsToCompare").toggle();
+                },
+                GATrackFilters: {
+                    category: "Search filters",
+                    filters: [
+                        @Html.Raw(Json.Serialize(Model.SizeFilterGroup)), 
+                        @Html.Raw(Json.Serialize(Model.SectorFilterGroup)), 
+                        @Html.Raw(Json.Serialize(Model.ReportingYearFilterGroup)), 
+                        @Html.Raw(Json.Serialize(Model.ReportingStatusFilterGroup))
+                        ]
                 }
             });
 

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -52,6 +52,8 @@
 
             //Keep comparison basket within viewport
             GOVUK.stickAtTopWhenScrolling.init();
+            
+            let serializedModel = @Html.Raw(Json.Serialize(Model));
 
             new GOVUK.LiveSearch({
                 formId: "FinderForm",
@@ -59,13 +61,14 @@
                 onRefresh: function () {
                     $("#AddAllOrgsToCompare").toggle();
                 },
-                GATrackFilters: {
+                isTrackingFilters: true,
+                filterInfo: {
                     category: "Search filters",
-                    filters: [
-                        @Html.Raw(Json.Serialize(Model.SizeFilterGroup)), 
-                        @Html.Raw(Json.Serialize(Model.SectorFilterGroup)), 
-                        @Html.Raw(Json.Serialize(Model.ReportingYearFilterGroup)), 
-                        @Html.Raw(Json.Serialize(Model.ReportingStatusFilterGroup))
+                    filterGroups: [
+                        serializedModel['SizeFilterGroup'], 
+                        serializedModel['SectorFilterGroup'], 
+                        serializedModel['ReportingYearFilterGroup'], 
+                        serializedModel['ReportingStatusFilterGroup']
                         ]
                 }
             });

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -53,15 +53,9 @@
             //Keep comparison basket within viewport
             GOVUK.stickAtTopWhenScrolling.init();
 
-            // Instantiate an option select for each one found on the page
-            var filters = $('#FinderForm .govuk-option-select').map(function () {
-                return new GOVUK.OptionSelect({ $el: $(this) });
-            });
-
             new GOVUK.LiveSearch({
                 formId: "FinderForm",
                 $results: $('.js-live-search-results-block'),
-                //$atomAutodiscoveryLink: $atomAutodiscoveryLink,
                 onRefresh: function () {
                     $("#AddAllOrgsToCompare").toggle();
                 },
@@ -84,8 +78,6 @@
                     window.location.href = '/error/1146';
                 }
             });
-
         }());
-
     </script>
 }

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -53,7 +53,7 @@
             //Keep comparison basket within viewport
             GOVUK.stickAtTopWhenScrolling.init();
             
-            let serializedModel = @Html.Raw(Json.Serialize(Model));
+            let serializedModel = @Json.Serialize(Model);
 
             new GOVUK.LiveSearch({
                 formId: "FinderForm",


### PR DESCRIPTION
T - I've used the Google Analytics Debugger Chrome extension to check if the event were being sent and their properties and it all look good.
R - Low risk, since it doesn't affect the user. 
D - I'll add a page on Swiki about the GA setup.