### PR TITLE
Gpg 759 manage reports page

### DIFF
--- a/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
+++ b/GenderPayGap.Core/Helpers/ReportingYearsHelper.cs
@@ -11,11 +11,16 @@ namespace GenderPayGap.Core.Helpers
         public static List<int> GetReportingYears()
         {
             int firstReportingYear = Global.FirstReportingYear;
-            int currentReportingYear = SectorTypes.Public.GetAccountingStartDate().Year;
+            int currentReportingYear = GetCurrentReportingYear();
             int numberOfYears = currentReportingYear - firstReportingYear + 1;
 
             List<int> reportingYears = Enumerable.Range(firstReportingYear, numberOfYears).Reverse().ToList();
             return reportingYears;
+        }
+
+        public static int GetCurrentReportingYear()
+        {
+            return SectorTypes.Public.GetAccountingStartDate().Year;
         }
 
         public static List<(int,string)> GetReportingYearWithCSVFileSize()

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/ManageOrganisationViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/ManageOrganisationViewModel.cs
@@ -106,8 +106,8 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
             OrganisationScope scopeForYear = organisation.GetScopeForYear(ReportingYear);
 
             return scopeForYear.IsInScopeVariant()
-                ? "REQUIRED TO REPORT"
-                : "NOT REQUIRED TO REPORT";
+                ? "You are required to report."
+                : "You are not required to report.";
         }
 
         private DateTime GetAccountingDate()

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/ManageOrganisationViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/ManageOrganisationViewModel.cs
@@ -132,7 +132,7 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
                    && !Global.ReportingStartYearsToExcludeFromLateFlagEnforcement.Contains(GetAccountingDate().Year);
         }
 
-        private ReportTag GetReportTag()
+        public ReportTag GetReportTag()
         {
             Return returnForYear = organisation.GetReturn(ReportingYear);
             bool reportIsSubmitted = returnForYear != null;

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
@@ -60,32 +60,12 @@
         
         @{
             await Html.RenderPartialAsync("OrganisationReportsTable", Model);
-        }
-        
-        <h2 class="govuk-heading-l">Registered users</h2>
 
-        @{
-            var usersRegisteredToReportForOrganisation = Model.Organisation.UserOrganisations.Where(uo => uo.PINConfirmedDate.HasValue).Select(uo => uo.User).Distinct().ToList();
-        }
-        @if (usersRegisteredToReportForOrganisation.Count == 0)
-        {
-            <p class="govuk-body">
-                You are the only person registered to report for this employer.
-            </p>
-            <p class="govuk-body">
-                If you remove yourself:
-            </p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>You will not be able to report for this employer</li>
-                <li>Someone else must register this employer to report - this can take up to a week</li>
-                <li>Your account will remain open</li>
-            </ul>
-        } else
-        {
-            <p class="govuk-body">
-                The following people are registered to report gender pay gap information for this employer. 
-            </p>
-
+            <div class="govuk-!-margin-bottom-6">
+                <p>
+                    <a href="" class="govuk-!-font-size-19 govuk-link govuk-!-font-weight-bold">See all reports</a> <!--TODO: Point this link to the manage all reports page when that is created-->
+                </p>
+            </div>
             await Html.RenderPartialAsync("UsersRegisteredToReportForOrganisation", Model);
         }
         

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
@@ -41,19 +41,7 @@
                 for @(Model.Organisation.OrganisationName)
             </span>
         </h1>
-        
-        <dl>
-            <dt class="govuk-body govuk-!-font-weight-bold">
-                Registered Address
-            </dt>
-            <dd class="govuk-caption-m govuk-!-font-size-16 govuk-!-margin-left-0">
-                @foreach (string addressLine in Model.Organisation.GetLatestAddress().GetAddressLines())
-                {
-                    @(addressLine)<br/>
-                }
-            </dd>
-        </dl>
-        
+
         <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
@@ -70,7 +58,6 @@
             </div>
         </details>
         
-
         @{
             await Html.RenderPartialAsync("OrganisationReportsTable", Model);
         }
@@ -101,6 +88,17 @@
 
             await Html.RenderPartialAsync("UsersRegisteredToReportForOrganisation", Model);
         }
+        
+        <h2 class="govuk-heading-l">
+            Registered Address
+        </h2>
+        <p class="govuk-body">
+            @foreach (string addressLine in Model.Organisation.GetLatestAddress().GetAddressLines())
+            {
+                @(addressLine)<br/>
+            }
+        </p>
+
 
     </div>
 </div>

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
@@ -63,7 +63,7 @@
 
             <div class="govuk-!-margin-bottom-6">
                 <p>
-                    <a href="" class="govuk-!-font-size-19 govuk-link govuk-!-font-weight-bold">See all reports</a> <!--TODO: Point this link to the manage all reports page when that is created-->
+                    <a href="" class="govuk-!-font-size-19 govuk-link govuk-!-font-weight-bold">See all reports</a> <!--TODO: GPG-916: Point this link to the manage all reports page when that is created-->
                 </p>
             </div>
             await Html.RenderPartialAsync("UsersRegisteredToReportForOrganisation", Model);

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
@@ -70,7 +70,7 @@
             </div>
         </details>
         
