### PR TITLE
GPG-712 Late submission fix

### DIFF
--- a/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
+++ b/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
@@ -48,7 +48,7 @@ namespace GenderPayGap.Core.Helpers
             int mostRecentReportingYear = Global.FirstReportingYear;
             foreach (int year in from year in GetReportingYears()
                 let accountingDate = SectorTypes.Private.GetAccountingStartDate(year)
-                where GetDeadlineForAccountingDate(accountingDate) < VirtualDateTime.Now
+                where DeadlineForAccountingDateHasPassed(accountingDate)
                 select year)
             {
                 mostRecentReportingYear = year;
@@ -56,6 +56,11 @@ namespace GenderPayGap.Core.Helpers
             }
 
             return mostRecentReportingYear;
+        }
+
+        public static bool DeadlineForAccountingDateHasPassed(DateTime accountingDate)
+        {
+            return GetDeadlineForAccountingDate(accountingDate) < VirtualDateTime.Now;
         }
 
     }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Services/Submission/IsCurrentSnapshotYearTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Services/Submission/IsCurrentSnapshotYearTests.cs
@@ -31,10 +31,6 @@ namespace GenderPayGap.Tests.Services.SubmissionService
         [TestCase(SectorTypes.Public, 2018)]
         public void ReturnsFalseWhenNotCurrentYear(SectorTypes testSector, int testYear)
         {
-            // Arrange
-            DateTime testSnapshotDate = testSector.GetAccountingStartDate();
-            var expectCalledGetSnapshotDate = false;
-
             // Mocks
             var mockService = new Mock<WebUI.Classes.Services.SubmissionService>(
                 mockDataRepo.Object,
@@ -42,19 +38,10 @@ namespace GenderPayGap.Tests.Services.SubmissionService
                 mockDraftFileBL.Object);
             mockService.CallBase = true;
 
-            // Override GetPreviousReportingStartDate and return expectedYear
-            mockService.Setup(ss => ss.GetSnapshotDate(It.IsIn(testSector), It.IsAny<int>()))
-                .Returns(
-                    () => {
-                        expectCalledGetSnapshotDate = true;
-                        return testSnapshotDate;
-                    });
-
             // Assert
             WebUI.Classes.Services.SubmissionService testService = mockService.Object;
             bool actual = testService.IsCurrentSnapshotYear(testSector, testYear);
 
-            Assert.IsTrue(expectCalledGetSnapshotDate, "Expected to call GetSnapshotDate");
             Assert.IsFalse(actual, "Expected IsCurrentSnapshotYear to return true");
         }
 

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Services/Submission/IsHistoricSnapshotYearTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Services/Submission/IsHistoricSnapshotYearTests.cs
@@ -31,10 +31,6 @@ namespace GenderPayGap.Tests.Services.SubmissionService
         [TestCase(SectorTypes.Public, 2018)]
         public void ReturnsTrueForHistoricYears(SectorTypes testSector, int testHistoricYear)
         {
-            // Arrange
-            DateTime testSnapshotDate = testSector.GetAccountingStartDate();
-            var expectCalledGetSnapshotDate = false;
-
             // Mocks
             var mockService = new Mock<WebUI.Classes.Services.SubmissionService>(
                 mockDataRepo.Object,
@@ -42,19 +38,10 @@ namespace GenderPayGap.Tests.Services.SubmissionService
                 mockDraftFileBL.Object);
             mockService.CallBase = true;
 
-            // Override GetPreviousReportingStartDate and return expectedYear
-            mockService.Setup(ss => ss.GetSnapshotDate(It.IsIn(testSector), It.IsAny<int>()))
-                .Returns(
-                    () => {
-                        expectCalledGetSnapshotDate = true;
-                        return testSnapshotDate;
-                    });
-
             // Assert
             WebUI.Classes.Services.SubmissionService testService = mockService.Object;
             bool actual = testService.IsHistoricSnapshotYear(testSector, testHistoricYear);
 
-            Assert.IsTrue(expectCalledGetSnapshotDate, "Expected to call GetSnapshotDate");
             Assert.IsTrue(actual, "Expected IsHistoricSnapshotYear to return true");
         }
 
@@ -65,7 +52,6 @@ namespace GenderPayGap.Tests.Services.SubmissionService
             // Arrange
             DateTime testSnapshotDate = testSector.GetAccountingStartDate();
             int testHistoricYear = testSnapshotDate.Year;
-            var expectCalledGetSnapshotDate = false;
 
             // Mocks
             var mockService = new Mock<WebUI.Classes.Services.SubmissionService>(
@@ -74,19 +60,10 @@ namespace GenderPayGap.Tests.Services.SubmissionService
                 mockDraftFileBL.Object);
             mockService.CallBase = true;
 
-            // Override GetPreviousReportingStartDate and return expectedYear
-            mockService.Setup(ss => ss.GetSnapshotDate(It.IsIn(testSector), It.IsAny<int>()))
-                .Returns(
-                    () => {
-                        expectCalledGetSnapshotDate = true;
-                        return testSnapshotDate;
-                    });
-
             // Assert
             WebUI.Classes.Services.SubmissionService testService = mockService.Object;
             bool actual = testService.IsHistoricSnapshotYear(testSector, testHistoricYear);
 
