### PR TITLE
Gpg 909/910 add js filter

### DIFF
--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -349,10 +349,7 @@
         selectList.id = "filterYearSelect";
         selectList.addEventListener("change",function (e){
             for (var i = 0; i < elements.length; i++){
-                var tableRow = elements[i];
-                while (tableRow.tagName.toLowerCase() !== "tr"){
-                    tableRow = tableRow.parentElement;    
-                }
+                var tableRow = elements[i].closest("tr");
                 tableRow.hidden = true;
                 
                 if (elements[i].innerHTML.includes(e.target.value) || e.target.value === "Show All"){
@@ -376,13 +373,12 @@
         selectList.appendChild(showAll);
         
         var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
-        for (var i = 1; i < arrayOfYears.length; i++){
+        for (var i = 0; i < arrayOfYears.length; i++){
              var option = document.createElement("option");
              option.value = arrayOfYears[i];
              option.text = arrayOfYears[i];
              selectList.appendChild(option);
         }
         
-        selectList.selectedIndex = 0;
     </script>
 }

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -2,6 +2,7 @@
 @using GenderPayGap.WebUI.Models.Shared
 @using GenderPayGap.Core
 @using GenderPayGap.Core.Helpers
+@using GenderPayGap.WebUI.Models.Search
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @using Newtonsoft.Json
@@ -63,17 +64,35 @@
         </div>
 
         <div class="grid-row">
-            <div class="column-two-thirds">
+            <div class="column-two-thirds ">
                 <div class="grid-row">
                     <div class="column-full">
                         <hr style="margin-top: 0"/>
                         <div class="body" style="margin-top: 2em" id="filteringArea">
                             @{
-                                <input type="hidden" id="selectOptionsFromReports" 
-                                       value=@JsonConvert.SerializeObject(organisation
-                                                                               .GetRecentReports(Global.ShowReportYearCount)
-                                                                               .Select(report => 
-                                                                                   report.GetReportingPeriod()).ToArray())>
+                                var years = organisation.GetRecentReports(Global.ShowReportYearCount).Select(report => report.GetReportingPeriod()).ToArray();
+                                var options = new List<SelectItemViewModel>();
+                                foreach (string year in years)
+                                {
+                                    SelectItemViewModel option = new SelectItemViewModel()
+                                    {
+                                        Value = year,
+                                        Text = year,
+                                    };
+                                    options.Add(option);
+                                }
+                                
+                                Html.GovUkSelect(new SelectViewModel()
+                                {
+                                    Classes = "govuk-select",
+                                    Items = options
+                                });
+                            }
+                           
+                            
+                            @{
+                                <input type="hidden" id="selectOptionsFromReports"
+                                       value=@JsonConvert.SerializeObject(organisation .GetRecentReports(Global.ShowReportYearCount).Select(report => report.GetReportingPeriod()).ToArray())>
                             }
                             @if (organisation.GetSubmittedReports().Any() && organisation.Status == OrganisationStatuses.Retired)
                             {
@@ -112,7 +131,7 @@
                                     {
                                         Html = 
                                             @<text>
-                                                <h3 class="heading-small govuk-!-margin-top-0">@report.GetReportingPeriod() Reporting year</h3>
+                                                <h3 class="heading-small govuk-!-margin-top-0 yearTextForFiltering">@report.GetReportingPeriod() Reporting year</h3>
 
                                                 @{
                                                     ReportStatusBadgeType reportStatus = report.GetBadgeType;
@@ -166,7 +185,7 @@
                                 Html = @<text>
                                            <div>
                                                <div class="govuk-grid-column-one-half govuk-!-padding-left-0">
-                                                   <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0">Reporting Year</h3>
+                                                   <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 ">Reporting Year</h3>
                                                </div>
                                                <div class="govuk-grid-column-one-half govuk-!-padding-left-0">
                                                    <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-employer-table-right">Report Status</h3>
@@ -190,7 +209,7 @@
                                             @<text>
                                                 <div class="govuk-grid-column-full govuk-!-padding-left-0 govuk-!-padding-right-0 govuk-!-margin-bottom-2">
                                                     <div class="govuk-grid-column-one-half govuk-!-padding-left-0">
-                                                        <h3 class="heading-small govuk-!-margin-top-0">@report.GetReportingPeriod()</h3>
+                                                        <h3 class="heading-small govuk-!-margin-top-0 yearTextForFiltering">@report.GetReportingPeriod()</h3>
                                                     </div>
                                                     
                                                     @{
@@ -317,23 +336,34 @@
             });
         }());
         
-
         
         var parent = document.getElementById("filteringArea");
+        
+        var label = document.createElement("label");
+        label.className = "govuk-label";
+        label.for = "yearFilter";
+        label.textContent = "Filter for a reporting period";
+        
+        var elements = document.getElementsByClassName("yearTextForFiltering");
+        
         var selectlist = document.createElement("select");
+        selectlist.className = "govuk-select govuk-!-margin-bottom-3";
         selectlist.id = "filterYearSelect";
         selectlist.addEventListener("change",function (e){
-            if (e.target.value === "2021/22")
-                {
-                    console.log("if reached");
-                    var x = document.getElementsByClassName("govuk-table__body");
-                    console.log(x.length);
-                    x[0].style.display = "none";
-                    x[1].style.display = "none";
+            for (var i = 0; i < elements.length; i++){
+                var tableRow = elements[i];
+                while (tableRow.tagName.toLowerCase() !== "tr"){
+                    tableRow = tableRow.parentElement;    
                 }
-            })
-
-        
+                tableRow.hidden = true;
+                
+                if (elements[i].innerHTML.includes(e.target.value) || e.target.value === "Show All"){
+                    tableRow.hidden = false;
+                }
+            }
+        }) 
+       
+        parent.appendChild(label);
         parent.appendChild(selectlist);
 
         var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -4,6 +4,7 @@
 @using GenderPayGap.Core.Helpers
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
+@using Newtonsoft.Json
 @model EmployerDetailsViewModel
 @{
     Organisation organisation = Model.Organisation;
@@ -66,7 +67,14 @@
                 <div class="grid-row">
                     <div class="column-full">
                         <hr style="margin-top: 0"/>
-                        <div class="body" style="margin-top: 2em">
+                        <div class="body" style="margin-top: 2em" id="filteringArea">
+                            @{
+                                <input type="hidden" id="selectOptionsFromReports" 
+                                       value=@JsonConvert.SerializeObject(organisation
+                                                                               .GetRecentReports(Global.ShowReportYearCount)
+                                                                               .Select(report => 
+                                                                                   report.GetReportingPeriod()).ToArray())>
+                            }
                             @if (organisation.GetSubmittedReports().Any() && organisation.Status == OrganisationStatuses.Retired)
                             {
                                 <div class="govuk-warning-text">
@@ -240,6 +248,7 @@
                             }
                         ).ToList();
                     
+                    
                     int indexOfCompanyJoined = organisation.GetRecentReports(Global.ShowReportYearCount).ToList().FindIndex(report => Model.Organisation.Created > ReportingYearsHelper.GetDeadlineForAccountingDate(report.AccountingDate));
                     var dateJoinedRow = new TableRowViewModel
                     {
@@ -307,6 +316,27 @@
                 }
             });
         }());
