### PR TITLE
Fix ErrorController default action bug and redirect to /error if Ajax…

### DIFF
--- a/GenderPayGap.WebUI/Controllers/ErrorController.cs
+++ b/GenderPayGap.WebUI/Controllers/ErrorController.cs
@@ -29,7 +29,7 @@ namespace GenderPayGap.WebUI.Controllers
         [Route("/error/{errorCode?}")]
         public IActionResult Default(int errorCode = 500)
         {
-            if (errorCode == 0)
+            if (errorCode == 0 || !Enum.IsDefined(typeof(System.Net.HttpStatusCode), errorCode))
             {
                 if (Response.StatusCode.Between(400, 599))
                 {

--- a/GenderPayGap.WebUI/Scripts/Application/Ajaxify.js
+++ b/GenderPayGap.WebUI/Scripts/Application/Ajaxify.js
@@ -118,7 +118,7 @@ Errors:
                 onError(requestObject, error, errorThrown);
             }
             else {
-                window.location = '/error/1146';
+                window.location = '/error';
             }
         }).complete(function () {
             //Ensable all other ajaxified buttons

--- a/GenderPayGap.WebUI/Scripts/Application/LiveSearch.js
+++ b/GenderPayGap.WebUI/Scripts/Application/LiveSearch.js
@@ -111,7 +111,7 @@
             liveSearch.displayResults(response, this.searchState);
             liveSearch.clearLoadingIndicator();
         }).error(function () {
-            window.location = '/error/1146';
+            window.location = '/error';
         });
     };
 

--- a/GenderPayGap.WebUI/Views/Compare/CompareEmployers.cshtml
+++ b/GenderPayGap.WebUI/Views/Compare/CompareEmployers.cshtml
@@ -94,7 +94,7 @@
                     GOVUK.stickAtTopWhenScrolling.init();
                 },
                 onError: function (errorCode, error, errorThrown) {
-                    window.location.href = '/error/1146';
+                    window.location.href = '/error';
                 }
             });
 

--- a/GenderPayGap.WebUI/Views/ReportingStepByStep/Step1Task2.cshtml
+++ b/GenderPayGap.WebUI/Views/ReportingStepByStep/Step1Task2.cshtml
@@ -83,7 +83,7 @@
                     GOVUK.stickAtTopWhenScrolling.init();
                 },
                 onError: function(errorCode, error, errorThrown) {
-                    window.location.href = '/error/1146';
+                    window.location.href = '/error';
                 }
             });
 

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -193,7 +193,7 @@
 
             new GOVUK.Ajaxify({
                 onError: function(errorCode, error, errorThrown) {
-                    window.location.href = '/error/1146';
+                    window.location.href = '/error';
                 }
             });
         }());

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Report.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Report.cshtml
@@ -134,7 +134,7 @@
 
             new GOVUK.Ajaxify({
                 onError: function (errorCode, error, errorThrown) {
-                    window.location.href = '/error/1146';
+                    window.location.href = '/error';
                 }
             });
 

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -78,7 +78,7 @@
                     GOVUK.stickAtTopWhenScrolling.init();
                 },
                 onError: function (errorCode, error, errorThrown) {
-                    window.location.href = '/error/1146';
+                    window.location.href = '/error';
                 }
             });
         }());


### PR DESCRIPTION
… request fails

See ticket [GPG-763](https://technologyprogramme.atlassian.net/browse/GPG-763)

Issues
1. /error/errorCode request fails with 502 Bad Gateway if the code is not a valid status code.
2. User is redirected to /error/1146 if Ajax request fails

Acceptance criteria
1. /error/errorCode returns the "Something's gone wrong" page (500 error) if errorCode is not a valid HTTP status code
2. User is redirected to /error if Ajax request fails