### PR TITLE
GPG-538: use FormatYearAsReportingPeriod accross the codebase.

### DIFF
--- a/GenderPayGap.Core/Extensions/DateRoutines.cs
+++ b/GenderPayGap.Core/Extensions/DateRoutines.cs
@@ -198,11 +198,5 @@ namespace GenderPayGap.Extensions
 
             return defaultMaxDateTime ? DateTime.MaxValue : DateTime.MinValue;
         }
-
-        public static int ToTwoDigitYear(this int year)
-        {
-            return new DateTime(year, 1, 1).ToString("yy").ToInt32();
-        }
-
     }
 }

--- a/GenderPayGap.WebUI/Views/Compare/YearTabs.cshtml
+++ b/GenderPayGap.WebUI/Views/Compare/YearTabs.cshtml
@@ -1,5 +1,6 @@
 ﻿@using GenderPayGap.Core
 @using GenderPayGap.Core.Classes
+@using GenderPayGap.Core.Helpers
 @model CompareViewModel
 @{
     int endYear = SectorTypes.Private.GetAccountingStartDate().Year;
@@ -18,7 +19,7 @@
         {
             <li class="govuk-tabs__list-item @(Model.Year == year ? "govuk-tabs__list-item--selected" : "")">
                 <a class="govuk-tabs__tab" href="@Url.Action(nameof(CompareController.CompareEmployers), "Compare", new {year})">
-                    @year/@((year + 1).ToTwoDigitYear())
+                    @(ReportingYearsHelper.FormatYearAsReportingPeriod(year, "/"))
                 </a>
             </li>
         }

--- a/GenderPayGap.WebUI/Views/Scope/ConfirmScope.cshtml
+++ b/GenderPayGap.WebUI/Views/Scope/ConfirmScope.cshtml
@@ -1,6 +1,7 @@
 ﻿@using GovUkDesignSystem.GovUkDesignSystemComponents
 @using GovUkDesignSystem
 @using GenderPayGap.Core
+@using GenderPayGap.Core.Helpers
 @using GenderPayGap.WebUI.Classes.Formatters
 @using GenderPayGap.WebUI.Models.ScopeNew
 @using GenderPayGap.WebUI.Models.Shared.Patterns
@@ -13,7 +14,7 @@
 
 @{
     string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
-    string reportingYearsString = Model.ReportingYear.Year + "/" + (Model.ReportingYear.Year + 1).ToString().Substring(2, 2);
+    string reportingYearsString = ReportingYearsHelper.FormatYearAsReportingPeriod(Model.ReportingYear.Year, "/");
     string whyOutOfScopeFormatted = Model.WhyOutOfScope == WhyOutOfScope.Under250 ? "My employer had a headcount less than 250 employees on our snapshot date of " + new GDSDateFormatter(Model.ReportingYear).FullStartDate
         : "Other: " + Model.WhyOutOfScopeDetails;
     var breadcrumbModel = new ManageOrganisationBreadcrumbs 

--- a/GenderPayGap.WebUI/Views/Scope/OutOfScopeQuestions.cshtml
+++ b/GenderPayGap.WebUI/Views/Scope/OutOfScopeQuestions.cshtml
@@ -4,6 +4,7 @@
 @using GenderPayGap.WebUI.Controllers.SendFeedback
 @using GenderPayGap.WebUI.Models.ScopeNew
 @using GenderPayGap.Core
+@using GenderPayGap.Core.Helpers
 @using GenderPayGap.WebUI.Models.Shared.Patterns
 @model GenderPayGap.WebUI.Models.ScopeNew.ScopeViewModel
 
@@ -14,7 +15,7 @@
 
 @{
     string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
-    string reportingYearsString = Model.ReportingYear.Year + "/" + (Model.ReportingYear.Year + 1).ToString().Substring(2, 2);
+    string reportingYearsString = ReportingYearsHelper.FormatYearAsReportingPeriod(Model.ReportingYear.Year, "/");
     var breadcrumbModel = new ManageOrganisationBreadcrumbs 
     { 
         OrganisationName = Model.Organisation.OrganisationName, 

--- a/GenderPayGap.WebUI/Views/Submit/DraftComplete.cshtml
+++ b/GenderPayGap.WebUI/Views/Submit/DraftComplete.cshtml
@@ -1,4 +1,5 @@
 ﻿@using GenderPayGap.WebUI.Controllers.Guidance
+@using GenderPayGap.Core.Helpers
 @model GenderPayGap.WebUI.BusinessLogic.Models.Submit.ReturnViewModel
 <div class="grid-row">
     <div class="column-two-thirds">
@@ -9,7 +10,7 @@
 
             @await Html.CustomValidationSummaryAsync()
             <div class="govuk-box-highlight">
-                <h1 class="bold-large">You've saved a draft of your gender pay gap data for @(Model.AccountingDate.Year)/@(Model.AccountingDate.AddYears(1).Year.ToTwoDigitYear())</h1>
+                <h1 class="bold-large">You've saved a draft of your gender pay gap data for @(ReportingYearsHelper.FormatYearAsReportingPeriod(Model.AccountingDate.Year, "/"))</h1>
             </div>
             <a class="govuk-button" href="@Url.Action("ManageOrganisationsGet", "ManageOrganisations")">Continue</a>
         }


### PR DESCRIPTION
T - I've tested one of the changes by doing the following: go the homepage, click "search and compare" in the navbar", add a few employers for comparison, click "view comparison" check that the tab titles have the right date format e.g. 2019/2020. This tests the changes to the YearTabs.cshtml file. I'm not sure how to test the changes ConfirmScope.cshtml, OutOfScopeQuestions.cshtml and DraftComplete.cshtml.
R - There might be a few places missing. I haven't tested three of the changed files, there might be issues there.
D - none