### PR TITLE
GPG-472: Bar charts & keys have outline, screen reader ignore keys.

### DIFF
--- a/GenderPayGap.WebUI/Content/site.charts.css
+++ b/GenderPayGap.WebUI/Content/site.charts.css
@@ -103,8 +103,7 @@ govuk-chart-vert__head {
     width: 4em;
     height: 100%;
     bottom: 0;
-    outline: 2px solid;
-    outline-color: transparent;
+    outline: 2px solid transparent;
 }
 
 .govuk-chart-vert__bar--women, .govuk-chart-vert__caption--women {

--- a/GenderPayGap.WebUI/Content/site.charts.css
+++ b/GenderPayGap.WebUI/Content/site.charts.css
@@ -150,8 +150,7 @@ govuk-chart-vert__head {
 
 .govuk-chart-horz__bar {
     height: 2em;
-    outline: 2px solid;
-    outline-color: transparent;
+    outline: 2px solid transparent;
 }
 
 .govuk-chart-horz__bar--men {

--- a/GenderPayGap.WebUI/Content/site.charts.css
+++ b/GenderPayGap.WebUI/Content/site.charts.css
@@ -18,10 +18,12 @@
 
 .govuk-legend__caption--women:before {
 	background-color: #F46A25;
+    outline: 2px solid transparent;
 }
 
 .govuk-legend__caption--men:before {
-	background-color: #919397;
+    background-color: #919397;
+    outline: 2px solid transparent;
 }
 
 .govuk-chart-vert {
@@ -101,6 +103,8 @@ govuk-chart-vert__head {
     width: 4em;
     height: 100%;
     bottom: 0;
+    outline: 2px solid;
+    outline-color: transparent;
 }
 
 .govuk-chart-vert__bar--women, .govuk-chart-vert__caption--women {
@@ -147,6 +151,8 @@ govuk-chart-vert__head {
 
 .govuk-chart-horz__bar {
     height: 2em;
+    outline: 2px solid;
+    outline-color: transparent;
 }
 
 .govuk-chart-horz__bar--men {

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Quartiles/QuartilesBarChart.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Quartiles/QuartilesBarChart.cshtml
@@ -14,10 +14,10 @@
 
     <div class="govuk-chart-horz__foot">
         <div class="govuk-chart-horz__text--left">
-            <span class="bold-small">@(Model.FemaleFormatted)% <span class="visually-hidden"> of the @Model.Title.ToLower() are women</span></span>
+            <span class="bold-small">@(Model.FemaleFormatted)% <span class="visually-hidden"> &nbsp of the @Model.Title.ToLower() are women</span></span>
         </div>
         <div class="govuk-chart-horz__text--right">
-            <span class="bold-small">@(Model.MaleFormatted)% <span class="visually-hidden"> of the @Model.Title.ToLower() are men</span></span>
+            <span class="bold-small">@(Model.MaleFormatted)% <span class="visually-hidden"> &nbsp of the @Model.Title.ToLower() are men</span></span>
         </div>
     </div>
 

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Quartiles/QuartilesBarChart.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Quartiles/QuartilesBarChart.cshtml
@@ -14,10 +14,10 @@
 
     <div class="govuk-chart-horz__foot">
         <div class="govuk-chart-horz__text--left">
-            <span class="bold-small">@(Model.FemaleFormatted)% <span class="visually-hidden"> &nbsp of the @Model.Title.ToLower() are women</span></span>
+            <span class="bold-small">@(Model.FemaleFormatted)% <span class="visually-hidden"> &nbsp; of the @Model.Title.ToLower() are women</span></span>
         </div>
         <div class="govuk-chart-horz__text--right">
-            <span class="bold-small">@(Model.MaleFormatted)% <span class="visually-hidden"> &nbsp of the @Model.Title.ToLower() are men</span></span>
+            <span class="bold-small">@(Model.MaleFormatted)% <span class="visually-hidden"> &nbsp; of the @Model.Title.ToLower() are men</span></span>
         </div>
     </div>
 

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Quartiles/QuartilesSection.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Quartiles/QuartilesSection.cshtml
@@ -61,8 +61,8 @@
                     <div class="column-full">
                         <div class="govuk-legend">
                             <span class="font-xsmall">
-                                <span class="govuk-legend__caption govuk-legend__caption--women" data-legend-text="Women"></span>
-                                <span class="govuk-legend__caption govuk-legend__caption--men" data-legend-text="Men"></span>
+                                <span aria-hidden="true" class="govuk-legend__caption govuk-legend__caption--women" data-legend-text="Women"></span>
+                                <span aria-hidden="true" class="govuk-legend__caption govuk-legend__caption--men" data-legend-text="Men"></span>
                             </span>
                         </div>
 


### PR DESCRIPTION
### **Changes made :**
- Transparent border added to bar charts(both horizontal and vertical) this displays their outline on high contrast mode only.
- Transparent border added to keys "Women, Men", this displays their outline on high contrast mode only.
- Bar chart keys "Women, Men" hidden from screen-reader : they keys are irrelevant to screen readers as the data given by the bar charts is already given in text form without a colour key.

### **High Contrast mode with outlines visible:**
![High contrast borderes added](https://user-images.githubusercontent.com/62190777/183636615-c23fa2a6-e790-4f97-ba05-20c87229b542.PNG)

### **Screen reader ignoring bar graphs and keys and reading out the visually hidden data.**
![Screen reader](https://user-images.githubusercontent.com/62190777/183636677-072fb3b9-27e7-419e-a933-fc159e15c38f.png)

