### PR TITLE
GPG-767 Bump vulnerable dependencies

### DIFF
--- a/GenderPayGap.WebUI/package-lock.json
+++ b/GenderPayGap.WebUI/package-lock.json
@@ -469,9 +469,9 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "http-signature": {
       "version": "1.2.0",

--- a/GenderPayGap.WebUI/package-lock.json
+++ b/GenderPayGap.WebUI/package-lock.json
@@ -626,9 +626,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "loud-rejection": {
       "version": "1.6.0",


### PR DESCRIPTION
Both of these dependencies are used by `node-sass`.  `node-sass` accepts `hosted-git-info` >= 2.1.4 and `lodash` >= 4.17.15
There is no risk - I had a look at the changelogs and the changes aren't breaking.

Tested locally, `node-sass` works as expected, the css files being compiled