### PR TITLE
Gpg 916 all reports page

### DIFF
--- a/GenderPayGap.WebUI/Controllers/ManageOrganisations/ManageOrganisationsController.cs
+++ b/GenderPayGap.WebUI/Controllers/ManageOrganisations/ManageOrganisationsController.cs
@@ -96,12 +96,7 @@ namespace GenderPayGap.WebUI.Controllers.ManageOrganisations
                 dataRepository.GetAll<DraftReturn>()
                     .Where(d => d.OrganisationId == organisationId)
                     .ToList();
-            
-            if (string.IsNullOrWhiteSpace(encryptedOrganisationId))
-            {
-                return new HttpBadRequestResult("Missing employer identifier");
-            }
-            
+
             var totalEntries = organisation.GetRecentReports(Global.ShowReportYearCount).Count() + 1; // Years we report for + the year they joined
             var maxEntriesPerPage = 10;
             var totalPages = (int)Math.Ceiling((double)totalEntries / maxEntriesPerPage);

--- a/GenderPayGap.WebUI/Controllers/ManageOrganisations/ManageOrganisationsController.cs
+++ b/GenderPayGap.WebUI/Controllers/ManageOrganisations/ManageOrganisationsController.cs
@@ -116,7 +116,7 @@ namespace GenderPayGap.WebUI.Controllers.ManageOrganisations
                 page = totalPages;
             }
             
-            var viewModel = new AllOrganisationReportsViewModel(organisation, user, allDraftReturns, page, totalEntries, maxEntriesPerPage);
+            var viewModel = new AllOrganisationReportsViewModel(organisation, user, allDraftReturns, page, totalPages, maxEntriesPerPage);
             return View("AllOrganisationReports", viewModel);
         }
 

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GenderPayGap.Core.Helpers;
+using GenderPayGap.Database;
+using GenderPayGap.Database.Models;
+using GenderPayGap.WebUI.Models.Admin;
+
+namespace GenderPayGap.WebUI.Models.ManageOrganisations
+{
+    public class AllOrganisationReportsViewModel
+    {
+
+        public Database.Organisation Organisation { get; }
+        public User User { get; }
+
+        private readonly List<DraftReturn> allDraftReturns;
+
+        public AllOrganisationReportsViewModel(Database.Organisation organisation, User user, List<DraftReturn> allDraftReturns, int? currentPage, int? totalPages, int? entriesPerPage)
+        {
+            Organisation = organisation;
+            User = user;
+            this.allDraftReturns = allDraftReturns;
+            CurrentPage = currentPage;
+            TotalPages = totalPages;
+            EntriesPerPage = entriesPerPage;
+        }
+        
+        public int? CurrentPage { get; set; }
+        public int? TotalPages { get; set; }
+        public int? EntriesPerPage { get; set; }
+
+        public List<User> GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst()
+        {
+            List<User> users = Organisation.UserOrganisations
+                .Where(uo => uo.PINConfirmedDate.HasValue)
+                .Select(uo => uo.User)
+                .ToList();
+
+            // The current user must be in this list (otherwise we wouldn't be able to visit this page)
+            // So, remove the user from wherever they are n the list
+            // And insert them at the start of the list
+            users.Remove(User);
+            users.Insert(0, User);
+
+            return users;
+        }
+
+        public List<ManageOrganisationDetailsForYearViewModel> GetOrganisationDetailsForYears()
+        {
+            List<int> reportingYears = ReportingYearsHelper.GetReportingYears();
+            var detailsForYears = new List<ManageOrganisationDetailsForYearViewModel>();
+
+            foreach (int reportingYear in reportingYears)
+            {
+                // Get organisation's scope for given reporting year
+                var scopeForYear = Organisation.GetScopeForYear(reportingYear);
+
+                if (scopeForYear != null)
+                {
+                    detailsForYears.Add(
+                        new ManageOrganisationDetailsForYearViewModel(
+                            Organisation,
+                            reportingYear,
+                            allDraftReturns.Where(d => d.SnapshotYear == reportingYear)
+                                .OrderByDescending(d => d.Modified)
+                                .FirstOrDefault()
+                        )
+                    );
+                }
+            }
+
+            return detailsForYears;
+        }
+    }
+}

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
@@ -7,7 +7,6 @@ using GenderPayGap.Core.Helpers;
 using GenderPayGap.Database;
 using GenderPayGap.Database.Models;
 using GenderPayGap.WebUI.Classes;