-        <h2 class="govuk-heading-l">Manage reports</h2>
+
         @{
             await Html.RenderPartialAsync("OrganisationReportsTable", Model);
         }

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -30,10 +30,21 @@
         Text = " ",
         Colspan = 1
     });
+
+    var mobileHeadings = new List<TableCellViewModel>()
+    {
+        new TableCellViewModel
+        {
+            Text = " ",
+            Colspan = 1
+        }
+    };
     
     var allReturns = Model.GetOrganisationDetailsForYears();
     var desktopCurrentReportingPeriodRows = new List<TableRowViewModel>();
     var desktopMissingReportingPeriodRows = new List<TableRowViewModel>();
+    var mobileCurrentReportingPeriodRows = new List<TableRowViewModel>();
+    var mobileMissingReportingPeriodRows = new List<TableRowViewModel>();
     string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
     foreach (var organisationReturn in allReturns)
     {
@@ -42,28 +53,42 @@
         switch (reportTag)
         {
             case ReportTag.Submitted:
-                if(organisationReturn.ReportingYear == currentReportingYear)
-                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if (organisationReturn.ReportingYear == currentReportingYear)
+                {
+                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
+                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+                }
+
                 break;
             case ReportTag.SubmittedLate:
-                if(organisationReturn.ReportingYear == currentReportingYear)
-                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if (organisationReturn.ReportingYear == currentReportingYear)
+                {
+                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
+                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+                }
                 break;
             case ReportTag.Due:
-                if(organisationReturn.ReportingYear == currentReportingYear)
-                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if (organisationReturn.ReportingYear == currentReportingYear)
+                {
+                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
+                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+                }
                 break;
             case ReportTag.Overdue:
-                CreateAndAddCurrentReportingRow(desktopMissingReportingPeriodRows, organisationReturn);
+                AddRowDesktop(desktopMissingReportingPeriodRows, organisationReturn);
+                AddRowMobile(mobileMissingReportingPeriodRows, organisationReturn);
                 break;
             case ReportTag.NotRequired:
-                if(organisationReturn.ReportingYear == currentReportingYear)
-                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if (organisationReturn.ReportingYear == currentReportingYear)
+                {
+                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
+                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+                }
                 break;
         }
     }
 
-    void CreateAndAddCurrentReportingRow(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
+    void AddRowDesktop(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
     {
         var newRow = new TableRowViewModel
         {
@@ -128,94 +153,115 @@
         };
         rowList.Add(newRow);
     }
-}
 
-<h2 class="govuk-heading-l">Manage reports</h2>
-    @await Html.GovUkTable(new TableGovUkViewModel
-        {
-            Head = desktopHeadings,
-            Rows = desktopCurrentReportingPeriodRows,
-            Classes = "gpg-govuk-hideOnMobile"
-        })
-@{
-    if (desktopMissingReportingPeriodRows.Count > 0)
+    void AddRowMobile(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
     {
-        <h2 class="govuk-heading-l">Missing reports</h2>
-            @await Html.GovUkTable(new TableGovUkViewModel
+        var newRow = new TableRowViewModel
+        {
+            Row = new List<TableCellViewModel>
             {
-                Head = desktopHeadings,
-                Rows = desktopMissingReportingPeriodRows,
-                Classes = "gpg-govuk-hideOnMobile"
-            })
+                new TableCellViewModel
+                {
+                    Html = @<text>
+                               <div>
+                                   <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+                                       Snapshot date: @organisation.SectorType.GetAccountingStartDate(viewModel.ReportingYear).ToString("dd/MM/yyyy")
+                                   </p>
+                                   @if (viewModel.CanChangeScope())
+                                   {
+                                       <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+                                           @viewModel.GetRequiredToReportOrNotText()
+                                       </p>
+                                       <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+                                           <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = viewModel.ReportingYear})">
+                                               Think this is wrong?<span class="govuk-visually-hidden"> scope for year @viewModel.GetFormattedYearText()</span>
+                                           </a>
+                                       </div>
+                                   }
+                                   else
+                                   {
+                                       <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+                                           @viewModel.GetRequiredToReportOrNotText()
+                                       </p>
+                                   }
+                               </div>
+                               
+                               <strong class="govuk-tag @viewModel.GetReportTagClassName()">
+                                   @viewModel.GetReportTagText().ToUpper()
+                               </strong>
+                               
+                               <div>
+                                    @{
+                                        string description = viewModel.GetReportTagDescription();
+                                        string modifiedDateText = viewModel.GetModifiedDateText();
+                                        string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-3";
+        
+                                        if (description != null)
+                                        {
+                                            <div class="govuk-!-margin-top-3">@description</div>
+                                        }
+        
+                                        if (modifiedDateText != null)
+                                        {
+                                            <div class="@modifiedDateTextClass">@modifiedDateText</div>
+                                        }
+                                    }
+                               </div>
+                               <br/>
+                               
+                               <div class="govuk-!-margin-bottom-5">
+                                    <a loadtest-id="create-report-@viewModel.ReportingYear"
+                                       href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId, reportingYear = viewModel.ReportingYear, canTriggerLateSubmissionWarning = true})">
+                                        @viewModel.GetReportLinkText()
+                                    </a>
+                               </div>
+                           </text>
+                },
+            }
+        };
+        rowList.Add(newRow);
     }
 }
 