+        var parent = document.getElementById("filteringArea");
+        var selectlist = document.createElement("select");
+        selectlist.id = "filterYearSelect";
+        selectlist.onchange = function (){
+            //TODO: hide and unhide based on year selected.   
+        }
+            
+        parent.appendChild(selectlist);
 
+        var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
+        
+        var showAll = document.createElement("option");
+        showAll.value = "Show All";
+        showAll.text = "Show All";
+        selectlist.appendChild(showAll);
+        
+        for (var i = 1; i < arrayOfYears.length; i++){
+             var option = document.createElement("option");
+             option.value = arrayOfYears[i];
+             option.text = arrayOfYears[i];
+             selectlist.appendChild(option);
+        }
     </script>
 }

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -68,7 +68,13 @@
                 <div class="grid-row">
                     <div class="column-full">
                         <hr style="margin-top: 0"/>
-                        <div class="body" style="margin-top: 2em" id="filteringArea">
+                        <div class="body" style="margin-top: 2em">
+                            @await Html.PartialModelAsync(new Details
+                            {
+                                Id = "WhoNeedsToReport",
+                                LinkText = "Who is required to report, and the deadlines",
+                                SummaryPartial = "EmployerDetails/WhoNeedsToReport"
+                            })
                             @{
                                 var years = organisation.GetRecentReports(Global.ShowReportYearCount).Select(report => report.GetReportingPeriod()).ToArray();
                                 var options = new List<SelectItemViewModel>();
@@ -81,22 +87,25 @@
                                     };
                                     options.Add(option);
                                 }
