### PR TITLE
GPG-475: Comparison list changes changed to role="alert".

### DIFF
--- a/GenderPayGap.WebUI/Views/Compare/ComparisonBasket.cshtml
+++ b/GenderPayGap.WebUI/Views/Compare/ComparisonBasket.cshtml
@@ -25,7 +25,7 @@
             }
             @if (compareCount > 0)
             {
-                <div role="status">
+                <div role="alert">
                     Your comparison list contains <strong>@(compareCount) employer@(compareCount != 1 ? "s" : "")</strong>
                 </div>
             }


### PR DESCRIPTION
**Change made:**
 - The role of the message that shows how many companies you have in your comparison bin is changed from "status" to "alert" which causes the screen reader to read out how many we are comparing and gives the user immediate feedback.
 
 
![Comparison bin on screenreader](https://user-images.githubusercontent.com/62190777/183676460-809215d5-6a9e-4247-9021-17d4111454de.png)
 