### PR TITLE
4415: Remove unused code: Organisation.Modified

### DIFF
--- a/GenderPayGap.Database/Migrations/20230524114756_Remove Organisation.Modified.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524114756_Remove Organisation.Modified.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524114756_Remove Organisation.Modified")]
+    partial class RemoveOrganisationModified
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524114756_Remove Organisation.Modified.cs
+++ b/GenderPayGap.Database/Migrations/20230524114756_Remove Organisation.Modified.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveOrganisationModified : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Modified",
+                table: "Organisations");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Modified",
+                table: "Organisations",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/Organisation.cs
+++ b/GenderPayGap.Database/Models/Organisation.cs
@@ -38,8 +38,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Created { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
-        public DateTime Modified { get; set; } = VirtualDateTime.Now;
-        [JsonProperty]
         public DateTime? DateOfCessation { get; set; }
         [JsonProperty]
         public long? LatestPublicSectorTypeId { get; set; }


### PR DESCRIPTION
**What are we removing?**
The `Organisation` table has a `Created` field and a `Modified` field.
We are removing the `Modified` field and just keeping the `Created` field.

**Why?**
The `Modified` field has not been kept up-to-date correctly.
It is never used in any code across the application