### PR TITLE
GPG-779: Return all postcodes in all caps

### DIFF
--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -49,7 +49,7 @@ namespace GenderPayGap.Database
                     entity.Property(e => e.County).HasMaxLength(100);
 
                     entity.Property(e => e.PoBox).HasMaxLength(30);
-                    
+        
                     entity.Property(e => e.PostCode).HasMaxLength(20);
 
                     entity.Property(e => e.Source).HasMaxLength(255);

--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -49,7 +49,7 @@ namespace GenderPayGap.Database
                     entity.Property(e => e.County).HasMaxLength(100);
 
                     entity.Property(e => e.PoBox).HasMaxLength(30);
-
+                    
                     entity.Property(e => e.PostCode).HasMaxLength(20);
 
                     entity.Property(e => e.Source).HasMaxLength(255);

--- a/GenderPayGap.Database/Models/Extensions/Organisation.cs
+++ b/GenderPayGap.Database/Models/Extensions/Organisation.cs
@@ -108,7 +108,7 @@ namespace GenderPayGap.Database
                 City = address.TownCity,
                 County = address.County,
                 Country = address.Country,
-                PostCode = address.PostCode,
+                PostCode = address.GetPostCodeInAllCaps(),
                 PoBox = address.PoBox,
                 IsUkAddress = address.IsUkAddress,
                 RegistrationStatus = GetRegistrationStatus(),

--- a/GenderPayGap.Database/Models/Extensions/OrganisationAddress.cs
+++ b/GenderPayGap.Database/Models/Extensions/OrganisationAddress.cs
@@ -46,10 +46,10 @@ namespace GenderPayGap.Database
             {
                 list.Add(address.Country.TrimI());
             }
-
-            if (!string.IsNullOrWhiteSpace(address.PostCode))
+            
+            if (!string.IsNullOrWhiteSpace(address.GetPostCodeInAllCaps()))
             {
-                list.Add(address.PostCode.TrimI());
+                list.Add(address.GetPostCodeInAllCaps().TrimI());
             }
 
             if (!string.IsNullOrWhiteSpace(address.PoBox))
@@ -111,7 +111,7 @@ namespace GenderPayGap.Database
                    && string.Equals(TownCity, other.TownCity, StringComparison.Ordinal)
                    && string.Equals(County, other.County, StringComparison.Ordinal)
                    && string.Equals(Country, other.Country, StringComparison.Ordinal)
-                   && string.Equals(PostCode, other.PostCode, StringComparison.Ordinal)
+                   && string.Equals(GetPostCodeInAllCaps(), other.GetPostCodeInAllCaps(), StringComparison.Ordinal)
                    && string.Equals(PoBox, other.PoBox, StringComparison.Ordinal);
         }
 

--- a/GenderPayGap.Database/Models/Extensions/Return.cs
+++ b/GenderPayGap.Database/Models/Extensions/Return.cs
@@ -262,7 +262,7 @@ namespace GenderPayGap.Database
                 EmployerName = Organisation?.GetName(StatusDate)?.Name ?? Organisation.OrganisationName,
                 EmployerId = OrganisationId,
                 Address = Organisation.GetLatestAddress()?.GetAddressString(),
-                PostCode = Organisation.GetLatestAddress()?.PostCode,
+                PostCode = Organisation.GetLatestAddress()?.GetPostCodeInAllCaps(),
                 CompanyNumber = Organisation?.CompanyNumber,
                 SicCodes = Organisation?.GetSicCodeIdsString(StatusDate, "," + Environment.NewLine),
                 DiffMeanHourlyPercent = DiffMeanHourlyPayPercent,

--- a/GenderPayGap.Database/Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database/Models/OrganisationAddress.cs
@@ -58,7 +58,7 @@ namespace GenderPayGap.Database
 
         public string GetPostCodeInAllCaps()
         {
-            return PostCode.ToUpper();
+            return PostCode != null ? PostCode.ToUpper() : PostCode;
         }
 
     }

--- a/GenderPayGap.Database/Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database/Models/OrganisationAddress.cs
@@ -58,7 +58,7 @@ namespace GenderPayGap.Database
 
         public string GetPostCodeInAllCaps()
         {
-            return PostCode != null ? PostCode.ToUpper() : PostCode;
+            return PostCode?.ToUpper();
         }
 
     }

--- a/GenderPayGap.Database/Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database/Models/OrganisationAddress.cs
@@ -56,5 +56,10 @@ namespace GenderPayGap.Database
 
         public virtual ICollection<UserOrganisation> UserOrganisations { get; set; }
 
+        public string GetPostCodeInAllCaps()
+        {
+            return PostCode.ToUpper();
+        }
+
     }
 }