-                                
+
                                 Html.GovUkSelect(new SelectViewModel()
                                 {
                                     Classes = "govuk-select",
                                     Items = options
                                 });
-                            }
-                           
-                            
-                            @{
-                                <input type="hidden" id="selectOptionsFromReports"
-                                       value=@JsonConvert.SerializeObject(organisation .GetRecentReports(Global.ShowReportYearCount).Select(report => report.GetReportingPeriod()).ToArray())>
+                                <div id="filteringArea">
+                                    <input type="hidden" id="selectOptionsFromReports"
+                                           value=@JsonConvert.SerializeObject(
+                                                     organisation.GetRecentReports(
+                                                         Global.ShowReportYearCount)
+                                                         .Select(
+                                                             report => report.GetReportingPeriod())
+                                                         .ToArray())>
+                                </div>
                             }
                             @if (organisation.GetSubmittedReports().Any() && organisation.Status == OrganisationStatuses.Retired)
                             {
-                                <div class="govuk-warning-text">
+                                <div class="govuk-warning-text" id="warningText">
                                     <span class="govuk-warning-text__icon" aria-hidden="true" style="top: calc(50% - 15px)">!</span>
                                     <strong class="govuk-warning-text__text">
                                         <span class="govuk-warning-text__assistive">Notice</span>
@@ -106,15 +115,6 @@
                             }
                         </div>
 
-                        @await Html.PartialModelAsync(new Details
-                        {
-                            Id = "WhoNeedsToReport",
-                            LinkText = "Who is required to report, and the deadlines",
-                            SummaryPartial = "EmployerDetails/WhoNeedsToReport"
-                        })
-                        <p>
-                            For example, if the snapshot date is 5 April 2017 but the deadline is 4 April 2018 then the reporting period is 2017 - 2018.
-                        </p>
 
                     </div>
                 </div>
@@ -325,7 +325,6 @@
 
 @section Scripts {
     <script>
-
         (function() {
             "use strict";
 
@@ -336,20 +335,19 @@
             });
         }());
         
+        var parentForSelect = document.getElementById("filteringArea");
         
-        var parent = document.getElementById("filteringArea");
-        
-        var label = document.createElement("label");
-        label.className = "govuk-label";
-        label.for = "yearFilter";
-        label.textContent = "Filter for a reporting period";
+        var selectLabel = document.createElement("label");
+        selectLabel.className = "govuk-label";
+        selectLabel.for = "yearFilter";
+        selectLabel.textContent = "Filter for a reporting period";
         
         var elements = document.getElementsByClassName("yearTextForFiltering");
         
