### PR TITLE
GPG-752 prometheus app update

### DIFF
--- a/Infrastructure/gpg-metrics/gpg-prometheus/manifest.yml
+++ b/Infrastructure/gpg-metrics/gpg-prometheus/manifest.yml
@@ -7,3 +7,6 @@ applications:
 
     buildpacks:
       - https://github.com/alphagov/prometheus-buildpack.git
+
+    env:
+      PROMETHEUS_FLAGS: --storage.tsdb.retention.time=5d

--- a/Infrastructure/gpg-metrics/gpg-prometheus/manifest.yml
+++ b/Infrastructure/gpg-metrics/gpg-prometheus/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: gpg-prometheus
-    memory: 512M
+    memory: 3G
     routes:
       - route: gpg-prometheus.apps.internal
 


### PR DESCRIPTION
We've got the high disk utilisation alerts again...

As I expected, we could safely decrease the retention time as we don't use the in memory database but an external one.
Added the command I've run to [this documentation](https://technologyprogramme.atlassian.net/wiki/spaces/GPGS/pages/1437696070/Metrics)

**Note:** This has already been deployed. The app is working as expected. 