### PR TITLE
GPG-751 Fixed incorrect date bug

### DIFF
--- a/GenderPayGap.Core/Extensions/VirtualDateTime.cs
+++ b/GenderPayGap.Core/Extensions/VirtualDateTime.cs
@@ -7,6 +7,7 @@ namespace GenderPayGap.Extensions
 
         private static TimeSpan offsetCurrentDateTimeForSite = TimeSpan.Zero;
 
+        // This uses the system timezone
         public static DateTime Now => DateTime.Now.Add(offsetCurrentDateTimeForSite);
 
         public static DateTime UtcNow => DateTime.UtcNow.Add(offsetCurrentDateTimeForSite);

--- a/GenderPayGap.WebUI/Controllers/SendFeedback/FeedbackController.cs
+++ b/GenderPayGap.WebUI/Controllers/SendFeedback/FeedbackController.cs
@@ -5,6 +5,7 @@ using GenderPayGap.Core.Classes.Logger;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Database.Models;
+using GenderPayGap.Extensions;
 using GenderPayGap.WebUI.Classes;
 using GovUkDesignSystem.Parsers;
 using Microsoft.AspNetCore.Mvc;
@@ -112,7 +113,9 @@ namespace GenderPayGap.WebUI.Controllers.SendFeedback
 
                 Details = TruncateDetails(feedbackViewModel.Details),
                 EmailAddress = feedbackViewModel.EmailAddress,
-                PhoneNumber = feedbackViewModel.PhoneNumber
+                PhoneNumber = feedbackViewModel.PhoneNumber,
+                
+                CreatedDate = VirtualDateTime.Now
             };
         }
 

--- a/GenderPayGap.WebUI/Services/AuditLogger.cs
+++ b/GenderPayGap.WebUI/Services/AuditLogger.cs
@@ -6,6 +6,7 @@ using GenderPayGap.Core;
 using GenderPayGap.Core.Interfaces;
 using GenderPayGap.Database;
 using GenderPayGap.Database.Models;
+using GenderPayGap.Extensions;
 using GenderPayGap.WebUI.Helpers;
 
 namespace GenderPayGap.WebUI.Services
@@ -106,7 +107,8 @@ namespace GenderPayGap.WebUI.Services
                     OriginalUser = users.OriginalUser,
                     ImpersonatedUser = users.ImpersonatedUser,
                     Organisation = organisation,
-                    Details = details
+                    Details = details,
+                    CreatedDate = VirtualDateTime.Now
                 });
 
             dataRepository.SaveChanges();

--- a/GenderPayGap.WebUI/manifest-gpg-dev.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-dev.yml
@@ -9,3 +9,5 @@ applications:
    health-check-http-endpoint: /health-check
    health-check-type: http
    timeout: 60
+   env:
+     TZ: Europe/London

--- a/GenderPayGap.WebUI/manifest-gpg-loadtest.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-loadtest.yml
@@ -9,3 +9,5 @@ applications:
    health-check-http-endpoint: /health-check
    health-check-type: http
    timeout: 60
+   env:
+     TZ: Europe/London

--- a/GenderPayGap.WebUI/manifest-gpg-preprod.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-preprod.yml
@@ -9,3 +9,5 @@ applications:
    health-check-http-endpoint: /health-check
    health-check-type: http
    timeout: 60
+   env:
+     TZ: Europe/London

--- a/GenderPayGap.WebUI/manifest-gpg-prod.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-prod.yml
@@ -9,3 +9,5 @@ applications:
    health-check-http-endpoint: /health-check
    health-check-type: http
    timeout: 60
+   env:
+     TZ: Europe/London

--- a/GenderPayGap.WebUI/manifest-gpg-test.yml
+++ b/GenderPayGap.WebUI/manifest-gpg-test.yml
@@ -9,3 +9,5 @@ applications:
    health-check-http-endpoint: /health-check
    health-check-type: http
    timeout: 60
+   env:
+     TZ: Europe/London


### PR DESCRIPTION
The majority of the database tables contain a column for the created date. None of the dates contain the timezone.
 
`VirtualDateTime.Now` uses the system timezone - As this bug hasn't been reported until now, the system timezone must have been "Europe/London" initially. However, now the system timezone is "UTC".
As we can't consider all of the dates (from the db) to be in UTC format, we should change the system timezone. Added an environment variable for setting this.

We use `VirtualDateTime.Now` for all the entries apart from the audit logs and the feedback ones, for these the default value is now() that uses the database timezone. 
We should use "VirtualDateTime.Now" everywhere for consistency.

**Tests:** I deployed this build to the dev environment to test the manifest file change and everything works as expected, the system timezone being Europe/London.