### PR TITLE
4212: Accessibility: Remove unwanted HR, and mark a decorative HR as aria-hidden

### DIFF
--- a/GenderPayGap.WebUI/Views/Components/ReportOverview/ReportOverviewSections.cshtml
+++ b/GenderPayGap.WebUI/Views/Components/ReportOverview/ReportOverviewSections.cshtml
@@ -12,7 +12,7 @@
                     <a class="govuk-link govuk-!-margin-left-8" href="@(section.EditLink)">Edit</a>
                 </div>
             </div>
-            <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+            <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible" aria-hidden="true">
         </caption>
 
         @if (section.LeftTitle != null && section.RightTitle != null)

--- a/GenderPayGap.WebUI/Views/Login/Login.cshtml
+++ b/GenderPayGap.WebUI/Views/Login/Login.cshtml
@@ -9,8 +9,6 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <hr class="govuk-section-break govuk-section-break--xl"/>
-        
         <h1 class="govuk-heading-xl">Sign in</h1>
         
         @(await Html.GovUkErrorSummary(ViewData.ModelState))


### PR DESCRIPTION
**Note:** I've checked all the other `<hr>` tags in the code.
All the other `<hr>` tags have semantic meaning, so don't need the `aria-hidden="true"` attribute.