### PR TITLE
GPG-790 Fix bonus pay gap description typo

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/BonusPay/BonusDiffText.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/BonusPay/BonusDiffText.cshtml
@@ -6,7 +6,7 @@
         <div class="data data-metric column-full">
             @if (Model.MenReceivedBonuses)
             {
-                <span>When comparing mean (average) bonus pay, women&rsquo;s @(Model.Statistic) mean bonus pay is </span>
+                <span>When comparing @(Model.Statistic) (average) bonus pay, women&rsquo;s @(Model.Statistic) bonus pay is </span>
                 <span id="@(Model.Id)" class="data-item">
                     <span>@(string.Format("{0:0.#}", Model.Percent))% </span>
                     <span>@(Model.Compare)</span>


### PR DESCRIPTION
See ticket [GPG-790](https://technologyprogramme.atlassian.net/browse/GPG-790)
"mean" was duplicated because we displayed both "mean" and `Model.Statistic`.
We should use `Model.Statistic` instead of hardcoding "mean".

Tested locally.