### PR TITLE
GPG-766: add employer id to csv

### DIFF
--- a/GenderPayGap.Core/Models/DownloadResult.cs
+++ b/GenderPayGap.Core/Models/DownloadResult.cs
@@ -6,7 +6,7 @@ namespace GenderPayGap.Core.Models
     {
 
         public string EmployerName { get; set; }
-        public long OrganisationId { get; set; }
+        public long EmployerId { get; set; }
         public string Address { get; set; }
         public string CompanyNumber { get; set; }
         public string SicCodes { get; set; }

--- a/GenderPayGap.Core/Models/DownloadResult.cs
+++ b/GenderPayGap.Core/Models/DownloadResult.cs
@@ -6,6 +6,7 @@ namespace GenderPayGap.Core.Models
     {
 
         public string EmployerName { get; set; }
+        public long OrganisationId { get; set; }
         public string Address { get; set; }
         public string CompanyNumber { get; set; }
         public string SicCodes { get; set; }

--- a/GenderPayGap.Database/Models/Extensions/Return.cs
+++ b/GenderPayGap.Database/Models/Extensions/Return.cs
@@ -253,7 +253,7 @@ namespace GenderPayGap.Database
         {
             return new DownloadResult {
                 EmployerName = Organisation?.GetName(StatusDate)?.Name ?? Organisation.OrganisationName,
-                OrganisationId = OrganisationId,
+                EmployerId = OrganisationId,
                 Address = Organisation.GetLatestAddress()?.GetAddressString(),
                 CompanyNumber = Organisation?.CompanyNumber,
                 SicCodes = Organisation?.GetSicCodeIdsString(StatusDate, "," + Environment.NewLine),

--- a/GenderPayGap.Database/Models/Extensions/Return.cs
+++ b/GenderPayGap.Database/Models/Extensions/Return.cs
@@ -253,6 +253,7 @@ namespace GenderPayGap.Database
         {
             return new DownloadResult {
                 EmployerName = Organisation?.GetName(StatusDate)?.Name ?? Organisation.OrganisationName,
+                OrganisationId = OrganisationId,
                 Address = Organisation.GetLatestAddress()?.GetAddressString(),
                 CompanyNumber = Organisation?.CompanyNumber,
                 SicCodes = Organisation?.GetSicCodeIdsString(StatusDate, "," + Environment.NewLine),

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/UpdatePublicFacingDownloadFilesJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/UpdatePublicFacingDownloadFilesJob.cs
@@ -45,6 +45,7 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
                 .Include(o => o.OrganisationNames)
                 .Include(o => o.OrganisationAddresses)
                 .Include(o => o.OrganisationSicCodes)
+                .Include(o => o.OrganisationId)
                 .ToList();
 
             CustomLogger.Information($"UpdateDownloadFiles: Loading Returns");

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/UpdatePublicFacingDownloadFilesJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/UpdatePublicFacingDownloadFilesJob.cs
@@ -45,7 +45,6 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
                 .Include(o => o.OrganisationNames)
                 .Include(o => o.OrganisationAddresses)
                 .Include(o => o.OrganisationSicCodes)
-                .Include(o => o.OrganisationId)
                 .ToList();
 
             CustomLogger.Information($"UpdateDownloadFiles: Loading Returns");


### PR DESCRIPTION
This covers [GPG-760](https://technologyprogramme.atlassian.net/browse/GPG-766), which is to add the organisation ID to the CSV file in order to allow researchers to link an organisation over time.

T - Deployed on Dev and did the following: 
1. Logged in as an admin. 
2. Opened [hangfire](https://gender-pay-gap-dev.london.cloudapps.digital/admin/hangfire) 
3. Triggered the UPDATE_PUBLIC_FACING_DOWNLOAD_FILES_JOB. 
4. Went to [downloads page](https://gender-pay-gap-dev.london.cloudapps.digital/viewing/download) 
5. Downloaded all the csv files. 
6. Checked that the second column on each file is titled "EmployerId" 
7. Checked that the employer ids were present and were as expected 
8. Clicked "Search and compare" in the header 
9. Selected a few companies for comparison 
10. Went to the compare page 
11. Clicked "Download data (CSV)" 
12. Checked that the CSV does not contain the EmployerId column.

R - Very low risk. My code assumes the EmployerId always exists. This is a primary key, so that should be ok.
D -  not necessary.