+<h2 class="govuk-heading-l gpg-govuk-hideOnMobile">Manage reports</h2>
+<h2 class="govuk-heading-l gpg-govuk-hideOnDesktop govuk-!-margin-bottom-0">Manage reports</h2>
+@{
+    var missingReports = desktopMissingReportingPeriodRows.Count > 0;
+    var mobileReportingPeriodsClasses = missingReports ? "gpg-govuk-hideOnDesktop govuk-!-margin-bottom-9" : "gpg-govuk-hideOnDesktop govuk-!-margin-bottom-1";
+}
 
-<h2 class="govuk-heading-l">Old Manage reports</h2>
-<div class="overflowx">
-    <table class="govuk-table">
-    <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Year</th>
-            <th scope="col" class="govuk-table__header">Reporting requirement</th>
-            <th scope="col" class="govuk-table__header">Report status</th>
-            <th scope="col" class="govuk-table__header"></th>
-        </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-        @{
-            foreach (ManageOrganisationDetailsForYearViewModel detailsForYear in Model.GetOrganisationDetailsForYears())
-            {
+@await Html.GovUkTable(new TableGovUkViewModel
+    {
+        Head = desktopHeadings,
+        Rows = desktopCurrentReportingPeriodRows,
+        Classes = "gpg-govuk-hideOnMobile"
+    })
+@await Html.GovUkTable(new TableGovUkViewModel
+    {
+        Head = new List<TableCellViewModel>(),
+        Rows = mobileCurrentReportingPeriodRows,
+        Classes = mobileReportingPeriodsClasses
+    })
 
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-!-font-weight-bold">
-                        @detailsForYear.GetFormattedYearText()
-                    </td>
-                    
-                    <td class="govuk-table__cell">
-                        <div>
-                            @detailsForYear.GetRequiredToReportOrNotText()
-                        </div>
-                        @if (detailsForYear.CanChangeScope()) 
-                        {
-                            <div>
-                                <a href="@Url.Action("ChangeOrganisationScope", "Scope", new { encryptedOrganisationId, reportingYear = detailsForYear.ReportingYear })">
-                                    Think this is wrong?<span class="govuk-visually-hidden"> scope for year @detailsForYear.GetFormattedYearText()</span>
-                                </a>
-                            </div>
-                        }
-                    </td>
-                    
-                    <td class="govuk-table__cell">
-                        <strong class="govuk-tag @detailsForYear.GetReportTagClassName()">
-                            @detailsForYear.GetReportTagText().ToUpper()
-                        </strong>
-                        @{
-                            string description = detailsForYear.GetReportTagDescription();
-                            string modifiedDateText = detailsForYear.GetModifiedDateText();
-                            string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-3";
-                            
-                            if (description != null)
-                            {
-                                <div class="govuk-!-margin-top-3">@description</div>
-                            }
+@if (missingReports)
+{
+    <h2 class="govuk-heading-l gpg-govuk-hideOnMobile">Missing reports</h2>
+    <h2 class="govuk-heading-l gpg-govuk-hideOnDesktop govuk-!-margin-bottom-0">Missing reports</h2>
+        @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = desktopHeadings,
+            Rows = desktopMissingReportingPeriodRows,
+            Classes = "gpg-govuk-hideOnMobile govuk-!-margin-bottom-3"
+        })
+        @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = new List<TableCellViewModel>(),
+            Rows = mobileMissingReportingPeriodRows,
+            Classes = "gpg-govuk-hideOnDesktop govuk-!-margin-bottom-1"
+        })
+}
 
-                            if (modifiedDateText != null)
-                            {
-                                <div class="@modifiedDateTextClass">@modifiedDateText</div>
-                            }
-                        }
-                    </td>
 
-                    <td class="govuk-table__cell">
-                        <a loadtest-id="create-report-@detailsForYear.ReportingYear"
-                           href="@Url.Action("ReportOverview", "ReportOverview", new { encryptedOrganisationId, reportingYear = detailsForYear.ReportingYear, canTriggerLateSubmissionWarning = true})">
-                            @detailsForYear.GetReportLinkText()
-                        </a>
-                    </td>
-                </tr>
-            }
-        }
-    </tbody>
-</table>
-</div>
+    
+
+

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -1,31 +1,31 @@
-﻿@using GenderPayGap.WebUI.Models.ManageOrganisations
+﻿@using GenderPayGap.Core.Classes
 @using GenderPayGap.Core.Helpers