-using GenderPayGap.WebUI.Models.Admin;
 
 namespace GenderPayGap.WebUI.Models.ManageOrganisations
 {
@@ -16,8 +15,11 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
 
         public Database.Organisation Organisation { get; }
         public User User { get; }
-
+        
         private readonly List<DraftReturn> allDraftReturns;
+        public int? CurrentPage { get; set; }
+        public int? TotalPages { get; set; }
+        public int? EntriesPerPage { get; set; }
 
         public AllOrganisationReportsViewModel(Database.Organisation organisation, User user, List<DraftReturn> allDraftReturns, int? currentPage, int? totalPages, int? entriesPerPage)
         {
@@ -27,26 +29,6 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
             CurrentPage = currentPage;
             TotalPages = totalPages;
             EntriesPerPage = entriesPerPage;
-        }
-        
-        public int? CurrentPage { get; set; }
-        public int? TotalPages { get; set; }
-        public int? EntriesPerPage { get; set; }
-
-        public List<User> GetFullyRegisteredUsersForOrganisationWithCurrentUserFirst()
-        {
-            List<User> users = Organisation.UserOrganisations
-                .Where(uo => uo.PINConfirmedDate.HasValue)
-                .Select(uo => uo.User)
-                .ToList();
-
-            // The current user must be in this list (otherwise we wouldn't be able to visit this page)
-            // So, remove the user from wherever they are n the list
-            // And insert them at the start of the list
-            users.Remove(User);
-            users.Insert(0, User);
-
-            return users;
         }
 
         public List<AllOrganisationReportsForYearViewModel> GetOrganisationDetailsForYears()

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
@@ -65,18 +65,15 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
         public int ReportingYear { get; }
 
         private readonly Database.Organisation organisation;
-        private readonly DraftReturn draftReturnForYear;
         private readonly bool hasDraftReturnForYear;
 
         public AllOrganisationReportsForYearViewModel(Database.Organisation organisation, int reportingYear, DraftReturn draftReturnForYear)
         {
             this.organisation = organisation;
             ReportingYear = reportingYear;
-            this.draftReturnForYear = draftReturnForYear;
             hasDraftReturnForYear = draftReturnForYear != null;
         }
-
-
+        
         public object GetFormattedYearText()
         {
             return ReportingYearsHelper.FormatYearAsReportingPeriod(ReportingYear);

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
@@ -1,8 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using GenderPayGap.Core;
+using GenderPayGap.Core.Classes;
 using GenderPayGap.Core.Helpers;
 using GenderPayGap.Database;
 using GenderPayGap.Database.Models;
+using GenderPayGap.WebUI.Classes;
 using GenderPayGap.WebUI.Models.Admin;
 
 namespace GenderPayGap.WebUI.Models.ManageOrganisations
@@ -45,10 +49,10 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
             return users;
         }
 
-        public List<ManageOrganisationDetailsForYearViewModel> GetOrganisationDetailsForYears()
+        public List<AllOrganisationReportsForYearViewModel> GetOrganisationDetailsForYears()
         {
             List<int> reportingYears = ReportingYearsHelper.GetReportingYears();
-            var detailsForYears = new List<ManageOrganisationDetailsForYearViewModel>();
+            var detailsForYears = new List<AllOrganisationReportsForYearViewModel>();
 
             foreach (int reportingYear in reportingYears)
             {
@@ -58,7 +62,7 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
                 if (scopeForYear != null)
                 {
                     detailsForYears.Add(
-                        new ManageOrganisationDetailsForYearViewModel(
+                        new AllOrganisationReportsForYearViewModel(
                             Organisation,
                             reportingYear,
                             allDraftReturns.Where(d => d.SnapshotYear == reportingYear)
@@ -72,4 +76,190 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
             return detailsForYears;
         }
     }
+    
+    public class AllOrganisationReportsForYearViewModel
+    {
+
+        public int ReportingYear { get; }
+
+        private readonly Database.Organisation organisation;
+        private readonly DraftReturn draftReturnForYear;
+        private readonly bool hasDraftReturnForYear;
+
+        public AllOrganisationReportsForYearViewModel(Database.Organisation organisation, int reportingYear, DraftReturn draftReturnForYear)
+        {
+            this.organisation = organisation;
+            ReportingYear = reportingYear;
+            this.draftReturnForYear = draftReturnForYear;
+            hasDraftReturnForYear = draftReturnForYear != null;
+        }
+
+
+        public object GetFormattedYearText()
+        {
+            return ReportingYearsHelper.FormatYearAsReportingPeriod(ReportingYear);
+        }
+
+        public bool CanChangeScope()
+        {
+            int currentReportingYear = organisation.SectorType.GetAccountingStartDate().Year;
+            int earliestAllowedReportingYear = currentReportingYear - (Global.EditableScopeCount - 1);
+            return ReportingYear >= earliestAllowedReportingYear;
+        }
+
+        public string GetRequiredToReportOrNotText()
+        {
+            OrganisationScope scopeForYear = organisation.GetScopeForYear(ReportingYear);
+
+            return scopeForYear.IsInScopeVariant()
+                ? "You are required to report."
+                : "You are not required to report.";
+        }
+
+        private DateTime GetAccountingDate()
+        {
+            return organisation.SectorType.GetAccountingStartDate(ReportingYear);
+        }
+
+        private DateTime GetReportingDeadline()
+        {
+            DateTime snapshotDate = GetAccountingDate();
+            return ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate);
+        }
+
+        private bool DeadlineHasPassed()
+        {
+            return ReportingYearsHelper.DeadlineForAccountingDateHasPassed(GetAccountingDate());
+        }
+
+        private bool OrganisationIsRequiredToSubmit()
+        {
+            return organisation.GetScopeForYear(ReportingYear).IsInScopeVariant()
+                   && !Global.ReportingStartYearsToExcludeFromLateFlagEnforcement.Contains(GetAccountingDate().Year);
+        }
+
+        public ReportTag GetReportTag()
+        {
+            Return returnForYear = organisation.GetReturn(ReportingYear);
+            bool reportIsSubmitted = returnForYear != null;
+            
+            return reportIsSubmitted ? GetSubmittedReportTag(returnForYear) : GetNotSubmittedReportTag();
+        }
+
+        private ReportTag GetSubmittedReportTag(Return returnForYear)
+        {
+            bool returnIsRequired = returnForYear.IsRequired();
+            
+            if (returnIsRequired && returnForYear.IsLateSubmission)
+            {
+                return ReportTag.SubmittedLate;
+            }
+
+            return ReportTag.Submitted;
+        }
+
+        private ReportTag GetNotSubmittedReportTag()
+        {
+            if (!OrganisationIsRequiredToSubmit())
+            {
+                return ReportTag.NotRequired;
+            }
+
+            return DeadlineHasPassed() ? ReportTag.Overdue : ReportTag.Due;
+        }
+
+        public string GetReportTagText()
+        {
+            switch (GetReportTag())
+            {
+                case ReportTag.Due:
+                    return "Report due by " + GetReportingDeadline().ToGDSDate().FullStartDate;
+                case ReportTag.Overdue:
+                    return "Report overdue";
+                case ReportTag.Submitted:
+                    return "Report submitted";
+                case ReportTag.SubmittedLate:
+                    return "Report submitted late";
+                default:
+                    return "Report not required";
+            }
+        }
+        
+        public string GetReportTagClassName()
+        {
+            switch (GetReportTag())
+            {
+                case ReportTag.Due:
+                    return "govuk-tag--blue";
+                case ReportTag.Overdue:
+                    return "govuk-tag--red";
+                case ReportTag.Submitted:
+                case ReportTag.SubmittedLate:
+                    return "govuk-tag--green";
+                default:
+                    return "govuk-tag--grey";
+            }
+        }
+
+        public string GetReportTagDescription()
+        {
+            ReportTag tag = GetReportTag();
+            Return returnForYear = organisation.GetReturn(ReportingYear);
+
+            switch (tag)
+            {
+                case ReportTag.Overdue:
+                    return "This report was due on " + GetReportingDeadline().ToGDSDate().FullStartDate;
+                case ReportTag.Submitted:
+                case ReportTag.SubmittedLate:
+                    return "Reported on " + returnForYear.Modified.ToGDSDate().FullStartDate;
+                default:
+                    return null;
+            }
+        }
+
+        public string GetModifiedDateText()
+        {
+            if (hasDraftReturnForYear && draftReturnForYear.Modified != DateTime.MinValue)
+            {
+                return "Last edited on " + draftReturnForYear.Modified.ToGDSDate().FullStartDate;
+            }
+
+            return null;
+
+        }
+
+        public bool DoesReturnOrDraftReturnExistForYear()
+        {
+            Return returnForYear = organisation.GetReturn(ReportingYear);
+            bool hasReturnForYear = returnForYear != null;
+
+            return hasReturnForYear || hasDraftReturnForYear;
+        }
+
+        public string GetReportLinkText()
+        {
+            Return returnForYear = organisation.GetReturn(ReportingYear);
+            bool hasReturnForYear = returnForYear != null;
+
+            if (!hasReturnForYear && !hasDraftReturnForYear)
+            {
+                return "Draft report";
+            }
+
+            if (!hasReturnForYear && hasDraftReturnForYear)
+            {
+                return "Edit draft";
+            }
+
+            if (hasReturnForYear && !hasDraftReturnForYear)
+            {
+                return "Edit report";
+            }
+
+            return "Edit draft report";
+        }
+
+    }
+    
 }

--- a/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
+++ b/GenderPayGap.WebUI/Models/ManageOrganisations/AllOrganisationReportsViewModel.cs
@@ -121,7 +121,7 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
             return organisation.SectorType.GetAccountingStartDate(ReportingYear);
         }
 
-        private DateTime GetReportingDeadline()
+        public DateTime GetReportingDeadline()
         {
             DateTime snapshotDate = GetAccountingDate();
             return ReportingYearsHelper.GetDeadlineForAccountingDate(snapshotDate);
@@ -144,6 +144,26 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
             bool reportIsSubmitted = returnForYear != null;
             
             return reportIsSubmitted ? GetSubmittedReportTag(returnForYear) : GetNotSubmittedReportTag();
+        }
+
+        public ReportStatusBadgeType GetReportBadge()
+        {
+            var tag = GetReportTag();
+            switch (tag)
+            {
+                case ReportTag.Submitted:
+                    return ReportStatusBadgeType.Reported;
+                case ReportTag.SubmittedLate:
+                    return ReportStatusBadgeType.SubmittedLate;
+                case ReportTag.Due:
+                    return ReportStatusBadgeType.Due;
+                case ReportTag.Overdue:
+                    return ReportStatusBadgeType.Overdue;
+                case ReportTag.NotRequired:
+                    return ReportStatusBadgeType.NotRequired;
+                default:
+                    return ReportStatusBadgeType.Due;
+            }
         }
 
         private ReportTag GetSubmittedReportTag(Return returnForYear)
@@ -183,58 +203,6 @@ namespace GenderPayGap.WebUI.Models.ManageOrganisations
                 default:
                     return "Report not required";
             }
-        }
-        
-        public string GetReportTagClassName()
-        {
-            switch (GetReportTag())
-            {
-                case ReportTag.Due:
-                    return "govuk-tag--blue";
-                case ReportTag.Overdue:
-                    return "govuk-tag--red";
-                case ReportTag.Submitted:
-                case ReportTag.SubmittedLate:
-                    return "govuk-tag--green";
-                default:
-                    return "govuk-tag--grey";
-            }
-        }
-
-        public string GetReportTagDescription()
-        {
-            ReportTag tag = GetReportTag();
-            Return returnForYear = organisation.GetReturn(ReportingYear);
-
-            switch (tag)
-            {
-                case ReportTag.Overdue:
-                    return "This report was due on " + GetReportingDeadline().ToGDSDate().FullStartDate;
-                case ReportTag.Submitted:
-                case ReportTag.SubmittedLate:
-                    return "Reported on " + returnForYear.Modified.ToGDSDate().FullStartDate;
-                default:
-                    return null;
-            }
-        }
-
-        public string GetModifiedDateText()
-        {
-            if (hasDraftReturnForYear && draftReturnForYear.Modified != DateTime.MinValue)
-            {
-                return "Last edited on " + draftReturnForYear.Modified.ToGDSDate().FullStartDate;
-            }
-
-            return null;
-
-        }
-
-        public bool DoesReturnOrDraftReturnExistForYear()
-        {
-            Return returnForYear = organisation.GetReturn(ReportingYear);
-            bool hasReturnForYear = returnForYear != null;
-
-            return hasReturnForYear || hasDraftReturnForYear;
         }
 
         public string GetReportLinkText()

