### PR TITLE
GPG-847: Removed expire date info from the confirmation email

### DIFF
--- a/GenderPayGap.WebUI/Services/EmailSendingService.cs
+++ b/GenderPayGap.WebUI/Services/EmailSendingService.cs
@@ -26,7 +26,6 @@ namespace GenderPayGap.WebUI.Services
         {
             var personalisation = new Dictionary<string, dynamic>
             {
-                {"TimeWithUnits", "7 days"},
                 {"VerificationUrl", verificationUrl},
             };
 


### PR DESCRIPTION
We removed the expire details from the confirmation email template as the links don't expire.

Updated email:
![image](https://user-images.githubusercontent.com/40567916/158594104-f333cd20-f82f-4527-89b4-eaa325d13363.png)