+@using GenderPayGap.WebUI.Models.ManageOrganisations
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @using GenderPayGap.Core
-@using GenderPayGap.Database
 @model GenderPayGap.WebUI.Models.ManageOrganisations.ManageOrganisationViewModel
 
 @{
     var organisation = Model.Organisation;
     
     var desktopHeadings = new List<TableCellViewModel>();
-    desktopHeadings.Add(new TableCellViewModel()
+    desktopHeadings.Add(new TableCellViewModel
     {
         Text = "Snapshot date",
         Colspan = 1
     });
-    desktopHeadings.Add(new TableCellViewModel()
+    desktopHeadings.Add(new TableCellViewModel
     {
         Text = "Reporting requirements",
         Colspan = 1
     });
-    desktopHeadings.Add(new TableCellViewModel()
+    desktopHeadings.Add(new TableCellViewModel
     {
         Text = "Report status",
         Colspan = 1
     });
-    desktopHeadings.Add(new TableCellViewModel()
+    desktopHeadings.Add(new TableCellViewModel
     {
         Text = " ",
         Colspan = 1
@@ -38,42 +38,45 @@
     foreach (var organisationReturn in allReturns)
     {
         var reportTag = organisationReturn.GetReportTag();
+        var currentReportingYear = ReportingYearsHelper.GetCurrentReportingYear();
         switch (reportTag)
         {
             case ReportTag.Submitted:
-                CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if(organisationReturn.ReportingYear == currentReportingYear)
+                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
                 break;
             case ReportTag.SubmittedLate:
-                CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if(organisationReturn.ReportingYear == currentReportingYear)
+                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
                 break;
             case ReportTag.Due:
-                CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                if(organisationReturn.ReportingYear == currentReportingYear)
+                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
                 break;
             case ReportTag.Overdue:
+                CreateAndAddCurrentReportingRow(desktopMissingReportingPeriodRows, organisationReturn);
                 break;
             case ReportTag.NotRequired:
+                if(organisationReturn.ReportingYear == currentReportingYear)
+                    CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
                 break;
-            default:
-                throw new ArgumentOutOfRangeException();
         }
-
-
-
     }
 
     void CreateAndAddCurrentReportingRow(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
     {
-        var newRow = new TableRowViewModel()
+        var newRow = new TableRowViewModel
         {
-            Row = new List<TableCellViewModel>()
+            Row = new List<TableCellViewModel>
             {
-                new TableCellViewModel()
+                new TableCellViewModel
                 {
                     Html = @<text>
-                               @viewModel.GetFormattedYearText()
-                            </text>
+                               @organisation.SectorType.GetAccountingStartDate(viewModel.ReportingYear).ToString("dd/MM/yyyy")
+                            </text>,
+                    Classes = "govuk-!-font-weight-bold"
                 },
-                new TableCellViewModel()
+                new TableCellViewModel
                 {
                     Html = @<text>
                                 <div>
@@ -82,14 +85,14 @@
                                 @if (viewModel.CanChangeScope()) 
                                 {
                                     <div>
-                                        <a href="@Url.Action("ChangeOrganisationScope", "Scope", new { encryptedOrganisationId, reportingYear = organisationReturn.ReportingYear })">
+                                        <a href="@Url.Action("ChangeOrganisationScope", "Scope", new { encryptedOrganisationId, reportingYear = viewModel.ReportingYear })">
                                             Change<span class="govuk-visually-hidden"> scope for year @viewModel.GetFormattedYearText()</span>
                                         </a>
                                     </div>
                                 }
                             </text>
                 },
-                new TableCellViewModel()
+                new TableCellViewModel
                 {
                     Html = @<text>
                                 <strong class="govuk-tag @viewModel.GetReportTagClassName()">
@@ -112,7 +115,7 @@
                                 }
                             </text>
                 },
-                new TableCellViewModel()
+                new TableCellViewModel
                 {
                     Html = @<text>
                                 <a loadtest-id="create-report-@viewModel.ReportingYear"
@@ -125,12 +128,6 @@
         };
         rowList.Add(newRow);
     }
-    
-    
-    
-    
-
-    
 }
 
 <h2 class="govuk-heading-l">Manage reports</h2>
@@ -140,14 +137,19 @@
             Rows = desktopCurrentReportingPeriodRows,
             Classes = "gpg-govuk-hideOnMobile"
         })
+@{
+    if (desktopMissingReportingPeriodRows.Count > 0)
+    {
+        <h2 class="govuk-heading-l">Missing reports</h2>
+            @await Html.GovUkTable(new TableGovUkViewModel
+            {
+                Head = desktopHeadings,
+                Rows = desktopMissingReportingPeriodRows,
+                Classes = "gpg-govuk-hideOnMobile"
+            })
+    }
+}
 
-<h2 class="govuk-heading-l">Missing reports</h2>
-    @await Html.GovUkTable(new TableGovUkViewModel
-        {
-            Head = desktopHeadings,
-            Rows = new List<TableRowViewModel>(),
-            Classes = "gpg-govuk-hideOnMobile"
-        })
 
 <h2 class="govuk-heading-l">Old Manage reports</h2>
 <div class="overflowx">
@@ -178,7 +180,7 @@
                         {
                             <div>
                                 <a href="@Url.Action("ChangeOrganisationScope", "Scope", new { encryptedOrganisationId, reportingYear = detailsForYear.ReportingYear })">
-                                    Change<span class="govuk-visually-hidden"> scope for year @detailsForYear.GetFormattedYearText()</span>
+                                    Think this is wrong?<span class="govuk-visually-hidden"> scope for year @detailsForYear.GetFormattedYearText()</span>
                                 </a>
                             </div>
                         }

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -43,19 +43,20 @@
     {
         var reportTag = organisationReturn.GetReportTag();
         var currentReportingYear = ReportingYearsHelper.GetCurrentReportingYear();
-        if (reportTag == ReportTag.Overdue || reportTag == ReportTag.NotRequired)
+ 
+        if (reportTag == ReportTag.Overdue)
         {
-            AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
-            AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+            desktopMissingReportingPeriodRows.Add(GenerateDesktopRow(organisationReturn));
+            mobileMissingReportingPeriodRows.Add(GenerateMobileRow(organisationReturn));
         }
         else if (organisationReturn.ReportingYear == currentReportingYear)
         {
-            AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
-            AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+            desktopCurrentReportingPeriodRows.Add(GenerateDesktopRow(organisationReturn));
+            mobileCurrentReportingPeriodRows.Add(GenerateMobileRow(organisationReturn));
         }
     }
 
-    void AddRowDesktop(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
+    TableRowViewModel GenerateDesktopRow(ManageOrganisationDetailsForYearViewModel viewModel)
     {
         var newRow = new TableRowViewModel
         {
@@ -118,10 +119,10 @@
                 },
             }
         };
-        rowList.Add(newRow);
+        return newRow;
     }
 
-    void AddRowMobile(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
+    TableRowViewModel GenerateMobileRow(ManageOrganisationDetailsForYearViewModel viewModel)
     {
         var newRow = new TableRowViewModel
         {
@@ -186,7 +187,7 @@
                 },
             }
         };
-        rowList.Add(newRow);
+        return newRow;
     }
 }
 

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -8,38 +8,31 @@
 
 @{
     var organisation = Model.Organisation;
-    
-    var desktopHeadings = new List<TableCellViewModel>();
-    desktopHeadings.Add(new TableCellViewModel
-    {
-        Text = "Snapshot date",
-        Colspan = 1
-    });
-    desktopHeadings.Add(new TableCellViewModel
-    {
-        Text = "Reporting requirements",
-        Colspan = 1
-    });
-    desktopHeadings.Add(new TableCellViewModel
-    {
-        Text = "Report status",
-        Colspan = 1
-    });
-    desktopHeadings.Add(new TableCellViewModel
-    {
-        Text = " ",
-        Colspan = 1
-    });
 
-    var mobileHeadings = new List<TableCellViewModel>()
+    var desktopHeadings = new List<TableCellViewModel>
     {
+        new TableCellViewModel
+        {
+            Text = "Snapshot date",
+            Colspan = 1
+        },
+        new TableCellViewModel
+        {
+            Text = "Reporting requirements",
+            Colspan = 1
+        },
+        new TableCellViewModel
+        {
+            Text = "Report status",
+            Colspan = 1
+        },
         new TableCellViewModel
         {
             Text = " ",
             Colspan = 1
         }
     };
-    
+
     var allReturns = Model.GetOrganisationDetailsForYears();
     var desktopCurrentReportingPeriodRows = new List<TableRowViewModel>();
     var desktopMissingReportingPeriodRows = new List<TableRowViewModel>();
@@ -50,41 +43,15 @@
     {
         var reportTag = organisationReturn.GetReportTag();
         var currentReportingYear = ReportingYearsHelper.GetCurrentReportingYear();
-        switch (reportTag)
+        if (reportTag == ReportTag.Overdue || reportTag == ReportTag.NotRequired)
         {
-            case ReportTag.Submitted:
-                if (organisationReturn.ReportingYear == currentReportingYear)
-                {
-                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
-                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
-                }
-
-                break;
-            case ReportTag.SubmittedLate:
-                if (organisationReturn.ReportingYear == currentReportingYear)
-                {
-                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
-                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
-                }
-                break;
-            case ReportTag.Due:
-                if (organisationReturn.ReportingYear == currentReportingYear)
-                {
-                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
-                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
-                }
-                break;
-            case ReportTag.Overdue:
-                AddRowDesktop(desktopMissingReportingPeriodRows, organisationReturn);
-                AddRowMobile(mobileMissingReportingPeriodRows, organisationReturn);
-                break;
-            case ReportTag.NotRequired:
-                if (organisationReturn.ReportingYear == currentReportingYear)
-                {
-                    AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
-                    AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
-                }
-                break;
+            AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
+            AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
+        }
+        else if (organisationReturn.ReportingYear == currentReportingYear)
+        {
+            AddRowDesktop(desktopCurrentReportingPeriodRows, organisationReturn);
+            AddRowMobile(mobileCurrentReportingPeriodRows, organisationReturn);
         }
     }
 
@@ -111,7 +78,7 @@
                                 {
                                     <div>
                                         <a href="@Url.Action("ChangeOrganisationScope", "Scope", new { encryptedOrganisationId, reportingYear = viewModel.ReportingYear })">
-                                            Change<span class="govuk-visually-hidden"> scope for year @viewModel.GetFormattedYearText()</span>
+                                            Think this is wrong?<span class="govuk-visually-hidden"> scope for year @viewModel.GetFormattedYearText()</span>
                                         </a>
                                     </div>
                                 }

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -1,7 +1,155 @@
 ﻿@using GenderPayGap.WebUI.Models.ManageOrganisations
 @using GenderPayGap.Core.Helpers
+@using GovUkDesignSystem
+@using GovUkDesignSystem.GovUkDesignSystemComponents
+@using GenderPayGap.Core
+@using GenderPayGap.Database
 @model GenderPayGap.WebUI.Models.ManageOrganisations.ManageOrganisationViewModel
 
+@{
+    var organisation = Model.Organisation;
+    
+    var desktopHeadings = new List<TableCellViewModel>();
+    desktopHeadings.Add(new TableCellViewModel()
+    {
+        Text = "Snapshot date",
+        Colspan = 1
+    });
+    desktopHeadings.Add(new TableCellViewModel()
+    {
+        Text = "Reporting requirements",
+        Colspan = 1
+    });
+    desktopHeadings.Add(new TableCellViewModel()
+    {
+        Text = "Report status",
+        Colspan = 1
+    });
+    desktopHeadings.Add(new TableCellViewModel()
+    {
+        Text = " ",
+        Colspan = 1
+    });
+    
+    var allReturns = Model.GetOrganisationDetailsForYears();
+    var desktopCurrentReportingPeriodRows = new List<TableRowViewModel>();
+    var desktopMissingReportingPeriodRows = new List<TableRowViewModel>();
+    string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
+    foreach (var organisationReturn in allReturns)
+    {
+        var reportTag = organisationReturn.GetReportTag();
+        switch (reportTag)
+        {
+            case ReportTag.Submitted:
+                CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                break;
+            case ReportTag.SubmittedLate:
+                CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                break;
+            case ReportTag.Due:
+                CreateAndAddCurrentReportingRow(desktopCurrentReportingPeriodRows, organisationReturn);
+                break;
+            case ReportTag.Overdue:
+                break;
+            case ReportTag.NotRequired:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+
+
+
+    }
+
+    void CreateAndAddCurrentReportingRow(List<TableRowViewModel> rowList, ManageOrganisationDetailsForYearViewModel viewModel)
+    {
+        var newRow = new TableRowViewModel()
+        {
+            Row = new List<TableCellViewModel>()
+            {
+                new TableCellViewModel()
+                {
+                    Html = @<text>
+                               @viewModel.GetFormattedYearText()
+                            </text>
+                },
+                new TableCellViewModel()
+                {
+                    Html = @<text>
+                                <div>
+                                    @viewModel.GetRequiredToReportOrNotText()
+                                </div>
+                                @if (viewModel.CanChangeScope()) 
+                                {
+                                    <div>
+                                        <a href="@Url.Action("ChangeOrganisationScope", "Scope", new { encryptedOrganisationId, reportingYear = organisationReturn.ReportingYear })">
+                                            Change<span class="govuk-visually-hidden"> scope for year @viewModel.GetFormattedYearText()</span>
+                                        </a>
+                                    </div>
+                                }
+                            </text>
+                },
+                new TableCellViewModel()
+                {
+                    Html = @<text>
+                                <strong class="govuk-tag @viewModel.GetReportTagClassName()">
+                                    @viewModel.GetReportTagText().ToUpper()
+                                </strong>
+                                @{
+                                    string description = viewModel.GetReportTagDescription();
+                                    string modifiedDateText = viewModel.GetModifiedDateText();
+                                    string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-3";
+                                    
+                                    if (description != null)
+                                    {
+                                        <div class="govuk-!-margin-top-3">@description</div>
+                                    }
+        
+                                    if (modifiedDateText != null)
+                                    {
+                                        <div class="@modifiedDateTextClass">@modifiedDateText</div>
+                                    }
+                                }
+                            </text>
+                },
+                new TableCellViewModel()
+                {
+                    Html = @<text>
+                                <a loadtest-id="create-report-@viewModel.ReportingYear"
+                                    href="@Url.Action("ReportOverview", "ReportOverview", new { encryptedOrganisationId, reportingYear = viewModel.ReportingYear, canTriggerLateSubmissionWarning = true})">
+                                    @viewModel.GetReportLinkText()
+                                </a>
+                            </text>
+                },
+            }
+        };
+        rowList.Add(newRow);
+    }
+    
+    
+    
+    
+
+    
+}
+
+<h2 class="govuk-heading-l">Manage reports</h2>
+    @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = desktopHeadings,
+            Rows = desktopCurrentReportingPeriodRows,
+            Classes = "gpg-govuk-hideOnMobile"
+        })
+
+<h2 class="govuk-heading-l">Missing reports</h2>
+    @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = desktopHeadings,
+            Rows = new List<TableRowViewModel>(),
+            Classes = "gpg-govuk-hideOnMobile"
+        })
+
+<h2 class="govuk-heading-l">Old Manage reports</h2>
 <div class="overflowx">
     <table class="govuk-table">
     <thead class="govuk-table__head">
@@ -16,8 +164,7 @@
         @{
             foreach (ManageOrganisationDetailsForYearViewModel detailsForYear in Model.GetOrganisationDetailsForYears())
             {
-                string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
-                
+
                 <tr class="govuk-table__row">
                     <td class="govuk-table__cell govuk-!-font-weight-bold">
                         @detailsForYear.GetFormattedYearText()

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/OrganisationReportsTable.cshtml
@@ -194,11 +194,11 @@
                                     @{
                                         string description = viewModel.GetReportTagDescription();
                                         string modifiedDateText = viewModel.GetModifiedDateText();
-                                        string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-3";
+                                        string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-4";
         
                                         if (description != null)
                                         {
-                                            <div class="govuk-!-margin-top-3">@description</div>
+                                            <div class="govuk-!-margin-top-1">@description</div>
                                         }
         
                                         if (modifiedDateText != null)

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/UsersRegisteredToReportForOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/UsersRegisteredToReportForOrganisation.cshtml
@@ -1,35 +1,130 @@
 ﻿@using GenderPayGap.Database
+@using GovUkDesignSystem
+@using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.ManageOrganisations.ManageOrganisationViewModel
 
 @{
     var encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
+
+    var desktopHeadings = new List<TableCellViewModel>
+    {
+        new TableCellViewModel
+        {
+            Text = "User",
+            Colspan = 1
+        },
+        new TableCellViewModel
+        {
+            Text = "Action",
+            Colspan = 1
+        }
+    };
+    var mobileRows = new List<TableRowViewModel>();
+    @foreach (User userRegisteredToReport in Model.GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst())
+    {
+        var encryptedUserId = Encryption.EncryptQuerystring(userRegisteredToReport.UserId.ToString());
+        var newRow = new TableRowViewModel
+        {
+            Row = new List<TableCellViewModel>
+            {
+                new TableCellViewModel
+                {
+                    Html = @<text>
+                               <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+                                   @userRegisteredToReport.Fullname
+                                   @if (userRegisteredToReport.UserId == Model.User.UserId)
+                                   {
+                                       <span>(You)</span>
+                                   }
+                                </p>
+                               <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+                                   <a class="govuk-link" href="@(Url.Action("RemoveOrganisation", "Organisation", new {orgId = encryptedOrganisationId, userId = encryptedUserId}))">
+                                       Remove user <span class="govuk-visually-hidden">@userRegisteredToReport.Fullname</span>
+                                   </a>
+                               </p>
+                            </text>
+                },
+                new TableCellViewModel
+                {
+                    Text = " "
+                }
+            },
+        };
+        mobileRows.Add(newRow);
+    }
+    
+    var desktopRows = new List<TableRowViewModel>();
+    @foreach (User userRegisteredToReport in Model.GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst())
+    {
+        var encryptedUserId = Encryption.EncryptQuerystring(userRegisteredToReport.UserId.ToString());
+        var newRow = new TableRowViewModel
+        {
+            Row = new List<TableCellViewModel>
+            {
+                new TableCellViewModel
+                {
+                    Html = @<text>
+                               @userRegisteredToReport.Fullname
+                               @if (userRegisteredToReport.UserId == Model.User.UserId)
+                               {
+                                   <span>(You)</span>
+                               }
+                               <br/>
+                            </text>
+                },
+                new TableCellViewModel
+                {
+                    Html = @<text>
+                               <a class="govuk-link" href="@(Url.Action("RemoveOrganisation", "Organisation", new {orgId = encryptedOrganisationId, userId = encryptedUserId}))">
+                                  Remove user <span class="govuk-visually-hidden">@userRegisteredToReport.Fullname</span>
+                              </a>
+                            </text>
+                }
+            },
+        };
+        desktopRows.Add(newRow);
+    }
+    
 }
 
-<table class="govuk-table">
-    <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">User</th>
-            <th scope="col" class="govuk-table__header">Action</th>
-        </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-        @foreach (User userRegisteredToReport in Model.GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst())
+<h2 class="govuk-heading-l">Registered users</h2>
+    @{
+        var usersRegisteredToReportForOrganisation = Model.Organisation.UserOrganisations.Where(uo => uo.PINConfirmedDate.HasValue).Select(uo => uo.User).Distinct().ToList();
+    }
+
+    @if (usersRegisteredToReportForOrganisation.Count == 0)
+    {
+        <p class="govuk-body govuk-!-margin-bottom-0">
+            You are the only person registered to report for this employer.
+        </p>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+            If you remove yourself:
+        </p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+            <li>You will not be able to report for this employer</li>
+            <li>Someone else must register this employer to report - this can take up to a week</li>
+            <li>Your account will remain open</li>
+        </ul>
+    }
+    else
+    {
+        <p class="govuk-body govuk-!-margin-bottom-0">
+            The following people are registered to report gender pay gap information for this employer.
+        </p>
+    }
+        
+    @await Html.GovUkTable(new TableGovUkViewModel
         {
-            var encryptedUserId = Encryption.EncryptQuerystring(userRegisteredToReport.UserId.ToString());
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">
-                    @userRegisteredToReport.Fullname
-                    @if (userRegisteredToReport.UserId == Model.User.UserId)
-                    {
-                        <span>(You)</span>
-                    }
-                </td>
-                <td class="govuk-table__cell">
-                    <a class="govuk-link" href="@(Url.Action("RemoveOrganisation", "Organisation", new {orgId = encryptedOrganisationId, userId = encryptedUserId}))">
-                        Remove user <span class="govuk-visually-hidden">@userRegisteredToReport.Fullname</span>
-                    </a>
-                </td>
-            </tr>
-        }
-    </tbody>
-</table>
+            Head = desktopHeadings,
+            Rows = desktopRows,
+            Classes = "gpg-govuk-hideOnMobile"
+        })
+    @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = new List<TableCellViewModel>(),
+            Rows = mobileRows,
+            Classes = "gpg-govuk-hideOnDesktop"
+        })
+
+
+

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/UsersRegisteredToReportForOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/UsersRegisteredToReportForOrganisation.cshtml
@@ -19,11 +19,14 @@
             Colspan = 1
         }
     };
