### PR TITLE
GPG-738 Check if GA has been initialised before sending event

### DIFF
--- a/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_Tracking.cshtml
@@ -45,8 +45,8 @@
     function sendGpgEvent(Event) {
         Event.hitType = 'event';
         
-        // Only send GA event if required fields present
-        if (Event.eventCategory && Event.eventAction) {
+        // Only send GA event if GA is initialised and the required fields are present
+        if (ga && Event.eventCategory && Event.eventAction) {
             ga('send', Event);
         }
     }


### PR DESCRIPTION
We need to check if GA has been initialised before trying to send an event. Error:
```
Uncaught ReferenceError: ga is not defined
    at sendGpgEvent (search-results?t=1&search=&orderBy=relevance:85)
    at n.sendFilterEventToGA (application.min.js?v=915E15zCJnZebMOgwW5cwgDSh_VB5EeEmuhHD-28_Kg:1)
    at n.updateResults (application.min.js?v=915E15zCJnZebMOgwW5cwgDSh_VB5EeEmuhHD-28_Kg:1)
    at n.formChange (application.min.js?v=915E15zCJnZebMOgwW5cwgDSh_VB5EeEmuhHD-28_Kg:1)
    at HTMLFormElement.dispatch (jquery-1.11.3.min.js:2)
    at HTMLFormElement.v.handle (jquery-1.11.3.min.js:2)
```