### PR TITLE
GPG-842: Get return by reporting year

### DIFF
--- a/GenderPayGap.Database/Models/Extensions/Organisation.cs
+++ b/GenderPayGap.Database/Models/Extensions/Organisation.cs
@@ -324,17 +324,17 @@ namespace GenderPayGap.Database
                 .FirstOrDefault();
         }
 
-        //Returns the latest return for the specified accounting year or the latest ever if no accounting year is 
+        // Returns the latest return for the specified accounting year or the latest ever if no accounting year is 
         public Return GetReturn(int year = 0)
         {
-            DateTime accountingStartDate = SectorType.GetAccountingStartDate(year);
+            int reportingYear = year == 0 ? VirtualDateTime.Now.Year : year;
             return Returns
-                .Where(r => r.Status == ReturnStatuses.Submitted && r.AccountingDate == accountingStartDate)
+                .Where(r => r.Status == ReturnStatuses.Submitted && r.AccountingDate.Year == reportingYear)
                 .OrderByDescending(r => r.StatusDate)
                 .FirstOrDefault();
         }
 
-        //Returns the latest scope for the current accounting date
+        // Returns the latest scope for the current accounting date
         public OrganisationScope GetCurrentScope()
         {
             var accountingStartDate = SectorType.GetAccountingStartDate();

--- a/GenderPayGap.Database/Models/Extensions/Organisation.cs
+++ b/GenderPayGap.Database/Models/Extensions/Organisation.cs
@@ -327,9 +327,9 @@ namespace GenderPayGap.Database
         // Returns the latest return for the specified accounting year or the latest ever if no accounting year is 
         public Return GetReturn(int year = 0)
         {
-            int reportingYear = year == 0 ? VirtualDateTime.Now.Year : year;
+            DateTime accountingStartDate = SectorType.GetAccountingStartDate(year);
             return Returns
-                .Where(r => r.Status == ReturnStatuses.Submitted && r.AccountingDate.Year == reportingYear)
+                .Where(r => r.Status == ReturnStatuses.Submitted && r.AccountingDate.Year == accountingStartDate.Year)
                 .OrderByDescending(r => r.StatusDate)
                 .FirstOrDefault();
         }


### PR DESCRIPTION
See details: https://technologyprogramme.atlassian.net/browse/GPG-842

When the sector of an organisation is changed all the accounting dates in the database are updated (for all the returns and scopes). This issue is caused by the following: the sector of an organisation was updated without updating the accounting date as well.

When fetching the return from the database we should compare the years of the accounting dates.