--- a/GenderPayGap.WebUI/Models/Shared/ReportStatusBadgeViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Shared/ReportStatusBadgeViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using GenderPayGap.Core;
 
-namespace GenderPayGap.WebUI.Models
+namespace GenderPayGap.WebUI.Models.Shared
 {
 
     public class ReportStatusBadgeViewModel
@@ -8,6 +8,8 @@ namespace GenderPayGap.WebUI.Models
         public ReportStatusBadgeType ReportStatus { get; set; }
         public string DateText { get; set; }
         public bool Desktop { get; set; }
+        public string DesktopClasses { get; set; }
+        public string MobileClasses  { get; set; }
 
     }
 }

--- a/GenderPayGap.WebUI/Models/Shared/ReportStatusBadgeViewModel.cs
+++ b/GenderPayGap.WebUI/Models/Shared/ReportStatusBadgeViewModel.cs
@@ -8,8 +8,6 @@ namespace GenderPayGap.WebUI.Models.Shared
         public ReportStatusBadgeType ReportStatus { get; set; }
         public string DateText { get; set; }
         public bool Desktop { get; set; }
-        public string DesktopClasses { get; set; }
-        public string MobileClasses  { get; set; }
-
+        public string Classes { get; set; }
     }
 }

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
@@ -12,7 +12,7 @@
     ViewBag.Title = "View all your employers reports - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
     var organisation = Model.Organisation;
-    string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
+    string encryptedOrganisationId = Encryption.EncryptQuerystring(organisation.OrganisationId.ToString());
 }
 
 @section BeforeMain {
@@ -57,40 +57,29 @@
         {
             new TableCellViewModel
             {
-                Text = "Snapshot date",
-                Colspan = 1
+                Text = "Snapshot date"
             },
             new TableCellViewModel
             {
                 Text = "Reporting requirement",
-                Colspan = 1
             },
             new TableCellViewModel
             {
                 Text = "Report status",
-                Colspan = 1
             },
             new TableCellViewModel
             {
                 Text = " ",
-                Colspan = 1
             }
         };
         
-
-        var yearsForSelectComponent = new List<string>();
-        var allDesktopRows = new List<TableRowViewModel>();
-        var allMobileRows = new List<TableRowViewModel>();
         var allReports = Model.GetOrganisationDetailsForYears();
-        foreach (var report in allReports)
-        {
-            allDesktopRows.Add(GenerateDesktopRow(report));
-            allMobileRows.Add(GenerateMobileRow(report));
-        }
-
+        var yearsForSelectComponent = allReports.Select(report => organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy")).ToList();
+        var allDesktopRows = allReports.Select(report => GenerateDesktopRow(report)).ToList();
+        var allMobileRows = allReports.Select(report => GenerateMobileRow(report)).ToList();
+        
         TableRowViewModel GenerateDesktopRow(AllOrganisationReportsForYearViewModel report)
         {
-            yearsForSelectComponent.Add(@organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy"));
             var newRow = new TableRowViewModel
             {
                 Row = new List<TableCellViewModel>

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
@@ -111,7 +111,7 @@
                                    @if (report.CanChangeScope())
                                    {
                                        <div>
-                                           <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = report.ReportingYear})">
+                                           <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = report.ReportingYear})" class="govuk-link">
                                                Think this is wrong?<span class="govuk-visually-hidden"> scope for year @report.GetFormattedYearText()</span>
                                            </a>
                                        </div>
@@ -134,7 +134,7 @@
                     new TableCellViewModel
                     {
                         Html = @<text>
-                                   <a loadtest-id="create-report-@report.ReportingYear"
+                                   <a loadtest-id="create-report-@report.ReportingYear" class="govuk-link"
                                       href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId, reportingYear = report.ReportingYear, canTriggerLateSubmissionWarning = true})">
                                        @report.GetReportLinkText()
                                    </a>
@@ -163,7 +163,7 @@
                                     @if (report.CanChangeScope())
                                     {
                                         <div class="govuk-!-margin-top-1">
-                                            <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = report.ReportingYear})">
+                                            <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = report.ReportingYear})" class="govuk-link">
                                                 Think this is wrong?<span class="govuk-visually-hidden"> scope for year @report.GetFormattedYearText()</span>
                                             </a>
                                         </div>
@@ -178,11 +178,12 @@
                                            }); 
                                     }
                                     <br/>
-                                    <a loadtest-id="create-report-@report.ReportingYear"
+                                    <a loadtest-id="create-report-@report.ReportingYear" class="govuk-link"
                                        href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId, reportingYear = report.ReportingYear, canTriggerLateSubmissionWarning = true})">
                                         @report.GetReportLinkText()
                                     </a>
                                 </text>,
+                        Classes = "govuk-!-padding-bottom-8"
                     }
                 }
             };

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
@@ -1,6 +1,8 @@
 ﻿@using Newtonsoft.Json
 @using GenderPayGap.Core
+@using GenderPayGap.Core.Classes
 @using GenderPayGap.Core.Helpers