+
     var mobileRows = new List<TableRowViewModel>();
+    var desktopRows = new List<TableRowViewModel>();
     @foreach (User userRegisteredToReport in Model.GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst())
     {
         var encryptedUserId = Encryption.EncryptQuerystring(userRegisteredToReport.UserId.ToString());
-        var newRow = new TableRowViewModel
+
+        var mobileRow = new TableRowViewModel
         {
             Row = new List<TableCellViewModel>
             {
@@ -36,55 +39,47 @@
                                    {
                                        <span>(You)</span>
                                    }
-                                </p>
+                               </p>
                                <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
                                    <a class="govuk-link" href="@(Url.Action("RemoveOrganisation", "Organisation", new {orgId = encryptedOrganisationId, userId = encryptedUserId}))">
                                        Remove user <span class="govuk-visually-hidden">@userRegisteredToReport.Fullname</span>
                                    </a>
                                </p>
                             </text>
-                },
-                new TableCellViewModel
-                {
-                    Text = " "
                 }
-            },
+            }
         };
-        mobileRows.Add(newRow);
-    }
-    
-    var desktopRows = new List<TableRowViewModel>();
-    @foreach (User userRegisteredToReport in Model.GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst())
-    {
-        var encryptedUserId = Encryption.EncryptQuerystring(userRegisteredToReport.UserId.ToString());
-        var newRow = new TableRowViewModel
+        var desktopRow = new TableRowViewModel
         {
             Row = new List<TableCellViewModel>
             {
                 new TableCellViewModel
                 {
                     Html = @<text>
-                               @userRegisteredToReport.Fullname
-                               @if (userRegisteredToReport.UserId == Model.User.UserId)
-                               {
-                                   <span>(You)</span>
-                               }
-                               <br/>
+                               <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+                                   @userRegisteredToReport.Fullname
+                                   @if (userRegisteredToReport.UserId == Model.User.UserId)
+                                   {
+                                       <span>(You)</span>
+                                   }
+                               </p>
                             </text>
                 },
                 new TableCellViewModel
                 {
                     Html = @<text>
-                               <a class="govuk-link" href="@(Url.Action("RemoveOrganisation", "Organisation", new {orgId = encryptedOrganisationId, userId = encryptedUserId}))">
-                                  Remove user <span class="govuk-visually-hidden">@userRegisteredToReport.Fullname</span>
-                              </a>
+                              <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+                                  <a class="govuk-link" href="@(Url.Action("RemoveOrganisation", "Organisation", new {orgId = encryptedOrganisationId, userId = encryptedUserId}))">
+                                      Remove user <span class="govuk-visually-hidden">@userRegisteredToReport.Fullname</span>
+                                  </a>
+                              </p>
                             </text>
                 }
-            },
+            }
         };
