### PR TITLE
GPG-783 Fixed invalid reporting year for late submissions bug

### DIFF
--- a/GenderPayGap.WebUI/Views/Submit/LateReason.cshtml
+++ b/GenderPayGap.WebUI/Views/Submit/LateReason.cshtml
@@ -34,6 +34,9 @@
             @Html.HiddenFor(model => Model.SectorType)
             @Html.HiddenFor(model => Model.OrganisationSize)
 
+            @Html.HiddenFor(model => model.ReportInfo.ReportModifiedDate)
+            @Html.HiddenFor(model => model.ReportInfo.ReportingStartDate)
+
             // handles the reason error css class
             HtmlString reasonErrorClass = null;
             if (string.IsNullOrEmpty(Model.LateReason))


### PR DESCRIPTION
See ticket [GPG-783](https://technologyprogramme.atlassian.net/browse/GPG-783)

The reporting year was incorrect because the reporting start date (that is used for building that string) was not passed when submitting the late reason and the year for the default value was 1.