### PR TITLE
GPG-752 Fixed csv negative values bug

### DIFF
--- a/GenderPayGap.Core/Helpers/CsvWriter.cs
+++ b/GenderPayGap.Core/Helpers/CsvWriter.cs
@@ -10,6 +10,13 @@ namespace GenderPayGap.Core.Helpers
     public static class CsvWriter
     {
 
+        /*
+         * The default injection characters are: '=', '@', '+', '-'
+         * We ignore '-' because we don't want the negative figures to be sanitized (i.e., prepended with a tab character)
+         * We sanitize manually the other fields that start with '-' using the CustomConverter
+         */
+        private static readonly char[] InjectionCharacters = {'=', '@', '+'};
+
         public static T Write<T>(Func<MemoryStream, StreamReader, StreamWriter, CsvHelper.CsvWriter, T> write)
         {
             var config = new CsvConfiguration(CultureInfo.CurrentCulture)
@@ -25,13 +32,6 @@ namespace GenderPayGap.Core.Helpers
                 return write(memoryStream, streamReader, streamWriter, csvWriter);
             }
         }
-
-        /*
-         * The default injection characters are: '=', '@', '+', '-'
-         * We ignore '-' because we don't want the negative figures to be sanitized (i.e., prepended with a tab character)
-         * We sanitize manually the other fields that start with '-' using the CustomConverter
-         */
-        private static readonly char[] InjectionCharacters = {'=', '@', '+'};
 
         private class CustomConverter : DefaultTypeConverter
         {

--- a/GenderPayGap.Core/Helpers/CsvWriter.cs
+++ b/GenderPayGap.Core/Helpers/CsvWriter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+
+namespace GenderPayGap.Core.Helpers
+{
+    public static class CsvWriter
+    {
+
+        public static T Write<T>(Func<MemoryStream, StreamReader, StreamWriter, CsvHelper.CsvWriter, T> write)
+        {
+            var config = new CsvConfiguration(CultureInfo.CurrentCulture)
+            {
+                InjectionCharacters = InjectionCharacters, SanitizeForInjection = true
+            };
+            using (var memoryStream = new MemoryStream())
+            using (var streamReader = new StreamReader(memoryStream))
+            using (var streamWriter = new StreamWriter(memoryStream))
+            using (var csvWriter = new CsvHelper.CsvWriter(streamWriter, config))
+            {
+                csvWriter.Configuration.TypeConverterCache.AddConverter<string>(new CustomConverter());
+                return write(memoryStream, streamReader, streamWriter, csvWriter);
+            }
+        }
+
+        /*
+         * The default injection characters are: '=', '@', '+', '-'
+         * We ignore '-' because we don't want the negative figures to be sanitized (i.e., prepended with a tab character)
+         * We sanitize manually the other fields that start with '-' using the CustomConverter
+         */
+        private static readonly char[] InjectionCharacters = {'=', '@', '+'};
+
+        private class CustomConverter : DefaultTypeConverter
+        {
+
+            public override string ConvertToString(object value,
+                IWriterRow row,
+                MemberMapData memberMapData)
+            {
+                if (HasToBeSanitized(value))
+                {
+                    return '\t' + value.ToString();
+                }
+
+                return base.ConvertToString(value, row, memberMapData);
+            }
+
+            private bool HasToBeSanitized(object value)
+            {
+                return value is string s && !decimal.TryParse(s, out _) && s.StartsWith('-');
+            }
+
+        }
+
+    }
+}

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CoreTests/Helpers/CsvWriterTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/CoreTests/Helpers/CsvWriterTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.IO;
+using GenderPayGap.Core.Helpers;
+using NUnit.Framework;
+
+namespace GenderPayGap.Core.Tests.Helpers
+{
+    [TestFixture]
+    public class CsvWriterTests
+    {
+
+        [TestCase('-')]
+        [TestCase('+')]
+        [TestCase('@')]
+        [TestCase('=')]
+        public void CsvWriter_Sanitizes_Strings_That_Start_With(char character)
+        {
+            // Arrange
+            var value = character + "test";
+            var expectedCsvRow = "\t" + character + "test\r\n";
+
+            // Act
+            var actualCsvRow = CsvWriter.Write(WriteValue(value));
+
+            // Assert
+            Assert.AreEqual(expectedCsvRow, actualCsvRow);
+        }
+
+        [Test]
+        public void CsvWriter_Does_Not_Sanitize_Negative_Values()
+        {
+            // Arrange
+            var value = -10.2;
+            var expectedCsvRow = "-10.2\r\n";
+
+            // Act
+            var actualCsvRow = CsvWriter.Write(WriteValue(value));
+
+            // Assert
+            Assert.AreEqual(expectedCsvRow, actualCsvRow);
+        }
+
+        [Test]
+        public void CsvWriter_Does_Not_Sanitize_Strings_That_Do_Not_Start_With_Injection_Character()
+        {
+            // Arrange
+            var value = "Test - string that doesn't start with an injection character";
+            var expectedCsvRow = "Test - string that doesn't start with an injection character\r\n";
+
+            // Act
+            var actualCsvRow = CsvWriter.Write(WriteValue(value));
+
+            // Assert
+            Assert.AreEqual(expectedCsvRow, actualCsvRow);
+        }
+
+        private Func<MemoryStream, StreamReader, StreamWriter, CsvHelper.CsvWriter, string> WriteValue<T>(T value)
+        {
+            return (memoryStream, streamReader, streamWriter, csvWriter) =>
+            {
+                csvWriter.WriteField(value);
+                csvWriter.NextRecord();
+                streamWriter.Flush();
+                memoryStream.Position = 0;
+                return streamReader.ReadToEnd();
+            };
+        }
+
+    }
+}

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminFeedbackController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminFeedbackController.cs
@@ -1,9 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using CsvHelper;
-using CsvHelper.Configuration;
 using GenderPayGap.Core;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database.Models;
@@ -55,19 +51,7 @@ namespace GenderPayGap.WebUI.Controllers
                 feedback = feedback.Where(f => f.FeedbackStatus == FeedbackStatus.NotSpam);
             }
 
-            var memoryStream = new MemoryStream();
-            using (var writer = new StreamWriter(memoryStream))
-            {
-                var config = new CsvConfiguration(CultureInfo.CurrentCulture) { SanitizeForInjection = true };
-                using (var csv = new CsvWriter(writer, config))
-                {
-                    csv.WriteRecords(feedback.ToList());
-                }
-            }
-
-            var fileContentResult = new FileContentResult(memoryStream.GetBuffer(), "text/csv") {FileDownloadName = "Feedback.csv"};
-
-            return fileContentResult;
+            return DownloadHelper.CreateCsvDownload(feedback, "Feedback.csv");
         }
 
     }


### PR DESCRIPTION
See ticket [GPG-768](https://technologyprogramme.atlassian.net/browse/GPG-768)

We have the following CSV files:
- Admin downloads
- Admin feedback download
- Comparison results
- Public facing files

I excluded '-' from the injection characters as the injection function cannot be configured by us. However, we can add a custom type converter. Here all the values that start with '-' and are not decimals (we have only decimal figures) are prepended with a tab.

All the CSV files should be sanitized. Therefore, I added a custom `CsvWriter` and used it everywhere.

Added tests. Apart from that I've also checked the AC pass for all the files apart from the public facing ones locally. The public facing files are built by a background job - we don't run them locally. I will make sure I'll test this once deployed to the dev environment.