+@using GenderPayGap.WebUI.Models.ManageOrganisations
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.ManageOrganisations.AllOrganisationReportsViewModel
@@ -10,8 +12,8 @@
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
     var organisation = Model.Organisation;
     // Breadkcrumbs for going back
-    // All reports header
-    // for [Organisation name]
+    // All reports header **
+    // for [Organisation name] **
     // filter (requires main table to exist with class name that matches)
     // main table
     // Pagination
@@ -28,7 +30,7 @@
             </span>
         </h1>
     </div>
-    <div class="filteringArea">
+    <div id="filteringArea">
         <input type="hidden" id="selectOptionsFromReports"
                value=@JsonConvert.SerializeObject(
                          organisation.GetRecentReports(
@@ -38,51 +40,126 @@
                              .ToArray())>
     </div>
     @{
-        var desktopHeader = new TableRowViewModel
+        var desktopHeader = new List<TableCellViewModel>
         {
-            Row = new List<TableCellViewModel>
+            new TableCellViewModel
             {
-                new TableCellViewModel
-                {
-                    Html = @<text>
-                               <div>
-                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
-                                       <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 ">Snapshot date</h3>
-                                   </div>
-                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
-                                       <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-employer-table-right">Reporting requirements</h3>
-                                   </div>
-                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
-                                       <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-employer-table-right">Report Status</h3>
-                                   </div>
-                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
-                                   </div>
-                               </div>
-                            </text>
-                }
+                Text = "Snapshot date",
+                Colspan = 1
+            },
+            new TableCellViewModel
+            {
+                Text = "Reporting requirement",
+                Colspan = 1
+            },
+            new TableCellViewModel
+            {
+                Text = "Report status",
+                Colspan = 1
+            },
+            new TableCellViewModel
+            {
+                Text = " ",
+                Colspan = 1
             }
         };
-        var allDesktopRows = organisation
-            .GetRecentReports(Global.ShowReportYearCount)
-            .Select
-            (
-                report => new TableRowViewModel
+        
+        string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
+        var allDesktopRows = new List<TableRowViewModel>();
+        var allMobileRows = new List<TableRowViewModel>();
+        var allReports = Model.GetOrganisationDetailsForYears();
+        foreach (var report in allReports)
+        {
+            var reportTag = report.GetReportTag();
+            var currentReportingYear = ReportingYearsHelper.GetCurrentReportingYear();
+ 
+            allDesktopRows.Add(GenerateDesktopRow(report));
+            allMobileRows.Add(GenerateMobileRow(report));
+        }
+
+        TableRowViewModel GenerateDesktopRow(AllOrganisationReportsForYearViewModel report)
+        {
+            var newRow = new TableRowViewModel
+            {
+                Row = new List<TableCellViewModel>
                 {
-                    Row = new List<TableCellViewModel>
+                    new TableCellViewModel
                     {
-                        new TableCellViewModel
-                        {
-                            Html = @<text>
-                                       <p>
-                                           @report.GetReportingPeriod()
-                                       </p>
-                                    </text>
-                        }
+                        Html = @<text>
+                                   <span class="yearTextForFiltering">@organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy")</span>
+                                </text>,
+                        Classes = "govuk-!-font-weight-bold"
+                    },
+                    new TableCellViewModel
+                    {
+                        Html = @<text>
+                                   <div>
+                                       @report.GetRequiredToReportOrNotText()
+                                   </div>
+                                   @if (report.CanChangeScope())
+                                   {
+                                       <div>
+                                           <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = report.ReportingYear})">
+                                               Think this is wrong?<span class="govuk-visually-hidden"> scope for year @report.GetFormattedYearText()</span>
+                                           </a>
+                                       </div>
+                                   }
+                                </text>
+                    },
+                    new TableCellViewModel
+                    {
+                        Html = @<text>
+                                   <strong class="govuk-tag @report.GetReportTagClassName()">
+                                       @report.GetReportTagText().ToUpper()
+                                   </strong>
+                                   @{
+                                       string description = report.GetReportTagDescription();
+                                       string modifiedDateText = report.GetModifiedDateText();
+                                       string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-3";
+
+                                       if (description != null)
+                                       {
+                                           <div class="govuk-!-margin-top-3">@description</div>
+                                       }
+
+                                       if (modifiedDateText != null)
+                                       {
+                                           <div class="@modifiedDateTextClass">@modifiedDateText</div>
+                                       }
+                                   }
+                                </text>
+                    },
+                    new TableCellViewModel
+                    {
+                        Html = @<text>
+                                   <a loadtest-id="create-report-@report.ReportingYear"
+                                      href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId, reportingYear = report.ReportingYear, canTriggerLateSubmissionWarning = true})">
+                                       @report.GetReportLinkText()
+                                   </a>
+                                </text>
+                    },
+                }
+            };
+            return newRow;
+        }
+        TableRowViewModel GenerateMobileRow(AllOrganisationReportsForYearViewModel report)
+        {
+            var newRow = new TableRowViewModel
+            {
+                Row = new List<TableCellViewModel>
+                {
+                    new TableCellViewModel
+                    {
+                        Html = @<text>
+                                   @organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy")
+                                </text>,
+                        Classes = "govuk-!-font-weight-bold"
                     }
                 }
-            )
-            .ToList();
-        var allMobileRows = new List<TableRowViewModel>();
+            };
+            return newRow;
+        }
+        
         var dateJoinedRow = new TableRowViewModel
         {
             Row = new List<TableCellViewModel>
@@ -96,7 +173,8 @@
                                        Text = "Employer joined Gender Pay Gap service on " + @Model.Organisation.Created.ToString("dd/MM/yyyy"),
                                        Classes = "govuk-!-margin-top-4 govuk-!-text-align-centre"
                                    })
-                            </text>
+                            </text>,
+                    Colspan = 4
                 }
             }
         };