-            Assert.IsTrue(expectCalledGetSnapshotDate, "Expected to call GetSnapshotDate");
             Assert.IsFalse(actual, "Expected IsHistoricSnapshotYear to return false");
         }
 

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Services/SubmissionServiceTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Services/SubmissionServiceTests.cs
@@ -547,7 +547,7 @@ namespace GenderPayGap.Tests
         [Description("IsCurrentSnapshotYear: Returns false When SnapshotYear is not the Current Year")]
         public void IsCurrentSnapshotYear_Returns_false_When_SnapshotYear_is_not_the_Current_Year()
         {
-            var currentSnapshotYear = 2001;
+            var currentSnapshotYear = VirtualDateTime.Now.Year;
             var testSnapshotYear = 1999;
 
             // Mocks
@@ -556,10 +556,6 @@ namespace GenderPayGap.Tests
                 mockScopeBL.Object,
                 _mockDraftFileBL.Object);
             mockService.CallBase = true;
-
-            // Override GetCurrentReportingStartDate and return expectedYear
-            mockService.Setup(ss => ss.GetSnapshotDate(It.IsIn(SectorTypes.Private), It.IsIn(testSnapshotYear)))
-                .Returns(new DateTime(currentSnapshotYear, 4, 5));
 
             // Sanity checks
             Expect(currentSnapshotYear != testSnapshotYear, "SanityCheck: curReportingYear should not equal the testReportingStartYear");
@@ -573,8 +569,8 @@ namespace GenderPayGap.Tests
         [Description("IsCurrentSnapshotYear: Returns true When SnapshotYear is the Current Year")]
         public void IsCurrentSnapshotYear_Returns_true_When_SnapshotYear_is_the_Current_Year()
         {
-            var currentSnapshotYear = 2001;
-            var testSnapshotYear = 2001;
+            var currentSnapshotYear = VirtualDateTime.Now.Year;
+            var testSnapshotYear = VirtualDateTime.Now.Year;
 
             // Mocks
             var mockService = new Mock<SubmissionService>(
@@ -582,10 +578,6 @@ namespace GenderPayGap.Tests
                 mockScopeBL.Object,
                 _mockDraftFileBL.Object);
             mockService.CallBase = true;
-
-            // Override GetReportingStartDate and return expectedYear
-            mockService.Setup(ss => ss.GetSnapshotDate(It.IsAny<SectorTypes>(), It.IsAny<int>()))
-                .Returns(new DateTime(currentSnapshotYear, 4, 5));
 
             // Sanity checks
             Expect(currentSnapshotYear == testSnapshotYear, "SanityCheck: curReportingYear should equal the testReportingStartYear");

--- a/GenderPayGap.WebUI/Classes/Presentation/SubmissionService.cs
+++ b/GenderPayGap.WebUI/Classes/Presentation/SubmissionService.cs
@@ -73,7 +73,7 @@ namespace GenderPayGap.WebUI.Classes.Services
 
         public bool IsHistoricSnapshotYear(SectorTypes sector, int snapshotYear)
         {
-            return ReportingYearsHelper.DeadlineForAccountingDateHasPassed(sector.GetAccountingStartDate(snapshotYear));
+            return !IsCurrentSnapshotYear(sector, snapshotYear);
         }
 
         public virtual bool IsValidSnapshotYear(int snapshotYear)

--- a/GenderPayGap.WebUI/Classes/Presentation/SubmissionService.cs
+++ b/GenderPayGap.WebUI/Classes/Presentation/SubmissionService.cs
@@ -6,6 +6,7 @@ using System.Security.Authentication;
 using System.Threading.Tasks;
 using GenderPayGap.Core;
 using GenderPayGap.Core.Classes;
+using GenderPayGap.Core.Helpers;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Extensions;
@@ -67,20 +68,12 @@ namespace GenderPayGap.WebUI.Classes.Services
 
         public bool IsCurrentSnapshotYear(SectorTypes sector, int snapshotYear)
         {
-            // Get the current reporting year
-            int currentReportingStartYear = GetCurrentSnapshotDate(sector).Year;
-
-            // Return year compare result
-            return snapshotYear == currentReportingStartYear;
+            return !ReportingYearsHelper.DeadlineForAccountingDateHasPassed(sector.GetAccountingStartDate(snapshotYear));
         }
 
         public bool IsHistoricSnapshotYear(SectorTypes sector, int snapshotYear)
         {
-            // Get the previous reporting year
-            int currentReportingStartYear = GetCurrentSnapshotDate(sector).Year;
-
-            // Return year compare result
-            return snapshotYear < currentReportingStartYear;
+            return ReportingYearsHelper.DeadlineForAccountingDateHasPassed(sector.GetAccountingStartDate(snapshotYear));
         }
 
         public virtual bool IsValidSnapshotYear(int snapshotYear)

--- a/GenderPayGap.WebUI/Controllers/OrganisationController.cs
+++ b/GenderPayGap.WebUI/Controllers/OrganisationController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GenderPayGap.Core;
 using GenderPayGap.Core.Classes;
+using GenderPayGap.Core.Helpers;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Core.Models;
 using GenderPayGap.Core.Models.HttpResultModels;
@@ -321,7 +322,7 @@ namespace GenderPayGap.WebUI.Controllers
             SectorTypes sectorType = userOrg.Organisation.SectorType;
 
             // Determine if this is for the previous reporting year
-            bool isPrevReportingYear = SubmissionService.IsCurrentSnapshotYear(sectorType, reportingStartYear) == false;
+            bool isPrevReportingYear = SubmissionService.IsHistoricSnapshotYear(sectorType, reportingStartYear);
 
             // Set the reporting session globals
             ReportingOrganisationId = organisationId;


### PR DESCRIPTION
**Issue:**
After removing 2020 from `ReportingStartYearsToExcludeFromLateFlagEnforcement` reports were marked as late (even though the deadline for 2020 was in October)

**Fix:**
Updated the late reports logic: check whether the deadline has already passed or not.

I've already tested this on the load test environment. [Here](https://technologyprogramme.atlassian.net/browse/GPG-712) are all the things that I've checked.