### PR TITLE
GPG-771: fix non expandable filters bug.

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/Finder/SearchResults.cshtml
@@ -52,6 +52,12 @@
 
             //Keep comparison basket within viewport
             GOVUK.stickAtTopWhenScrolling.init();
+
+            // Instantiate an option select for each one found on the page
+            // This will make each filter group expandable and add a counter of selected filters
+            $('#FinderForm .govuk-option-select').map(function () {
+                new GOVUK.OptionSelect({ $el: $(this) });
+            });
             
             let serializedModel = @Json.Serialize(Model);
 


### PR DESCRIPTION
T - Went to the viewing page. Checked that the filters were expandable. Selected a few filters, and checked that the counter under the filter group title were udpated.
R - Very low. This is code that already existed but had been wrongly removed (by me 😅)
D - no need.