### PR TITLE
4415: Remove unused code: UserOrganisation.Address

### DIFF
--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -386,18 +386,11 @@ namespace GenderPayGap.Database
                 entity => {
                     entity.HasKey(e => new {e.UserId, e.OrganisationId}).HasName("PK_dbo.UserOrganisations");
 
-                    entity.HasIndex(e => e.AddressId);
-
                     entity.HasIndex(e => e.OrganisationId);
 
                     entity.HasIndex(e => e.UserId);
 
                     entity.Property(e => e.Method).HasColumnName("MethodId").HasDefaultValueSql("((0))");
-
-                    entity.HasOne(d => d.Address)
-                        .WithMany(p => p.UserOrganisations)
-                        .HasForeignKey(d => d.AddressId)
-                        .HasConstraintName("FK_dbo.UserOrganisations_dbo.OrganisationAddresses_AddressId");
 
                     entity.HasOne(d => d.Organisation)
                         .WithMany(p => p.UserOrganisations)
@@ -417,8 +410,6 @@ namespace GenderPayGap.Database
             modelBuilder.Entity<InactiveUserOrganisation>(
                 entity => {
                     entity.HasKey(e => new { e.UserId, e.OrganisationId }).HasName("PK_dbo.InactiveUserOrganisations");
-
-                    entity.HasIndex(e => e.AddressId);
 
                     entity.HasIndex(e => e.OrganisationId);
 

--- a/GenderPayGap.Database/Migrations/20230523165523_Remove UserOrganisation.Address.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230523165523_Remove UserOrganisation.Address.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230523165523_Remove UserOrganisation.Address")]
+    partial class RemoveUserOrganisationAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230523165523_Remove UserOrganisation.Address.cs
+++ b/GenderPayGap.Database/Migrations/20230523165523_Remove UserOrganisation.Address.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveUserOrganisationAddress : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_InactiveUserOrganisations_OrganisationAddresses_AddressId",
+                table: "InactiveUserOrganisations");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_dbo.UserOrganisations_dbo.OrganisationAddresses_AddressId",
+                table: "UserOrganisations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserOrganisations_AddressId",
+                table: "UserOrganisations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InactiveUserOrganisations_AddressId",
+                table: "InactiveUserOrganisations");
+
+            migrationBuilder.DropColumn(
+                name: "AddressId",
+                table: "UserOrganisations");
+
+            migrationBuilder.DropColumn(
+                name: "AddressId",
+                table: "InactiveUserOrganisations");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "AddressId",
+                table: "UserOrganisations",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "AddressId",
+                table: "InactiveUserOrganisations",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserOrganisations_AddressId",
+                table: "UserOrganisations",
+                column: "AddressId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InactiveUserOrganisations_AddressId",
+                table: "InactiveUserOrganisations",
+                column: "AddressId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InactiveUserOrganisations_OrganisationAddresses_AddressId",
+                table: "InactiveUserOrganisations",
+                column: "AddressId",
+                principalTable: "OrganisationAddresses",
+                principalColumn: "AddressId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_dbo.UserOrganisations_dbo.OrganisationAddresses_AddressId",
+                table: "UserOrganisations",
+                column: "AddressId",
+                principalTable: "OrganisationAddresses",
+                principalColumn: "AddressId",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/InactiveUserOrganisation.cs
+++ b/GenderPayGap.Database/Models/InactiveUserOrganisation.cs
@@ -30,13 +30,9 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Modified { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
-        public long? AddressId { get; set; }
-        [JsonProperty]
         public RegistrationMethods Method { get; set; } = RegistrationMethods.Unknown;
 
         public virtual Organisation Organisation { get; set; }
-
-        public virtual OrganisationAddress Address { get; set; }
 
         public virtual User User { get; set; }
 

--- a/GenderPayGap.Database/Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database/Models/OrganisationAddress.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using GenderPayGap.Core;
 using GenderPayGap.Extensions;
 using Newtonsoft.Json;
@@ -9,11 +8,6 @@ namespace GenderPayGap.Database
     [JsonObject(MemberSerialization.OptIn)]
     public partial class OrganisationAddress
     {
-
-        public OrganisationAddress()
-        {
-            UserOrganisations = new HashSet<UserOrganisation>();
-        }
 
         [JsonProperty]
         public long AddressId { get; set; }
@@ -53,8 +47,6 @@ namespace GenderPayGap.Database
         public bool? IsUkAddress { get; set; }
 
         public virtual Organisation Organisation { get; set; }
-
-        public virtual ICollection<UserOrganisation> UserOrganisations { get; set; }
 
         public string GetPostCodeInAllCaps()
         {

--- a/GenderPayGap.Database/Models/UserOrganisation.cs
+++ b/GenderPayGap.Database/Models/UserOrganisation.cs
@@ -30,13 +30,9 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Modified { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
-        public long? AddressId { get; set; }
-        [JsonProperty]
         public RegistrationMethods Method { get; set; } = RegistrationMethods.Unknown;
 
         public virtual Organisation Organisation { get; set; }
-
-        public virtual OrganisationAddress Address { get; set; }
 
         public virtual User User { get; set; }
 

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/Administration/AdminDatabaseIntegrityChecksControllerTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/Administration/AdminDatabaseIntegrityChecksControllerTests.cs
@@ -18,7 +18,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers.Administration
 
         private static UserOrganisation CreateUserOrganisation(Organisation org, long userId)
         {
-            return new UserOrganisation {Organisation = org, UserId = userId, Address = new OrganisationAddress()};
+            return new UserOrganisation {Organisation = org, UserId = userId};
         }
 
         private static Organisation CreateOrganisation()

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/Administration/AdminUnconfirmedPinsControllerTests.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/Controllers/Administration/AdminUnconfirmedPinsControllerTests.cs
@@ -21,7 +21,7 @@ namespace GenderPayGap.WebUI.Tests.Controllers.Administration
         private static UserOrganisation CreateUserOrganisation(Organisation org, long userId, DateTime? pinConfirmedDate)
         {
             return new UserOrganisation {
-                Organisation = org, UserId = userId, PINConfirmedDate = pinConfirmedDate, Address = new OrganisationAddress()
+                Organisation = org, UserId = userId, PINConfirmedDate = pinConfirmedDate
             };
         }
 

--- a/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationEnterPinController.cs
+++ b/GenderPayGap.WebUI/Controllers/AddOrganisation/AddOrganisationEnterPinController.cs
@@ -154,7 +154,6 @@ namespace GenderPayGap.WebUI.Controllers.AddOrganisation
                     Sector = userOrg.Organisation.SectorType,
                     Organisation = userOrg.Organisation.OrganisationName,
                     CompanyNo = userOrg.Organisation.CompanyNumber,
-                    Address = userOrg.Address.GetAddressString(),
                     SicCodes = userOrg.Organisation.GetSicCodeIdsString(),
                     UserFirstname = userOrg.User.Firstname,
                     UserLastname = userOrg.User.Lastname,

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationStatusController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationStatusController.cs
@@ -215,7 +215,6 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = inactiveUserOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = inactiveUserOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = inactiveUserOrganisation.ConfirmAttempts,
-                AddressId = inactiveUserOrganisation.AddressId,
                 Method = inactiveUserOrganisation.Method
             };
         }
@@ -241,7 +240,6 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = userOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = userOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = userOrganisation.ConfirmAttempts,
-                AddressId = userOrganisation.AddressId,
                 Method = userOrganisation.Method
             };
         }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminPendingRegistrationsController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminPendingRegistrationsController.cs
@@ -50,7 +50,7 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                     .OrderBy(uo => uo.Modified)
                     .ToList();
 
-            List<UserOrganisation> nonUkAddressRegistrations = allManualRegistrations.Where(uo => uo.Address.IsUkAddress == false).ToList();
+            List<UserOrganisation> nonUkAddressRegistrations = allManualRegistrations.Where(uo => uo.Organisation.GetLatestAddress().IsUkAddress == false).ToList();
             List<UserOrganisation> publicSectorRegistrations = allManualRegistrations.Where(uo => uo.Organisation.SectorType == SectorTypes.Public).ToList();
             List<UserOrganisation> remainingRegistrations = allManualRegistrations.Except(publicSectorRegistrations).Except(nonUkAddressRegistrations).ToList();
 
@@ -170,7 +170,7 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                     Sector = userOrganisation.Organisation.SectorType,
                     Organisation = userOrganisation.Organisation.OrganisationName,
                     CompanyNo = userOrganisation.Organisation.CompanyNumber,
-                    Address = userOrganisation?.Address.GetAddressString(),
+                    Address = userOrganisation.Organisation.GetLatestAddress()?.GetAddressString(),
                     SicCodes = userOrganisation.Organisation.GetSicCodeIdsString(),
                     UserFirstname = userOrganisation.User.Firstname,
                     UserLastname = userOrganisation.User.Lastname,
@@ -207,7 +207,7 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                     Sector = userOrganisation.Organisation.SectorType,
                     Organisation = userOrganisation.Organisation.OrganisationName,
                     CompanyNo = userOrganisation.Organisation.CompanyNumber,
-                    Address = userOrganisation?.Address.GetAddressString(),
+                    Address = userOrganisation?.Organisation.GetLatestAddress()?.GetAddressString(),
                     SicCodes = userOrganisation.Organisation.GetSicCodeIdsString(),
                     UserFirstname = userOrganisation.User.Firstname,
                     UserLastname = userOrganisation.User.Lastname,

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminUserStatusController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminUserStatusController.cs
@@ -139,7 +139,6 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = inactiveUserOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = inactiveUserOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = inactiveUserOrganisation.ConfirmAttempts,
-                AddressId = inactiveUserOrganisation.AddressId,
                 Method = inactiveUserOrganisation.Method
             };
         }