--- a/GenderPayGap.WebUI/BusinessLogic/Services/UpdateFromCompaniesHouseService.cs
+++ b/GenderPayGap.WebUI/BusinessLogic/Services/UpdateFromCompaniesHouseService.cs
@@ -152,7 +152,7 @@ namespace GenderPayGap.WebUI.BusinessLogic.Services
                 && string.IsNullOrEmpty(address.County)
                 && string.IsNullOrEmpty(address.Country)
                 && string.IsNullOrEmpty(address.PoBox)
-                && string.IsNullOrEmpty(address.PostCode)
+                && string.IsNullOrEmpty(address.GetPostCodeInAllCaps())
             )
             {
                 return true;

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationFoundController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationFoundController.cs
@@ -270,7 +270,7 @@ namespace GenderPayGap.WebUI.Controllers.AddOrganisation
             }
             else
             {
-                viewModel.IsUkAddress = PostcodesIoApi.IsValidPostcode(organisationAddress?.PostCode)
+                viewModel.IsUkAddress = PostcodesIoApi.IsValidPostcode(organisationAddress?.GetPostCodeInAllCaps())
                     ? AddOrganisationIsUkAddress.Yes
                     : (AddOrganisationIsUkAddress?) null;
             }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminDownloadsController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminDownloadsController.cs
@@ -124,6 +124,7 @@ namespace GenderPayGap.WebUI.Controllers
                     org =>
                     {
                         OrganisationAddress address = org.GetLatestAddress();
+                        string postCode = address.GetPostCodeInAllCaps();
                         return new
                         {
                             org.OrganisationId,
@@ -135,7 +136,7 @@ namespace GenderPayGap.WebUI.Controllers
                             address.TownCity,
                             address.County,
                             address.Country,
-                            address.PostCode,
+                            postCode,
                         };
                     })
                 .ToList();

--- a/GenderPayGap.WebUI/Controllers/RegisterController.Request.cs
+++ b/GenderPayGap.WebUI/Controllers/RegisterController.Request.cs
@@ -113,7 +113,7 @@ namespace GenderPayGap.WebUI.Controllers
             model.Address2 = userOrg.Address.Address2;
             model.Address3 = userOrg.Address.Address3;
             model.Country = userOrg.Address.Country;
-            model.Postcode = userOrg.Address.PostCode;
+            model.Postcode = userOrg.Address.GetPostCodeInAllCaps();
             model.PoBox = userOrg.Address.PoBox;
 
             model.RegisteredAddress = userOrg.Address.Status == AddressStatuses.Pending

--- a/GenderPayGap.WebUI/Models/Admin/ChangeOrganisationAddressViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/ChangeOrganisationAddressViewModel.cs
@@ -36,7 +36,7 @@ namespace GenderPayGap.WebUI.Models.Admin
             TownCity = address?.TownCity;
             County = address?.County;
             Country = address?.Country;
-            PostCode = address?.PostCode;
+            PostCode = address?.GetPostCodeInAllCaps();
 
             if (address?.IsUkAddress != null)
             {

--- a/GenderPayGap.WebUI/Services/PinInThePostService.cs
+++ b/GenderPayGap.WebUI/Services/PinInThePostService.cs
@@ -48,8 +48,8 @@ namespace GenderPayGap.WebUI.Services
             string companyName = userOrganisation.Organisation.OrganisationName;
 
             List<string> address = GetAddressInFourLineFormat(userOrganisation.Organisation);
-
-            string postCode = userOrganisation.Organisation.GetLatestAddress().PostCode;
+            
+            string postCode = userOrganisation.Organisation.GetLatestAddress().GetPostCodeInAllCaps();
 
             string returnUrl = urlHelper.Action("ManageOrganisationsGet", "ManageOrganisations", null, "https");
             DateTime pinExpiryDate = VirtualDateTime.Now.AddDays(Global.PinInPostExpiryDays);

--- a/GenderPayGap.WebUI/Views/AdminOrganisationAddress/ConfirmAddressChange.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationAddress/ConfirmAddressChange.cshtml
@@ -148,7 +148,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Post code</th>
                         <td class="govuk-table__cell">
-                            @(latestAddress?.PostCode)
+                            @(latestAddress?.GetPostCodeInAllCaps())
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.PostCode)

--- a/GenderPayGap.WebUI/Views/AdminOrganisationAddress/OfferNewCompaniesHouseAddress.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationAddress/OfferNewCompaniesHouseAddress.cshtml
@@ -145,7 +145,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Post code</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().PostCode)
+                            @(Model.Organisation.GetLatestAddress().GetPostCodeInAllCaps())
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.PostCode)


### PR DESCRIPTION
Test
Went onto the employer details page and manage org page to make sure the postcode was in all caps. When this is deployed to dev we will be testing the downloaded CSVs

Risk
Since the Postcode automatic getter is still public devs in the future could access it that way, however, this is necessary for setting up entity framework

Docs
N/A