### PR TITLE
GPG-808 Admin can add new address if none

### DIFF
--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationAddressController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationAddressController.cs
@@ -203,10 +203,9 @@ namespace GenderPayGap.WebUI.Controllers.Admin
 
         private void SaveChangesAndAuditAction(ChangeOrganisationAddressViewModel viewModel, Organisation organisation)
         {
-            OrganisationAddress latestAddress = organisation.GetLatestAddress();
-            string oldAddressString = latestAddress?.GetAddressString();
+            string oldAddressString = organisation.GetLatestAddress()?.GetAddressString();
 
-            if (latestAddress != null)
+            if (oldAddressString != null)
             {
                 RetireOldAddress(organisation);
             }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationAddressController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationAddressController.cs
@@ -58,7 +58,8 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                         UpdateFromCompaniesHouseService.CreateOrganisationAddressFromCompaniesHouseAddress(
                         organisationFromCompaniesHouse.RegisteredOfficeAddress);
 
-                    if (!organisation.GetLatestAddress().AddressMatches(addressFromCompaniesHouse))
+                    OrganisationAddress latestAddress = organisation.GetLatestAddress();
+                    if (latestAddress != null && !latestAddress.AddressMatches(addressFromCompaniesHouse))
                     {
                         return OfferNewCompaniesHouseAddress(organisation, addressFromCompaniesHouse);
                     }
@@ -93,7 +94,7 @@ namespace GenderPayGap.WebUI.Controllers.Admin
 
         private IActionResult SendToManualChangePage(Organisation organisation)
         {
-            OrganisationAddress address = organisation.OrganisationAddresses.OrderByDescending(a => a.Created).First();
+            OrganisationAddress address = organisation.OrganisationAddresses.OrderByDescending(a => a.Created).FirstOrDefault();
 
             var viewModel = new ChangeOrganisationAddressViewModel
             {
@@ -202,9 +203,13 @@ namespace GenderPayGap.WebUI.Controllers.Admin
 
         private void SaveChangesAndAuditAction(ChangeOrganisationAddressViewModel viewModel, Organisation organisation)
         {
-            string oldAddressString = organisation.GetLatestAddress().GetAddressString();
+            OrganisationAddress latestAddress = organisation.GetLatestAddress();
+            string oldAddressString = latestAddress?.GetAddressString();
 
-            RetireOldAddress(organisation);
+            if (latestAddress != null)
+            {
+                RetireOldAddress(organisation);
+            }
 
             OrganisationAddress newOrganisationAddress = CreateOrganisationAddressFromViewModel(viewModel);
             AddNewAddressToOrganisation(newOrganisationAddress, organisation);

--- a/GenderPayGap.WebUI/Models/Admin/ChangeOrganisationAddressViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Admin/ChangeOrganisationAddressViewModel.cs
@@ -29,16 +29,16 @@ namespace GenderPayGap.WebUI.Models.Admin
 
         public void PopulateFromOrganisationAddress(OrganisationAddress address)
         {
-            PoBox = address.PoBox;
-            Address1 = address.Address1;
-            Address2 = address.Address2;
-            Address3 = address.Address3;
-            TownCity = address.TownCity;
-            County = address.County;
-            Country = address.Country;
-            PostCode = address.PostCode;
+            PoBox = address?.PoBox;
+            Address1 = address?.Address1;
+            Address2 = address?.Address2;
+            Address3 = address?.Address3;
+            TownCity = address?.TownCity;
+            County = address?.County;
+            Country = address?.Country;
+            PostCode = address?.PostCode;
 
-            if (address.IsUkAddress.HasValue)
+            if (address?.IsUkAddress != null)
             {
                 IsUkAddress = address.IsUkAddress.Value
                     ? ManuallyChangeOrganisationAddressIsUkAddress.Yes

--- a/GenderPayGap.WebUI/Views/AdminOrganisationAddress/ConfirmAddressChange.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminOrganisationAddress/ConfirmAddressChange.cshtml
@@ -60,6 +60,9 @@
             @(Html.AntiForgeryToken())
             @(Html.HiddenFor(m => m.Action))
             @(Html.HiddenFor(m => m.Reason))
+            @{
+                var latestAddress = Model.Organisation.GetLatestAddress();
+            }
 
             <table class="govuk-table">
                 <thead class="govuk-table__head">
@@ -75,7 +78,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">PO Box</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().PoBox)
+                            @(latestAddress?.PoBox)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.PoBox)
@@ -85,7 +88,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Address 1</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().Address1)
+                            @(latestAddress?.Address1)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.Address1)
@@ -95,7 +98,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Address 2</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().Address2)
+                            @(latestAddress?.Address2)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.Address2)
@@ -105,7 +108,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Address 3</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().Address3)
+                            @(latestAddress?.Address3)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.Address3)
@@ -115,7 +118,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Town / city</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().TownCity)
+                            @(latestAddress?.TownCity)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.TownCity)
@@ -125,7 +128,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">County</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().County)
+                            @(latestAddress?.County)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.County)
@@ -135,7 +138,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Country</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().Country)
+                            @(latestAddress?.Country)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.Country)
@@ -145,7 +148,7 @@
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">Post code</th>
                         <td class="govuk-table__cell">
-                            @(Model.Organisation.GetLatestAddress().PostCode)
+                            @(latestAddress?.PostCode)
                         </td>
                         <td class="govuk-table__cell">
                             @(Model.PostCode)


### PR DESCRIPTION
See ticket [GPG-808](https://technologyprogramme.atlassian.net/browse/GPG-808) - details about the bug in comments.

Testing:
* Tested locally. Once the employer has an address, the user can add it to their account and report successfully

Risk: None
Documentation: Not required