-        desktopRows.Add(newRow);
+        desktopRows.Add(desktopRow);
+        mobileRows.Add(mobileRow);
     }
-    
 }
 
 <h2 class="govuk-heading-l">Registered users</h2>
@@ -125,6 +120,4 @@
             Rows = mobileRows,
             Classes = "gpg-govuk-hideOnDesktop"
         })
-
-
-
+        

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -184,7 +184,6 @@
                                                <div class="govuk-grid-column-one-half govuk-!-padding-left-0">
                                                    <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-employer-table-right">Report Status</h3>
                                                </div>
-
                                            </div>
                                         </text>
                             }
@@ -251,7 +250,6 @@
                                                                     View report <span class="visually-hidden">for @report.GetReportingPeriod()</span>
                                                                 </a>
                                                             </div>
-
                                                         </div>
                                                         break;
                                                 }


### PR DESCRIPTION
This page is for users who are logged in and are associated with a company. This gives them a sort of dashboard where they can move onto other actions such as completing a report, editing an old report or viewing all reports.

### Changes:
-  There was one large table which held info for every reporting year on one page, we now have 2 tables, 1) latest due report, 2) missing reports.
![image](https://user-images.githubusercontent.com/62190777/198076071-a73b9c42-bb05-4473-917d-f4ad3eb29b5d.png)
 - Company registered address moved to bottom of the page and styled as per the rest of the page.
![image](https://user-images.githubusercontent.com/62190777/198076163-80d504db-f088-471a-b82f-6249976207e8.png)
 - Link to view all reports page created (though not linked up yet).
![image](https://user-images.githubusercontent.com/62190777/198076338-c248b8b5-fd41-449b-9592-d8d3083d19cc.png)

Note: I moved the "registered users" table over to using a design library component as I had to make a visual change to it and saw an opportunity to improve the maintainability of the code.

 
 
