### PR TITLE
GPG-473-tabs-on-compare: aria-selected and role added

### DIFF
--- a/GenderPayGap.WebUI/Views/Compare/YearTabs.cshtml
+++ b/GenderPayGap.WebUI/Views/Compare/YearTabs.cshtml
@@ -17,8 +17,8 @@
     <ul class="govuk-tabs__list">
         @for (int year = startYear; year <= endYear; year++)
         {
-            <li class="govuk-tabs__list-item @(Model.Year == year ? "govuk-tabs__list-item--selected" : "")">
-                <a class="govuk-tabs__tab" href="@Url.Action(nameof(CompareController.CompareEmployers), "Compare", new {year})">
+            <li role="tablist" class="govuk-tabs__list-item @(Model.Year == year ? "govuk-tabs__list-item--selected" : "")">
+                <a aria-selected=@(Model.Year == year ? "true" : "false") role="tab" class="govuk-tabs__tab" href="@Url.Action(nameof(CompareController.CompareEmployers), "Compare", new {year})">
                     @(ReportingYearsHelper.FormatYearAsReportingPeriod(year, "/"))
                 </a>
             </li>


### PR DESCRIPTION
![tbas](https://user-images.githubusercontent.com/62190777/182650685-c8546504-f494-47bf-879c-6837b0cef3d2.PNG)
![selected](https://user-images.githubusercontent.com/62190777/182650716-7c7fbe95-6aa1-48a6-9ef2-1f404374ca52.PNG)
This ticket fixes an issue where the aria-selected labels were either not showing or not responding to the currently selected year.
This also fixes an issue where the role was not set to "tab" which caused screen readers to display each of the tab links as "links" they now show as selected and unselected tabs (as seen in the attached screenshots).
