### PR TITLE
GPG-826: Trust AWS Cloudfront IP ranges

### DIFF
--- a/Infrastructure/gpg-ipdeny/nginx.conf
+++ b/Infrastructure/gpg-ipdeny/nginx.conf
@@ -38,6 +38,7 @@ http {
   set_real_ip_from 127.0.0.1/32;
   set_real_ip_from 172.16.0.0/12;
   set_real_ip_from 192.168.0.0/16;
+  {{ env "AWS_CLOUDFRONT_TRUSTED" }}
   real_ip_recursive on;
   
   limit_req_zone $binary_remote_addr zone=rate_limiting_ip_address_bucket:10m rate=50r/s;


### PR DESCRIPTION
We found out the nginx app didn't work in Prod when checking if the EHRC endpoints were IP protected. Turned out the app was not configured correctly (as in it didn't work with a cdn routed domain)

You can see the gov.uk PaaS support reply here: https://technologyprogramme.atlassian.net/browse/GPG-826

Tested the configuration on the load test environment 