### PR TITLE
GPG-770 Added test for reporting year excluded from late flag enforcement

### DIFF
--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/AppSettings.UnitTests.json
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/AppSettings.UnitTests.json
@@ -1,4 +1,5 @@
 ﻿{
   "AdminEmails": "*@geo.gov.uk",
-  "GEODistributionList": "geo-distribution-list@example.com"
+  "GEODistributionList": "geo-distribution-list@example.com",
+  "ReportingStartYearsToExcludeFromLateFlagEnforcement": "[2019]"
 }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/TestsCommon/TestHelpers/ReturnHelper.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/TestsCommon/TestHelpers/ReturnHelper.cs
@@ -160,5 +160,20 @@ namespace GenderPayGap.Tests.Common.TestHelpers
             return lateReturn;
         }
 
+        public static Return CreateLateReturn(int reportingYear, SectorTypes sector, ScopeStatuses scopeStatus, int modifiedDateOffset)
+        {
+            DateTime snapshotDate = sector.GetAccountingStartDate(reportingYear);
+            DateTime nextSnapshotDate = snapshotDate.AddYears(1);
+            DateTime modifiedDate = nextSnapshotDate.AddDays(modifiedDateOffset);
+
+            Organisation testOrganisation = sector == SectorTypes.Private
+                ? OrganisationHelper.GetPrivateOrganisation()
+                : OrganisationHelper.GetPublicOrganisation();
+
+            OrganisationScope testScope = ScopeHelper.CreateScope(scopeStatus, snapshotDate);
+            
+            return CreateLateReturn(testOrganisation, snapshotDate, modifiedDate, testScope);
+        }
+
     }
 }

--- a/GenderPayGap.WebUI/appsettings.LOCAL.json
+++ b/GenderPayGap.WebUI/appsettings.LOCAL.json
@@ -2,5 +2,6 @@
   "DaysToKeepBackupFiles": 0,
   "GoogleAnalyticsAccountId": "UA-93591336-1",
   "FeatureFlagNewReportingJourney": "true",
-  "FeatureFlagNewManageOrganisationsJourney": "true"
+  "FeatureFlagNewManageOrganisationsJourney": "true",
+  "ReportingStartYearsToExcludeFromLateFlagEnforcement": [2019]
 }

--- a/GenderPayGap.WebUI/appsettings.LOCAL.json
+++ b/GenderPayGap.WebUI/appsettings.LOCAL.json
@@ -3,5 +3,5 @@
   "GoogleAnalyticsAccountId": "UA-93591336-1",
   "FeatureFlagNewReportingJourney": "true",
   "FeatureFlagNewManageOrganisationsJourney": "true",
-  "ReportingStartYearsToExcludeFromLateFlagEnforcement": [2019]
+  "ReportingStartYearsToExcludeFromLateFlagEnforcement": "[2019]"
 }


### PR DESCRIPTION
See ticket [GPG-770](https://technologyprogramme.atlassian.net/browse/GPG-770)

I checked all the AC on the dev environment.
We already have tests for these. I added one test that was missing - check if the report is marked as late if the reporting year is excluded from late flag enforcement.