### PR TITLE
GPG-773: Add rate limitng

### DIFF
--- a/Infrastructure/gpg-ipdeny/nginx.conf
+++ b/Infrastructure/gpg-ipdeny/nginx.conf
@@ -38,6 +38,8 @@ http {
   set_real_ip_from 172.16.0.0/12;
   set_real_ip_from 192.168.0.0/16;
   real_ip_recursive on;
+  
+  limit_req_zone $binary_remote_addr zone=rate_limiting_ip_address_bucket:10m rate=50r/s;
 
   server {
     listen {{ port }};
@@ -80,6 +82,8 @@ http {
       allow 127.0.0.1/32;
       {{ env "DENIED_IPS" }}
       allow all;
+      
+      limit_req zone=rate_limiting_ip_address_bucket
 
       resolver 169.254.0.2;
 

--- a/Infrastructure/gpg-ipdeny/nginx.conf
+++ b/Infrastructure/gpg-ipdeny/nginx.conf
@@ -83,7 +83,7 @@ http {
       {{ env "DENIED_IPS" }}
       allow all;
       
-      limit_req zone=rate_limiting_ip_address_bucket
+      limit_req zone=rate_limiting_ip_address_bucket;
 
       resolver 169.254.0.2;
 


### PR DESCRIPTION
Limit requests made to the app to 50 requests per second per IP Address

Risks:

People who use scripts to access the site and pull large amounts of data could be negatively affected e.g. their requests could timeout, or just take longer than it might have usually taken before

Potential DDOS attacks could circumvent this limit by just using lots of IP Addresses at once 


Testing:

Using the "hey" package, I make several requests to the loadtest environment, some exceeding the rate limit while others stayed under

**100 Requests, 10 concurrent workers, 10 Queries per second**

``` 
Summary:
 Total:       1.2774 secs
 Slowest:     0.3603 secs
 Fastest:     0.0154 secs
 Average:     0.0626 secs
 Requests/sec: 78.2833

...

Status code distribution:
 [200] 40 responses
 [503] 60 responses
```

**80 Requests, 1 worker, 40 Queries per second**

```
Summary:
  Total:        5.4264 secs
  Slowest:      0.5212 secs
  Fastest:      0.0396 secs
  Average:      0.0674 secs
  Requests/sec: 14.7428

...

Status code distribution:
  [200] 80 responses
```
