### PR TITLE
4415: Remove unused code: Return.Created

### DIFF
--- a/GenderPayGap.Database/Migrations/20230524115208_Remove Return.Created.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524115208_Remove Return.Created.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524115208_Remove Return.Created")]
+    partial class RemoveReturnCreated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524115208_Remove Return.Created.cs
+++ b/GenderPayGap.Database/Migrations/20230524115208_Remove Return.Created.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveReturnCreated : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "Returns");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "Returns",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/Extensions/Organisation.cs
+++ b/GenderPayGap.Database/Models/Extensions/Organisation.cs
@@ -118,7 +118,7 @@ namespace GenderPayGap.Database
                 SicSectionNames = sicCodes.Select(sic => sic.SicCode.SicSection.Description).Distinct().ToArray(),
                 SicCodeIds = sicCodes.Select(sicCode => sicCode.SicCodeId.ToString()).Distinct().ToArray(),
                 Address = GetLatestAddress()?.GetAddressString(),
-                LatestReportedDate = submittedReports.Select(x => x.Created).FirstOrDefault(),
+                LatestReportedDate = submittedReports.Select(x => x.Modified).FirstOrDefault(),
                 ReportedYears = submittedReports.Select(x => x.AccountingDate.Year.ToString()).ToArray(),
                 ReportedLateYears =
                     submittedReports.Where(x => x.IsLateSubmission).Select(x => x.AccountingDate.Year.ToString()).ToArray(),
@@ -329,8 +329,8 @@ namespace GenderPayGap.Database
         public Return GetReturnForYearAsOfDate(int reportingYear, DateTime asOfDate)
         {
             return GetAllReturnsForYear(reportingYear)
-                .Where(r => r.Created.Date <= asOfDate.Date)  // Use "X.Date <= Y.Date" to make sure we're not comparing times of day
-                .OrderByDescending(r => r.Created)
+                .Where(r => r.Modified.Date <= asOfDate.Date)  // Use "X.Date <= Y.Date" to make sure we're not comparing times of day
+                .OrderByDescending(r => r.Modified)
                 .FirstOrDefault();
         }
 

--- a/GenderPayGap.Database/Models/Return.cs
+++ b/GenderPayGap.Database/Models/Return.cs
@@ -52,9 +52,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public string StatusDetails { get; set; }
         [JsonProperty]
-        public DateTime Created { get; set; } = VirtualDateTime.Now;
-
-        [JsonProperty]
         public DateTime Modified { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
         public string JobTitle { get; set; }

--- a/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/TestsCommon/TestHelpers/ReturnHelper.cs
+++ b/GenderPayGap.UnitTests/GenderPayGap.WebUI.Tests/TestsCommon/TestHelpers/ReturnHelper.cs
@@ -152,7 +152,6 @@ namespace GenderPayGap.Tests.Common.TestHelpers
                 AccountingDate = snapshotDate,
                 MinEmployees = 250,
                 MaxEmployees = 499,
-                Created = modifiedDate,
                 Modified = modifiedDate,
                 Status = ReturnStatuses.Submitted
             };

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminDownloadsController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminDownloadsController.cs
@@ -300,7 +300,6 @@ namespace GenderPayGap.WebUI.Controllers
                         org.SectorType,
                         Submitted = org.GetReturn(year) != null,
                         ReportingDeadline = ReportingYearsHelper.GetDeadlineForAccountingDate(org.SectorType.GetAccountingStartDate(year)).ToString("d MMMM yyyy"),
-                        SubmittedDate = org.GetReturn(year)?.Created,
                         ModifiedDate = org.GetReturn(year)?.Modified,
                         org.GetReturn(year)?.LateReason
 


### PR DESCRIPTION
**What are we removing?**
The `Return` table has a `Created` field and a `Modified` field.
We are removing the `Created` field and just keeping the `Modified` field.

**Why?**
Both fields are used for the same purpose, but the `Modified` field is used much more than the `Created` date.
We don't keep the two dates up to date consistently, so it's confusing to have both.