@@ -165,7 +164,6 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = userOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = userOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = userOrganisation.ConfirmAttempts,
-                AddressId = userOrganisation.AddressId,
                 Method = userOrganisation.Method
             };
         }

--- a/GenderPayGap.WebUI/Repositories/RegistrationRepository.cs
+++ b/GenderPayGap.WebUI/Repositories/RegistrationRepository.cs
@@ -103,10 +103,6 @@ namespace GenderPayGap.WebUI.Repositories
             {
                 User = user,
                 Organisation = organisation,
-
-                // The address isn't important for registering organisation that are already in our database, or are from Companies House
-                // But, for manual registrations, we use this to validate the address and mark the address as Active once it is approved
-                Address = organisation.GetLatestAddress()
             };
 
             DecideRegistrationMethod(userOrganisation);

--- a/GenderPayGap.WebUI/Views/AdminPendingRegistrations/Sections/PendingRegistrationsForOrganisationType.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminPendingRegistrations/Sections/PendingRegistrationsForOrganisationType.cshtml
@@ -29,7 +29,7 @@ else
                     <td class="govuk-table__cell">
                         <b>@(userOrg.Organisation.OrganisationName)</b>
                         <br/>
-                        @(userOrg.Address.GetAddressString())
+                        @(userOrg.Organisation.GetLatestAddress()?.GetAddressString())
                     </td>
                     <td class="govuk-table__cell">
                         @(userOrg.Organisation.SectorType)


### PR DESCRIPTION
**What are we removing?**
`UserOrganisation` currently has a foreign key to `OrganisationAddress`.

**Why?**
Currently, **both** `Organisation` and `UserOrganisation` have foreign keys to `OrganisationAddress`.

`OrganisationAddress` conceptually belongs to `Organisation`, not to `UserOrganisation`.

`UserOrganisation` has a foreign key to `Organisation`.
and `Organisation` has a foreign key to `OrganisationAddress`.
so it's easy to navigate from `UserOrganisation` to an `OrganisationAddress`, without needing a direct link (which can get out of date).
