### PR TITLE
GPG-761: remove duplicate filter title

### DIFF
--- a/GenderPayGap.WebUI/Content/Site.css
+++ b/GenderPayGap.WebUI/Content/Site.css
@@ -663,6 +663,10 @@ input[type=submit] {
     height: 20px;
 }
 
+.finder .govuk-option-select .options-container .option-select-legend {
+    display: none;
+}
+
 .js-enabled .finder .govuk-option-select {
     padding: 0 0 1px 0;
     /* styles for collapsibleness. .js-collapsible is added by the javascript if the browser is not ie6/7 in which case these don't collapse */

--- a/GenderPayGap.WebUI/Content/Site.css
+++ b/GenderPayGap.WebUI/Content/Site.css
@@ -663,10 +663,6 @@ input[type=submit] {
     height: 20px;
 }
 
-.finder .govuk-option-select .options-container .option-select-legend {
-    display: none;
-}
-
 .js-enabled .finder .govuk-option-select {
     padding: 0 0 1px 0;
     /* styles for collapsibleness. .js-collapsible is added by the javascript if the browser is not ie6/7 in which case these don't collapse */

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
@@ -12,7 +12,7 @@
     <div class="options-container" id="@(Model.Id)" aria-label="@(Model.Label) filter" style="max-height: @(maxHeight)">
         <div class="js-auto-height-inner">
             <fieldset>
-                <legend>@(Model.Label)</legend>
+                <legend class="option-select-legend">@(Model.Label)</legend>
                 @foreach (OptionSelect item in Model.Metadata)
                 {
                     <label for="@(item.Id)" @(item.Disabled ? "disabled" : string.Empty)>

--- a/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/Parts/Facets/OptionSelect.cshtml
@@ -12,7 +12,7 @@
     <div class="options-container" id="@(Model.Id)" aria-label="@(Model.Label) filter" style="max-height: @(maxHeight)">
         <div class="js-auto-height-inner">
             <fieldset>
-                <legend class="option-select-legend">@(Model.Label)</legend>
+                <legend class="govuk-visually-hidden">@(Model.Label)</legend>
                 @foreach (OptionSelect item in Model.Metadata)
                 {
                     <label for="@(item.Id)" @(item.Disabled ? "disabled" : string.Empty)>


### PR DESCRIPTION
T- I went to /viewing/search-results?t=1&search=&orderBy=relevance and checked that the filter titles don't appear twice. I also tested with NVA screen reader and it read the filter titles correctly.
R- Very low risks. Maybe we should remove the legend, since it might be unnecessary.
D- No need.