-        var selectlist = document.createElement("select");
-        selectlist.className = "govuk-select govuk-!-margin-bottom-3";
-        selectlist.id = "filterYearSelect";
-        selectlist.addEventListener("change",function (e){
+        var selectList = document.createElement("select");
+        selectList.className = "govuk-select govuk-!-margin-bottom-3";
+        selectList.id = "filterYearSelect";
+        selectList.addEventListener("change",function (e){
             for (var i = 0; i < elements.length; i++){
                 var tableRow = elements[i];
                 while (tableRow.tagName.toLowerCase() !== "tr"){
@@ -362,25 +360,29 @@
                 }
             }
         }) 
-       
-        parent.appendChild(label);
-        parent.appendChild(selectlist);
-
-        var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
         
+        var selectHint = document.createElement("div");
+        selectHint.className = "govuk-hint";
+        selectHint.textContent = "For example, if the snapshot date is 5 April 2017 but the deadline is 4 April 2018 then the reporting period is 2017 - 2018.";
+       
+        parentForSelect.appendChild(selectLabel);
+        parentForSelect.appendChild(selectList);
+        parentForSelect.appendChild(selectHint);
+
         var showAll = document.createElement("option");
         showAll.value = "Show All";
         showAll.text = "Show All";
         showAll.selected = true;
-        selectlist.appendChild(showAll);
+        selectList.appendChild(showAll);
         
+        var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
         for (var i = 1; i < arrayOfYears.length; i++){
              var option = document.createElement("option");
              option.value = arrayOfYears[i];
              option.text = arrayOfYears[i];
-             selectlist.appendChild(option);
+             selectList.appendChild(option);
         }
         
-        selectlist.selectedIndex = 0;
+        selectList.selectedIndex = 0;
     </script>
 }

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -316,13 +316,24 @@
                 }
             });
         }());
+        
+
+        
         var parent = document.getElementById("filteringArea");
         var selectlist = document.createElement("select");
         selectlist.id = "filterYearSelect";
-        selectlist.onchange = function (){
-            //TODO: hide and unhide based on year selected.   
-        }
-            
+        selectlist.addEventListener("change",function (e){
+            if (e.target.value === "2021/22")
+                {
+                    console.log("if reached");
+                    var x = document.getElementsByClassName("govuk-table__body");
+                    console.log(x.length);
+                    x[0].style.display = "none";
+                    x[1].style.display = "none";
+                }
+            })
+
+        
         parent.appendChild(selectlist);
 
         var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
@@ -330,6 +341,7 @@
         var showAll = document.createElement("option");
         showAll.value = "Show All";
         showAll.text = "Show All";
+        showAll.selected = true;
         selectlist.appendChild(showAll);
         
         for (var i = 1; i < arrayOfYears.length; i++){
@@ -338,5 +350,7 @@
              option.text = arrayOfYears[i];
              selectlist.appendChild(option);
         }
+        
+        selectlist.selectedIndex = 0;
     </script>
 }


### PR DESCRIPTION
**Overview:**
The purpose of this ticket is to add a filter that allows users to see a only a specific years details and then return to seeing all years with a "show all option".
This is to be done using a `<Select>`  element and is to only be visible to users with JavaScript enabled on their browsers.
This is to be visible on both mobile and desktop(covered in 2 tickets).

**Changes:**
- reorganisation, text removal and restructuring of area above the years (as per the Figma designs - https://www.figma.com/file/vPKrhKrWG6z762gFgYgkvR/GPG-Dev-Handover?node-id=108%3A120).
- Select, hint and label elements created and appended to div via javascript.
- Hidden <input> passes year options as json where they are picked up by the js and used to create options.
- Options are then compared with textContent in `<h3>` tags.
- the table rows are then selected by looking at the parent nodes until a `<tr>` tag is reached.

**Select dropdown:**
![image](https://user-images.githubusercontent.com/62190777/195054854-e0c5e0f9-9fbb-4ba6-9e2a-ae6b8589ce50.png)

**Specific year selected:**
![image](https://user-images.githubusercontent.com/62190777/195054999-79182a06-e8e3-4356-80ee-02b33e191313.png)



 