@@ -123,21 +201,23 @@
                     
         for (int i = startIndex; i < endIndex; i++)
         {
-            //mobileDisplayRows.Add(allMobileRows[i]);
+            mobileDisplayRows.Add(allMobileRows[i]);
             desktopDisplayRows.Add(allDesktopRows[i]);
-        }
-        
-        if (desktopDisplayRows.Count > 0)
-        {
-            desktopDisplayRows.Insert(0,desktopHeader);
         }
     }
     
     @await Html.GovUkTable(new TableGovUkViewModel
         {
-            Head = new List<TableCellViewModel>(),
+            Head = desktopHeader,
             Rows = desktopDisplayRows,
             Classes = "gpg-govuk-hideOnMobile"
+        })
+
+    @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = new List<TableCellViewModel>(),
+            Rows = mobileDisplayRows,
+            Classes = "gpg-govuk-hideOnDesktop"
         })
     
     @{
@@ -145,14 +225,14 @@
         {
             Text = "Next page",
             LabelText = $"{Model.CurrentPage + 1} of {Model.TotalPages}",
-            // Href = Url.Action("Employer", new {employerIdentifier, page = Model.CurrentPage + 1})
+            Href = Url.Action("AllOrganisationReportsGet", new {encryptedOrganisationId, page = Model.CurrentPage + 1})
         };
     
         var previousLink = new PaginationLinkViewModel()
         {
             Text = "Previous page",
             LabelText = $"{Model.CurrentPage - 1} of {Model.TotalPages}",
-            // Href = Url.Action("Employer", new {employerIdentifier, page = Model.CurrentPage - 1})
+            Href = Url.Action("AllOrganisationReportsGet", new {encryptedOrganisationId, page = Model.CurrentPage - 1})
         };
     
         // if (Model.TotalPages < 2 || Model.CurrentPage == Model.TotalPages)
@@ -168,50 +248,50 @@
 </div>
 
 <script>
-    //var parentForSelect = document.getElementById("filteringArea");
-    //    
-    //    var selectLabel = document.createElement("label");
-    //    selectLabel.className = "govuk-label";
-    //    selectLabel.for = "yearFilter";
-    //    selectLabel.textContent = "Filter for a reporting period";
-    //    
-    //    var elements = document.getElementsByClassName("yearTextForFiltering");
-    //    
-    //    var selectList = document.createElement("select");
-    //    selectList.className = "govuk-select govuk-!-margin-bottom-3";
-    //    selectList.id = "filterYearSelect";
-    //    selectList.addEventListener("change",function (e){
-    //        for (var i = 0; i < elements.length; i++){
-    //            var tableRow = elements[i].closest("tr");
-    //            tableRow.hidden = true;
-    //            
-    //            if (elements[i].innerHTML.includes(e.target.value) || e.target.value === "Show All"){
-    //                tableRow.hidden = false;
-    //            }
-    //        }
-    //    }) 
-    //    
-    //    var selectHint = document.createElement("div");
-    //    selectHint.className = "govuk-hint";
-    //    selectHint.textContent = "For example, if the snapshot date is 5 April 2017 but the deadline is 4 April 2018 then the reporting period is 2017 - 2018.";
-    //   
-    //    parentForSelect.appendChild(selectLabel);
-    //    parentForSelect.appendChild(selectList);
-    //    parentForSelect.appendChild(selectHint);
-    //
-    //    var showAll = document.createElement("option");
-    //    showAll.value = "Show All";
-    //    showAll.text = "Show All";
-    //    showAll.selected = true;
-    //    selectList.appendChild(showAll);
-    //    
-    //    var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
-    //    for (var i = 0; i < arrayOfYears.length; i++){
-    //         var option = document.createElement("option");
-    //         option.value = arrayOfYears[i];
-    //         option.text = arrayOfYears[i];
-    //         selectList.appendChild(option);
-    //    }
+    var parentForSelect = document.getElementById("filteringArea");
+    
+    var selectLabel = document.createElement("label");
+    selectLabel.className = "govuk-label";
+    selectLabel.for = "yearFilter";
+    selectLabel.textContent = "Filter for a reporting period";
+    
+    var elements = document.getElementsByClassName("yearTextForFiltering");
+    
+    var selectList = document.createElement("select");
+    selectList.className = "govuk-select govuk-!-margin-bottom-3";
+    selectList.id = "filterYearSelect";
+    selectList.addEventListener("change",function (e){
+        for (var i = 0; i < elements.length; i++){
+            var tableRow = elements[i].closest("tr");
+            tableRow.hidden = true;
+            
+            if (elements[i].innerHTML.includes(e.target.value) || e.target.value === "Show All"){
+                tableRow.hidden = false;
+            }
+        }
+    }) 
+    
+    var selectHint = document.createElement("div");
+    selectHint.className = "govuk-hint";
+    selectHint.textContent = "For example, if the snapshot date is 5 April 2017 but the deadline is 4 April 2018 then the reporting period is 2017 - 2018.";
+   
+    parentForSelect.appendChild(selectLabel);
+    parentForSelect.appendChild(selectList);
+    parentForSelect.appendChild(selectHint);
+
+    var showAll = document.createElement("option");
+    showAll.value = "Show All";
+    showAll.text = "Show All";
+    showAll.selected = true;
+    selectList.appendChild(showAll);
+    
+    var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
+    for (var i = 0; i < arrayOfYears.length; i++){
+         var option = document.createElement("option");
+         option.value = arrayOfYears[i];
+         option.text = arrayOfYears[i];
+         selectList.appendChild(option);
+    }
 </script>
 
 

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
@@ -3,6 +3,7 @@
 @using GenderPayGap.Core.Classes
 @using GenderPayGap.Core.Helpers
 @using GenderPayGap.WebUI.Models.ManageOrganisations
+@using GenderPayGap.WebUI.Models.Shared
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
 @model GenderPayGap.WebUI.Models.ManageOrganisations.AllOrganisationReportsViewModel
@@ -11,33 +12,45 @@
     ViewBag.Title = "View all your employers reports - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
     var organisation = Model.Organisation;
-    // Breadkcrumbs for going back
-    // All reports header **
-    // for [Organisation name] **
-    // filter (requires main table to exist with class name that matches)
-    // main table
-    // Pagination
-    
+    string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
+}
+
+@section BeforeMain {
+    @{
+        var crumbs = new List<CrumbViewModel>
+        {
+            new CrumbViewModel
+            {
+                Text = "Manage Employers",
+                Href = Url.Action("ManageOrganisationsGet", "ManageOrganisations")
+            },
+            new CrumbViewModel
+            {
+                Text = Model.Organisation.OrganisationName,
+                Href = Url.Action("ManageOrganisationGet", "ManageOrganisations", new {encryptedOrganisationId})
+            },
+            new CrumbViewModel
+            {
+                Text = "All reports"
+            },
+        };
+    }
+
+    @(await Html.GovUkBreadcrumbs(new BreadcrumbsViewModel
+    {
+        Crumbs = crumbs
+    }))
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl">
-            Manage your employer's reporting
+            All reports
             <br>
             <span class="govuk-!-font-size-27">
                 for @(Model.Organisation.OrganisationName)
             </span>
         </h1>
-    </div>
-    <div id="filteringArea">
-        <input type="hidden" id="selectOptionsFromReports"
-               value=@JsonConvert.SerializeObject(
-                         organisation.GetRecentReports(
-                             Global.ShowReportYearCount)
-                             .Select(
-                                 report => report.GetReportingPeriod())
-                             .ToArray())>
     </div>
     @{
         var desktopHeader = new List<TableCellViewModel>
@@ -64,21 +77,20 @@
             }
         };
         
