### PR TITLE
GPG-776: add postcode to CSV files.

### DIFF
--- a/GenderPayGap.Core/Models/DownloadResult.cs
+++ b/GenderPayGap.Core/Models/DownloadResult.cs
@@ -8,6 +8,7 @@ namespace GenderPayGap.Core.Models
         public string EmployerName { get; set; }
         public long EmployerId { get; set; }
         public string Address { get; set; }
+        public string PostCode { get; set; }
         public string CompanyNumber { get; set; }
         public string SicCodes { get; set; }
         public decimal DiffMeanHourlyPercent { get; set; }

--- a/GenderPayGap.Database/Models/Extensions/Return.cs
+++ b/GenderPayGap.Database/Models/Extensions/Return.cs
@@ -255,6 +255,7 @@ namespace GenderPayGap.Database
                 EmployerName = Organisation?.GetName(StatusDate)?.Name ?? Organisation.OrganisationName,
                 EmployerId = OrganisationId,
                 Address = Organisation.GetLatestAddress()?.GetAddressString(),
+                PostCode = Organisation.GetLatestAddress()?.PostCode,
                 CompanyNumber = Organisation?.CompanyNumber,
                 SicCodes = Organisation?.GetSicCodeIdsString(StatusDate, "," + Environment.NewLine),
                 DiffMeanHourlyPercent = DiffMeanHourlyPayPercent,


### PR DESCRIPTION
[GPG-776](https://technologyprogramme.atlassian.net/browse/GPG-776), to add the organisation postcode to the CSV files.

T - Deployed on Dev and did the following:

Logged in as an admin.
Opened hangfire
Triggered the UPDATE_PUBLIC_FACING_DOWNLOAD_FILES_JOB.
Went to downloads page
Downloaded all the csv files.
Checked that the fourth column on each file is titled "PostCode"
Checked that the postcodes were present and were as expected
Clicked "Search and compare" in the header
Selected a few companies for comparison
Went to the compare page
Clicked "Download data (CSV)"
Checked that the CSV does not contain the PostCode column.
R - Very low risk.
D - not necessary.