### PR TITLE
4415: Remove unused code: UserOrganisation.Modified

### DIFF
--- a/GenderPayGap.Database/Migrations/20230524111230_Remove UserOrganisation.Modified.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524111230_Remove UserOrganisation.Modified.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524111230_Remove UserOrganisation.Modified")]
+    partial class RemoveUserOrganisationModified
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524111230_Remove UserOrganisation.Modified.cs
+++ b/GenderPayGap.Database/Migrations/20230524111230_Remove UserOrganisation.Modified.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveUserOrganisationModified : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Modified",
+                table: "UserOrganisations");
+
+            migrationBuilder.DropColumn(
+                name: "Modified",
+                table: "InactiveUserOrganisations");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Modified",
+                table: "UserOrganisations",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Modified",
+                table: "InactiveUserOrganisations",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/InactiveUserOrganisation.cs
+++ b/GenderPayGap.Database/Models/InactiveUserOrganisation.cs
@@ -28,8 +28,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Created { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
-        public DateTime Modified { get; set; } = VirtualDateTime.Now;
-        [JsonProperty]
         public RegistrationMethods Method { get; set; } = RegistrationMethods.Unknown;
 
         public virtual Organisation Organisation { get; set; }

--- a/GenderPayGap.Database/Models/UserOrganisation.cs
+++ b/GenderPayGap.Database/Models/UserOrganisation.cs
@@ -28,8 +28,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Created { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
-        public DateTime Modified { get; set; } = VirtualDateTime.Now;
-        [JsonProperty]
         public RegistrationMethods Method { get; set; } = RegistrationMethods.Unknown;
 
         public virtual Organisation Organisation { get; set; }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminDownloadsController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminDownloadsController.cs
@@ -577,7 +577,7 @@ namespace GenderPayGap.WebUI.Controllers
                         record.Address = org.GetLatestAddress()?.GetAddressString();
 
                         UserOrganisation latestUserOrg = org.UserOrganisations
-                            .OrderByDescending(uo => uo.Modified)
+                            .OrderByDescending(uo => uo.Created)
                             .FirstOrDefault(
                                 uo => uo.HasBeenActivated()
                                       && uo.User.Status == UserStatuses.Active);

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationStatusController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationStatusController.cs
@@ -215,7 +215,8 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = inactiveUserOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = inactiveUserOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = inactiveUserOrganisation.ConfirmAttempts,
-                Method = inactiveUserOrganisation.Method
+                Method = inactiveUserOrganisation.Method,
+                Created = inactiveUserOrganisation.Created
             };
         }
 
@@ -240,7 +241,8 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = userOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = userOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = userOrganisation.ConfirmAttempts,
-                Method = userOrganisation.Method
+                Method = userOrganisation.Method,
+                Created = userOrganisation.Created
             };
         }
 

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminPendingRegistrationsController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminPendingRegistrationsController.cs
@@ -47,7 +47,7 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                     .Where(uo => uo.User.Status == UserStatuses.Active)
                     .Where(uo => uo.PINConfirmedDate == null)
                     .Where(uo => uo.Method == RegistrationMethods.Manual)
-                    .OrderBy(uo => uo.Modified)
+                    .OrderBy(uo => uo.Created)
                     .ToList();
 
             List<UserOrganisation> nonUkAddressRegistrations = allManualRegistrations.Where(uo => uo.Organisation.GetLatestAddress().IsUkAddress == false).ToList();

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminUserStatusController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminUserStatusController.cs
@@ -139,7 +139,8 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = inactiveUserOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = inactiveUserOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = inactiveUserOrganisation.ConfirmAttempts,
-                Method = inactiveUserOrganisation.Method
+                Method = inactiveUserOrganisation.Method,
+                Created = inactiveUserOrganisation.Created
             };
         }
 
@@ -164,7 +165,8 @@ namespace GenderPayGap.WebUI.Controllers
                 PINConfirmedDate = userOrganisation.PINConfirmedDate,
                 ConfirmAttemptDate = userOrganisation.ConfirmAttemptDate,
                 ConfirmAttempts = userOrganisation.ConfirmAttempts,
-                Method = userOrganisation.Method
+                Method = userOrganisation.Method,
+                Created = userOrganisation.Created
             };
         }
 

--- a/GenderPayGap.WebUI/Views/AdminPendingRegistrations/Sections/PendingRegistrationsForOrganisationType.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminPendingRegistrations/Sections/PendingRegistrationsForOrganisationType.cshtml
@@ -24,7 +24,7 @@ else
             {
                 <tr class="govuk-table__row">
                     <td class="govuk-table__cell" style="white-space: nowrap;">
-                        @(userOrg.Modified.ToString("d MMM yyyy"))
+                        @(userOrg.Created.ToString("d MMM yyyy"))
                     </td>
                     <td class="govuk-table__cell">
                         <b>@(userOrg.Organisation.OrganisationName)</b>


### PR DESCRIPTION
**What are we removing?**
The `UserOrganisation` table has a `Created` field and a `Modified` field.
We are removing the `Modified` field and just keeping the `Created` field.

**Why?**
The `Modified` field has not been kept up-to-date correctly.
Also, it is being used inconsistently (i.e. mainly to see when a row was created).
We keep other dates on the row for significant events, so there's no need to have a general `Modified` date.