-        string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
+
+        var yearsForSelectComponent = new List<string>();
         var allDesktopRows = new List<TableRowViewModel>();
         var allMobileRows = new List<TableRowViewModel>();
         var allReports = Model.GetOrganisationDetailsForYears();
         foreach (var report in allReports)
         {
-            var reportTag = report.GetReportTag();
-            var currentReportingYear = ReportingYearsHelper.GetCurrentReportingYear();
- 
             allDesktopRows.Add(GenerateDesktopRow(report));
             allMobileRows.Add(GenerateMobileRow(report));
         }
 
         TableRowViewModel GenerateDesktopRow(AllOrganisationReportsForYearViewModel report)
         {
+            yearsForSelectComponent.Add(@organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy"));
             var newRow = new TableRowViewModel
             {
                 Row = new List<TableCellViewModel>
@@ -109,23 +121,13 @@
                     new TableCellViewModel
                     {
                         Html = @<text>
-                                   <strong class="govuk-tag @report.GetReportTagClassName()">
-                                       @report.GetReportTagText().ToUpper()
-                                   </strong>
-                                   @{
-                                       string description = report.GetReportTagDescription();
-                                       string modifiedDateText = report.GetModifiedDateText();
-                                       string modifiedDateTextClass = description != null ? "" : "govuk-!-margin-top-3";
-
-                                       if (description != null)
-                                       {
-                                           <div class="govuk-!-margin-top-3">@description</div>
-                                       }
-
-                                       if (modifiedDateText != null)
-                                       {
-                                           <div class="@modifiedDateTextClass">@modifiedDateText</div>
-                                       }
+                                   @{ await Html.RenderPartialAsync("_ReportStatusBadge",
+                                          new ReportStatusBadgeViewModel
+                                          {
+                                              Desktop = true,
+                                              DateText = report.GetReportingDeadline().ToString("d MMMM yyyy"),
+                                              ReportStatus = report.GetReportBadge()
+                                          }); 
                                    }
                                 </text>
                     },
@@ -151,9 +153,36 @@
                     new TableCellViewModel
                     {
                         Html = @<text>
-                                   @organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy")
+                                   <span class="govuk-!-font-weight-bold ">
+                                       Snapshot date: @organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy")
+                                   <span class="yearTextForFiltering" style="visibility: hidden">@organisation.SectorType.GetAccountingStartDate(report.ReportingYear).ToString("dd/MM/yyyy")</span>
+                                   </span>
+                                    <div>
+                                        @report.GetRequiredToReportOrNotText()
+                                    </div>
+                                    @if (report.CanChangeScope())
+                                    {
+                                        <div class="govuk-!-margin-top-1">
+                                            <a href="@Url.Action("ChangeOrganisationScope", "Scope", new {encryptedOrganisationId, reportingYear = report.ReportingYear})">
+                                                Think this is wrong?<span class="govuk-visually-hidden"> scope for year @report.GetFormattedYearText()</span>
+                                            </a>
+                                        </div>
+                                    }
+                                    @{ await Html.RenderPartialAsync("_ReportStatusBadge",
+                                           new ReportStatusBadgeViewModel
+                                           {
+                                               Desktop = false,
+                                               DateText = report.GetReportingDeadline().ToString("d MMMM yyyy"),
+                                               ReportStatus = report.GetReportBadge(),
+                                               MobileClasses = "govuk-!-margin-top-5 govuk-!-margin-bottom-3"
+                                           }); 
+                                    }
+                                    <br/>
+                                    <a loadtest-id="create-report-@report.ReportingYear"
+                                       href="@Url.Action("ReportOverview", "ReportOverview", new {encryptedOrganisationId, reportingYear = report.ReportingYear, canTriggerLateSubmissionWarning = true})">
+                                        @report.GetReportLinkText()
+                                    </a>
                                 </text>,
-                        Classes = "govuk-!-font-weight-bold"
                     }
                 }
             };
@@ -205,19 +234,24 @@
             desktopDisplayRows.Add(allDesktopRows[i]);
         }
     }
+    <div class="govuk-grid-column-full" id="filteringArea">
+        <input type="hidden" id="selectOptionsFromReports"
+               value=@JsonConvert.SerializeObject(yearsForSelectComponent)>
+    </div>
+    <div class="govuk-grid-column-full">
     
     @await Html.GovUkTable(new TableGovUkViewModel
         {
             Head = desktopHeader,
             Rows = desktopDisplayRows,
-            Classes = "gpg-govuk-hideOnMobile"
+            Classes = "gpg-govuk-hideOnMobile govuk-grid-column-full"
         })
 
     @await Html.GovUkTable(new TableGovUkViewModel
         {
             Head = new List<TableCellViewModel>(),
             Rows = mobileDisplayRows,
-            Classes = "gpg-govuk-hideOnDesktop"
+            Classes = "gpg-govuk-hideOnDesktop govuk-grid-column-full"
         })
     
     @{
@@ -235,16 +269,17 @@
             Href = Url.Action("AllOrganisationReportsGet", new {encryptedOrganisationId, page = Model.CurrentPage - 1})
         };
     
-        // if (Model.TotalPages < 2 || Model.CurrentPage == Model.TotalPages)
-        //     nextLink = null;
-        // if (Model.CurrentPage < 2)
-        //     previousLink = null;
+        if (Model.TotalPages < 2 || Model.CurrentPage == Model.TotalPages)
+            nextLink = null;
+        if (Model.CurrentPage < 2)
+            previousLink = null;
     }
     @await Html.GovUkPagination(new PaginationViewModel()
         {
             Next = nextLink,
             Previous = previousLink,
         })
+    </div>
 </div>
 
 <script>
@@ -253,7 +288,7 @@
     var selectLabel = document.createElement("label");
     selectLabel.className = "govuk-label";
     selectLabel.for = "yearFilter";
-    selectLabel.textContent = "Filter for a reporting period";
+    selectLabel.textContent = "Filter for a snapshot date";
     
     var elements = document.getElementsByClassName("yearTextForFiltering");
     
@@ -270,14 +305,9 @@
             }
         }
     }) 
-    
-    var selectHint = document.createElement("div");
-    selectHint.className = "govuk-hint";
-    selectHint.textContent = "For example, if the snapshot date is 5 April 2017 but the deadline is 4 April 2018 then the reporting period is 2017 - 2018.";
    
     parentForSelect.appendChild(selectLabel);
     parentForSelect.appendChild(selectList);
-    parentForSelect.appendChild(selectHint);
 
     var showAll = document.createElement("option");
     showAll.value = "Show All";

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
@@ -144,6 +144,7 @@
             };
             return newRow;
         }
+        
         TableRowViewModel GenerateMobileRow(AllOrganisationReportsForYearViewModel report)
         {
             var newRow = new TableRowViewModel
@@ -174,7 +175,7 @@
                                                Desktop = false,
                                                DateText = report.GetReportingDeadline().ToString("d MMMM yyyy"),
                                                ReportStatus = report.GetReportBadge(),
-                                               MobileClasses = "govuk-!-margin-top-5 govuk-!-margin-bottom-3"
+                                               Classes = "govuk-!-margin-top-5 govuk-!-margin-bottom-3"
                                            }); 
                                     }
                                     <br/>
@@ -221,19 +222,13 @@
             allDesktopRows.Add(dateJoinedRow);
         }
         
-        var currentPage = Model.CurrentPage ?? 1;
+        var currentPage = Model.CurrentPage;
         var entriesPerPage = Model.EntriesPerPage ?? 10;
         var startIndex = (currentPage - 1) * entriesPerPage;
         var endIndex = startIndex + entriesPerPage > allDesktopRows.Count ? allDesktopRows.Count : startIndex + entriesPerPage;
