### PR TITLE
GPG-818 Check report hasn't already been submitted

### DIFF
--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/SubmissionControllerTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/SubmissionControllerTests.cs
@@ -716,7 +716,6 @@ namespace GenderPayGap.WebUI.Tests.Controllers
             var controller = UiTestHelper.GetController<SubmitController>(mockedUser.UserId, routeData);
             controller.ReportingOrganisationId = mockedOrganisation.OrganisationId;
             controller.ReportingOrganisationStartYear = Global.FirstReportingYear;
-            ;
 
             Mock<IDataRepository> mockedDatabase = AutoFacExtensions.ResolveAsMock<IDataRepository>();
 
@@ -756,7 +755,8 @@ namespace GenderPayGap.WebUI.Tests.Controllers
                 OrganisationId = mockedOrganisation.OrganisationId,
                 ReturnId = mockedOrganisation.Returns.First().ReturnId,
                 LateReason = mockedReturn.LateReason,
-                EHRCResponse = mockedReturn.EHRCResponse.ToString()
+                EHRCResponse = mockedReturn.EHRCResponse.ToString(),
+                AccountingDate = mockedReturn.AccountingDate
             };
 
             returnViewModel.ReportInfo = new ReportInfoModel

--- a/GenderPayGap.WebUI/Classes/Presentation/SubmissionService.cs
+++ b/GenderPayGap.WebUI/Classes/Presentation/SubmissionService.cs
@@ -31,6 +31,7 @@ namespace GenderPayGap.WebUI.Classes.Services
         SubmissionChangeSummary GetSubmissionChangeSummary(Return stashedReturn, Return databaseReturn);
 
         Return GetSubmissionById(long returnId);
+        Return GetReturnFromDatabase(long organisationId, int snapshotYear);
 
         // presentation
         Task<ReturnViewModel> GetReturnViewModelAsync(long organisationId, int snapshotYear, long userId);

--- a/GenderPayGap.WebUI/Controllers/SubmitController.CheckData.cs
+++ b/GenderPayGap.WebUI/Controllers/SubmitController.CheckData.cs
@@ -9,6 +9,7 @@ using GenderPayGap.Database;
 using GenderPayGap.WebUI.BusinessLogic.Classes;
 using GenderPayGap.WebUI.BusinessLogic.Models.Submit;
 using GenderPayGap.WebUI.Classes;
+using GenderPayGap.WebUI.ErrorHandling;
 using GenderPayGap.WebUI.Models.Submit;
 using GenderPayGap.WebUI.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -174,11 +175,20 @@ namespace GenderPayGap.WebUI.Controllers.Submission
             }
 
             Return postedReturn = submissionService.CreateDraftSubmissionFromViewModel(postedReturnViewModel);
+            Return databaseReturn = submissionService.GetReturnFromDatabase(postedReturnViewModel.OrganisationId, postedReturnViewModel.AccountingDate.Year);
 
             SubmissionChangeSummary changeSummary = null;
-            Return databaseReturn = submissionService.GetSubmissionById(postedReturnViewModel.ReturnId);
             if (databaseReturn != null)
             {
+                if (databaseReturn.ReturnId != postedReturnViewModel.ReturnId)
+                {
+                    throw new ReportAlreadySubmittedException
+                    {
+                        OrganisationId = postedReturn.Organisation.OrganisationId,
+                        ReportingYear = postedReturn.AccountingDate.Year
+                    };
+                }
+
                 changeSummary = submissionService.GetSubmissionChangeSummary(postedReturn, databaseReturn);
 
                 if (!changeSummary.HasChanged)

--- a/GenderPayGap.WebUI/ErrorHandling/CustomErrorPageExceptions.cs
+++ b/GenderPayGap.WebUI/ErrorHandling/CustomErrorPageExceptions.cs
@@ -78,4 +78,12 @@ namespace GenderPayGap.WebUI.ErrorHandling
         public override string ViewName => "../Errors/PinExpired";
         public override int StatusCode => 400;
     }
+    
+    public class ReportAlreadySubmittedException : CustomErrorPageException
+    {
+        public override string ViewName => "../Errors/ReportAlreadySubmitted";
+        public override int StatusCode => 403;
+        public long OrganisationId { get; set; }
+        public int ReportingYear { get; set; }
+    }
 }

--- a/GenderPayGap.WebUI/Views/Errors/ReportAlreadySubmitted.cshtml
+++ b/GenderPayGap.WebUI/Views/Errors/ReportAlreadySubmitted.cshtml
@@ -1,0 +1,27 @@
+﻿@using GenderPayGap.Core.Helpers
+@model GenderPayGap.WebUI.ErrorHandling.ReportAlreadySubmittedException
+
+@{
+    string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.OrganisationId.ToString());
+    ViewBag.Title = $"Report already submitted - Gender pay gap service";
+    Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <h1 class="govuk-heading-xl">
+            Report already submitted
+        </h1>
+        
+        <p class="govuk-body">
+            The @ReportingYearsHelper.FormatYearAsReportingPeriod(Model.ReportingYear) report has already been submitted. <br/>
+            You can see it on
+            <a href="@Url.Action("ManageOrganisationGet", "ManageOrganisations", new { encryptedOrganisationId })"
+               class="govuk-link">
+                your employer page
+            </a> and update it if required.
+        </p>
+
+    </div>
+</div>


### PR DESCRIPTION
One way to reproduce this bug is to have multiple sessions open at a given time. When the second report is submitted a error message should be displayed informing the user the report has already been submitted.

![image](https://user-images.githubusercontent.com/40567916/142667443-2408aadf-02b7-46a3-91ec-9bef284baf4d.png)
