### PR TITLE
GPG-773: Add burst and nodelay

### DIFF
--- a/Infrastructure/gpg-ipdeny/nginx.conf
+++ b/Infrastructure/gpg-ipdeny/nginx.conf
@@ -83,7 +83,7 @@ http {
       {{ env "DENIED_IPS" }}
       allow all;
       
-      limit_req zone=rate_limiting_ip_address_bucket;
+      limit_req zone=rate_limiting_ip_address_bucket burst=100 nodelay;
 
       resolver 169.254.0.2;
 


### PR DESCRIPTION
Add a burst queue of 100 requests

T: Clearing cache and loading up the loadtest site shows no 503s are thrown under normal loads

R: There could be someone trying to scrape data from the service doing a lot of requests that might exceed the burst queue (Low risk as the app wasn't designed for this)

D: In the README