-                
-        var desktopDisplayRows = new List<TableRowViewModel>();
-        var mobileDisplayRows = new List<TableRowViewModel>();
-                    
-        for (int i = startIndex; i < endIndex; i++)
-        {
-            mobileDisplayRows.Add(allMobileRows[i]);
-            desktopDisplayRows.Add(allDesktopRows[i]);
-        }
+
+        var desktopDisplayRows = allDesktopRows.Where((row, i) => i >= startIndex && i < endIndex).ToList();
+        var mobileDisplayRows = allMobileRows.Where((row, i) => i >= startIndex && i < endIndex).ToList();
     }
     <div class="govuk-grid-column-full" id="filteringArea">
         <input type="hidden" id="selectOptionsFromReports"

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReports.cshtml
@@ -1,0 +1,218 @@
+﻿@using Newtonsoft.Json
+@using GenderPayGap.Core
+@using GenderPayGap.Core.Helpers
+@using GovUkDesignSystem
+@using GovUkDesignSystem.GovUkDesignSystemComponents
+@model GenderPayGap.WebUI.Models.ManageOrganisations.AllOrganisationReportsViewModel
+
+@{
+    ViewBag.Title = "View all your employers reports - Gender pay gap service";
+    Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
+    var organisation = Model.Organisation;
+    // Breadkcrumbs for going back
+    // All reports header
+    // for [Organisation name]
+    // filter (requires main table to exist with class name that matches)
+    // main table
+    // Pagination
+    
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">
+            Manage your employer's reporting
+            <br>
+            <span class="govuk-!-font-size-27">
+                for @(Model.Organisation.OrganisationName)
+            </span>
+        </h1>
+    </div>
+    <div class="filteringArea">
+        <input type="hidden" id="selectOptionsFromReports"
+               value=@JsonConvert.SerializeObject(
+                         organisation.GetRecentReports(
+                             Global.ShowReportYearCount)
+                             .Select(
+                                 report => report.GetReportingPeriod())
+                             .ToArray())>
+    </div>
+    @{
+        var desktopHeader = new TableRowViewModel
+        {
+            Row = new List<TableCellViewModel>
+            {
+                new TableCellViewModel
+                {
+                    Html = @<text>
+                               <div>
+                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
+                                       <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 ">Snapshot date</h3>
+                                   </div>
+                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
+                                       <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-employer-table-right">Reporting requirements</h3>
+                                   </div>
+                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
+                                       <h3 class="heading-medium govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-employer-table-right">Report Status</h3>
+                                   </div>
+                                   <div class="govuk-grid-column-one-quarter govuk-!-padding-left-0">
+                                   </div>
+                               </div>
+                            </text>
+                }
+            }
+        };
+        var allDesktopRows = organisation
+            .GetRecentReports(Global.ShowReportYearCount)
+            .Select
+            (
+                report => new TableRowViewModel
+                {
+                    Row = new List<TableCellViewModel>
+                    {
+                        new TableCellViewModel
+                        {
+                            Html = @<text>
+                                       <p>
+                                           @report.GetReportingPeriod()
+                                       </p>
+                                    </text>
+                        }
+                    }
+                }
+            )
+            .ToList();
+        var allMobileRows = new List<TableRowViewModel>();
+        var dateJoinedRow = new TableRowViewModel
+        {
+            Row = new List<TableCellViewModel>
+            {
+                new TableCellViewModel
+                {
+                    Html = @<text>
+                               @await Html.GovUkHint(
+                                   new HintViewModel
+                                   {
+                                       Text = "Employer joined Gender Pay Gap service on " + @Model.Organisation.Created.ToString("dd/MM/yyyy"),
+                                       Classes = "govuk-!-margin-top-4 govuk-!-text-align-centre"
+                                   })
+                            </text>
+                }
+            }
+        };
+        
+        var indexOfCompanyJoined = organisation.GetRecentReports(Global.ShowReportYearCount).ToList().FindIndex(report => Model.Organisation.Created > ReportingYearsHelper.GetDeadlineForAccountingDate(report.AccountingDate));
+        if(indexOfCompanyJoined >= 0)
+        {
+            allMobileRows.Insert(indexOfCompanyJoined, dateJoinedRow);
+            allDesktopRows.Insert(indexOfCompanyJoined, dateJoinedRow);
+        }
+        else
+        {
+            allMobileRows.Add(dateJoinedRow);
+            allDesktopRows.Add(dateJoinedRow);
+        }
+        
+        var currentPage = Model.CurrentPage ?? 1;
+        var entriesPerPage = Model.EntriesPerPage ?? 10;
+        var startIndex = (currentPage - 1) * entriesPerPage;
+        var endIndex = startIndex + entriesPerPage > allDesktopRows.Count ? allDesktopRows.Count : startIndex + entriesPerPage;
+                
+        var desktopDisplayRows = new List<TableRowViewModel>();
+        var mobileDisplayRows = new List<TableRowViewModel>();
+                    
+        for (int i = startIndex; i < endIndex; i++)
+        {
+            //mobileDisplayRows.Add(allMobileRows[i]);
+            desktopDisplayRows.Add(allDesktopRows[i]);
+        }
+        
+        if (desktopDisplayRows.Count > 0)
+        {
+            desktopDisplayRows.Insert(0,desktopHeader);
+        }
+    }
+    
+    @await Html.GovUkTable(new TableGovUkViewModel
+        {
+            Head = new List<TableCellViewModel>(),
+            Rows = desktopDisplayRows,
+            Classes = "gpg-govuk-hideOnMobile"
+        })
+    
+    @{
+        var nextLink = new PaginationLinkViewModel()
+        {
+            Text = "Next page",
+            LabelText = $"{Model.CurrentPage + 1} of {Model.TotalPages}",
+            // Href = Url.Action("Employer", new {employerIdentifier, page = Model.CurrentPage + 1})
+        };
+    
+        var previousLink = new PaginationLinkViewModel()
+        {
+            Text = "Previous page",
+            LabelText = $"{Model.CurrentPage - 1} of {Model.TotalPages}",
+            // Href = Url.Action("Employer", new {employerIdentifier, page = Model.CurrentPage - 1})
+        };
+    
+        // if (Model.TotalPages < 2 || Model.CurrentPage == Model.TotalPages)
+        //     nextLink = null;
+        // if (Model.CurrentPage < 2)
+        //     previousLink = null;
+    }
+    @await Html.GovUkPagination(new PaginationViewModel()
+        {
+            Next = nextLink,
+            Previous = previousLink,
+        })
+</div>
+
+<script>
+    //var parentForSelect = document.getElementById("filteringArea");
+    //    
+    //    var selectLabel = document.createElement("label");
+    //    selectLabel.className = "govuk-label";
+    //    selectLabel.for = "yearFilter";
+    //    selectLabel.textContent = "Filter for a reporting period";
+    //    
+    //    var elements = document.getElementsByClassName("yearTextForFiltering");
+    //    
+    //    var selectList = document.createElement("select");
+    //    selectList.className = "govuk-select govuk-!-margin-bottom-3";
+    //    selectList.id = "filterYearSelect";
+    //    selectList.addEventListener("change",function (e){
+    //        for (var i = 0; i < elements.length; i++){
+    //            var tableRow = elements[i].closest("tr");
+    //            tableRow.hidden = true;
+    //            
+    //            if (elements[i].innerHTML.includes(e.target.value) || e.target.value === "Show All"){
+    //                tableRow.hidden = false;
+    //            }
+    //        }
+    //    }) 
+    //    
+    //    var selectHint = document.createElement("div");
+    //    selectHint.className = "govuk-hint";
+    //    selectHint.textContent = "For example, if the snapshot date is 5 April 2017 but the deadline is 4 April 2018 then the reporting period is 2017 - 2018.";
+    //   
+    //    parentForSelect.appendChild(selectLabel);
+    //    parentForSelect.appendChild(selectList);
+    //    parentForSelect.appendChild(selectHint);
+    //
+    //    var showAll = document.createElement("option");
+    //    showAll.value = "Show All";
+    //    showAll.text = "Show All";
+    //    showAll.selected = true;
+    //    selectList.appendChild(showAll);
+    //    
+    //    var arrayOfYears = JSON.parse(document.getElementById("selectOptionsFromReports").value);
+    //    for (var i = 0; i < arrayOfYears.length; i++){
+    //         var option = document.createElement("option");
+    //         option.value = arrayOfYears[i];
+    //         option.text = arrayOfYears[i];
+    //         selectList.appendChild(option);
+    //    }
+</script>
+
+
+

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReportsTable.cshtml
@@ -1,0 +1,2 @@
+﻿@model GenderPayGap.WebUI.Models.ManageOrganisations.ManageOrganisationViewModel
+

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReportsTable.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/AllOrganisationReportsTable.cshtml
@@ -1,2 +1,0 @@
-﻿@model GenderPayGap.WebUI.Models.ManageOrganisations.ManageOrganisationViewModel
-

--- a/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/ManageOrganisations/ManageOrganisation.cshtml
@@ -7,6 +7,7 @@
 @{
     ViewBag.Title = "Manage your employers - Gender pay gap service";
     Layout = "~/Views/GovUkFrontend/GovUkFrontendLayout.cshtml";
+    string encryptedOrganisationId = Encryption.EncryptQuerystring(Model.Organisation.OrganisationId.ToString());
 }
 
 @section BeforeMain {
@@ -21,7 +22,7 @@
             new CrumbViewModel
             {
                 Text = Model.Organisation.OrganisationName
-            }
+            },
         };
     }
 
