### PR TITLE
GPG-864: "details" moved to top of list and styling changed to match.

### DIFF
--- a/GenderPayGap.WebUI/Views/AdminFeedback/ViewFeedbackRowsPartial.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminFeedback/ViewFeedbackRowsPartial.cshtml
@@ -43,10 +43,10 @@
                                 </span>
                             </td>
                             <th scope="row" class="govuk-table__header">
-                                Difficulty
+                                Details
                             </th>
                             <td class="govuk-table__cell">
-                                @(feedback.Difficulty)
+                                @(feedback.Details)
                             </td>
                             <td class="govuk-table__cell" rowspan="7" style="border-bottom-width: 2px;">
                                 <form method="post"
@@ -74,6 +74,14 @@
                                         </button>
                                     }
                                 </form>
+                            </td>
+                        </tr>
+                            <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">
+                                Difficulty
+                            </th>
+                            <td class="govuk-table__cell">
+                                @(feedback.Difficulty)
                             </td>
                         </tr>
                         <tr class="govuk-table__row">
@@ -211,19 +219,11 @@
                             </td>
                         </tr>
                         <tr class="govuk-table__row">
-                            <th scope="row" class="govuk-table__header">
+                            <th scope="row" class="govuk-table__header" style="border-bottom-width: 2px;">
                                 Phone number
                             </th>
-                            <td class="govuk-table__cell">
+                            <td class="govuk-table__cell"  style="border-bottom-width: 2px; width: 53%;">
                                 @(feedback.PhoneNumber)
-                            </td>
-                        </tr>
-                        <tr class="govuk-table__row">
-                            <th scope="row" class="govuk-table__header" style="border-bottom-width: 2px;">
-                                Details
-                            </th>
-                            <td class="govuk-table__cell" style="border-bottom-width: 2px; width: 53%;">
-                                @(feedback.Details)
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
The nature of this ticket was moving the details of a feedback submission to the top of the list for to speed up the rate at which admins can determine if a feedback submission is spam or not.

**Initially the details section was at the bottom:**
![Before](https://user-images.githubusercontent.com/62190777/185157864-c9ef83ee-55e6-40ee-918a-68f54d39866c.PNG)

**Now the details are at the top of the list.**
![After](https://user-images.githubusercontent.com/62190777/185157947-b49d3bc1-208c-44b8-9a24-8e4413d67505.PNG)