@@ -63,7 +64,7 @@
 
             <div class="govuk-!-margin-bottom-6">
                 <p>
-                    <a href="" class="govuk-!-font-size-19 govuk-link govuk-!-font-weight-bold">See all reports</a> <!--TODO: GPG-916: Point this link to the manage all reports page when that is created-->
+                    <a href="@Url.Action("AllOrganisationReportsGet", "ManageOrganisations", new{encryptedOrganisationId})" class="govuk-!-font-size-19 govuk-link govuk-!-font-weight-bold">See all reports</a> <!--TODO: GPG-916: Point this link to the manage all reports page when that is created-->
                 </p>
             </div>
             await Html.RenderPartialAsync("UsersRegisteredToReportForOrganisation", Model);

--- a/GenderPayGap.WebUI/Views/Shared/_ReportStatusBadge.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_ReportStatusBadge.cshtml
@@ -61,20 +61,10 @@
             break;
 
     }
-
-    if(Model.Desktop)
-    {
-        htmlClass = htmlClass + " " + Model.DesktopClasses;
-    }
-    else
-    {
-        htmlClass = htmlClass + " " + Model.MobileClasses;
-    }
-
 }
 
 @await Html.GovUkTag(new TagViewModel
 {
     Html = html,
-    Classes = htmlClass
+    Classes = htmlClass + " " + Model.Classes
 })

--- a/GenderPayGap.WebUI/Views/Shared/_ReportStatusBadge.cshtml
+++ b/GenderPayGap.WebUI/Views/Shared/_ReportStatusBadge.cshtml
@@ -1,4 +1,4 @@
-﻿@model ReportStatusBadgeViewModel
+﻿@model GenderPayGap.WebUI.Models.Shared.ReportStatusBadgeViewModel
 @using GenderPayGap.Core
 @using GovUkDesignSystem
 @using GovUkDesignSystem.GovUkDesignSystemComponents
@@ -64,11 +64,11 @@
 
     if(Model.Desktop)
     {
-        htmlClass = htmlClass + " " + "govuk-employer-table-right";
+        htmlClass = htmlClass + " " + Model.DesktopClasses;
     }
     else
     {
-        htmlClass = htmlClass + " " + "govuk-!-margin-bottom-4 govuk-!-margin-top-4";
+        htmlClass = htmlClass + " " + Model.MobileClasses;
     }
 
 }

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -139,7 +139,7 @@
                                                         {
                                                             DateText = ReportingYearsHelper.GetDeadlineForAccountingDate(report.AccountingDate).ToString("d MMMM yyyy"),
                                                             ReportStatus = reportStatus,
-                                                            MobileClasses = "govuk-!-margin-bottom-4 govuk-!-margin-top-4"
+                                                            Classes = "govuk-!-margin-bottom-4 govuk-!-margin-top-4"
                                                         });
                                                 }
                                                             
@@ -220,7 +220,7 @@
                                                                        DateText = ReportingYearsHelper.GetDeadlineForAccountingDate(report.AccountingDate).ToString("d MMMM yyyy"),
                                                                        ReportStatus = reportStatus,
                                                                        Desktop = true,
-                                                                       DesktopClasses = "govuk-employer-table-right"
+                                                                       Classes = "govuk-employer-table-right"
                                                                    }); }
                                                         </div>
                                                     }

--- a/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
+++ b/GenderPayGap.WebUI/Views/Viewing/EmployerDetails/Employer.cshtml
@@ -134,11 +134,12 @@
                                                         reportStatus = ReportStatusBadgeType.Due;
                                                     }
                                                             
-                                                    await Html.RenderPartialAsync("EmployerDetails/Parts/_ReportStatusBadge",
+                                                    await Html.RenderPartialAsync("_ReportStatusBadge",
                                                         new ReportStatusBadgeViewModel
                                                         {
                                                             DateText = ReportingYearsHelper.GetDeadlineForAccountingDate(report.AccountingDate).ToString("d MMMM yyyy"),
-                                                            ReportStatus = reportStatus
+                                                            ReportStatus = reportStatus,
+                                                            MobileClasses = "govuk-!-margin-bottom-4 govuk-!-margin-top-4"
                                                         });
                                                 }
                                                             
@@ -213,12 +214,13 @@
                                                         }
         
                                                         <div class="govuk-grid-column-one-half govuk-!-padding-right-0 govuk-!-margin-top-3">
-                                                            @{ await Html.RenderPartialAsync("EmployerDetails/Parts/_ReportStatusBadge",
+                                                            @{ await Html.RenderPartialAsync("_ReportStatusBadge",
                                                                    new ReportStatusBadgeViewModel
                                                                    {
                                                                        DateText = ReportingYearsHelper.GetDeadlineForAccountingDate(report.AccountingDate).ToString("d MMMM yyyy"),
                                                                        ReportStatus = reportStatus,
-                                                                       Desktop = true
+                                                                       Desktop = true,
+                                                                       DesktopClasses = "govuk-employer-table-right"
                                                                    }); }
                                                         </div>
                                                     }


### PR DESCRIPTION
This ticket is concerned with the creation of a new "all reports" page, the idea being the that previous page covered in GPG-759 shows a "dashboard" of actionable reports whereas the the "all reports" page shows all previous reports including the unactionable ones and serves as an archive, this includes pagination and yearly filtering.

Image showing the design for desktop- 
![image](https://user-images.githubusercontent.com/62190777/200332924-3c8459a5-ea46-4329-bd93-623c50382a02.png)

Image showing my implementation on desktop
![image](https://user-images.githubusercontent.com/62190777/200347628-959d0403-12ec-4e35-beec-728b1ba60141.png)
Note: a change was agreed with the designer that we could reuse badges seen on the viewing pages, this is why the report status badges look different or are worded differently.

Image showing mobile design - 
![image](https://user-images.githubusercontent.com/62190777/200347993-20ba40fd-cedd-4d29-8fc0-303cb1a97125.png)

Image showing mobile implementation - 
![image](https://user-images.githubusercontent.com/62190777/200351020-456cb267-79c3-4b2c-9c71-5adc58283ded.png)

Note: a design change was agreed where the "draft report" button was moved below the badge so as to match the government design standards of having only single column tables on mobile devices.

Pagination is not visible as there needs to be more than 10 reports available for the next and previous buttons to appear.


