### PR TITLE
4415: Remove unused code: OrganisationScope.CampaignId

### DIFF
--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -148,8 +148,6 @@ namespace GenderPayGap.Database
                     entity.Property(e => e.RegisterStatus).HasColumnName("RegisterStatusId");
                     entity.Property(e => e.Status).HasColumnName("StatusId").HasDefaultValueSql("((0))");
 
-                    entity.Property(e => e.CampaignId).HasMaxLength(50);
-
                     entity.Property(e => e.Reason).HasMaxLength(1000);
 
                     entity.Property(e => e.SnapshotDate).HasDefaultValueSql("('1900-01-01T00:00:00.000')");

--- a/GenderPayGap.Database/Migrations/20230524120155_Remove OrganisationScope.CampaignId.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524120155_Remove OrganisationScope.CampaignId.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524120155_Remove OrganisationScope.CampaignId")]
+    partial class RemoveOrganisationScopeCampaignId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524120155_Remove OrganisationScope.CampaignId.cs
+++ b/GenderPayGap.Database/Migrations/20230524120155_Remove OrganisationScope.CampaignId.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveOrganisationScopeCampaignId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CampaignId",
+                table: "OrganisationScopes");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CampaignId",
+                table: "OrganisationScopes",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/OrganisationScope.cs
+++ b/GenderPayGap.Database/Models/OrganisationScope.cs
@@ -27,8 +27,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public string Reason { get; set; }
         [JsonProperty]
-        public string CampaignId { get; set; }
-        [JsonProperty]
         public DateTime SnapshotDate { get; set; }
         [JsonProperty]
         public ScopeRowStatuses Status { get; set; }


### PR DESCRIPTION
**What are we removing?**
The `OrganisationScope` table has a field `CampaignId`.

**Why?**
It's never written or read in any code at all and hasn't been for a long time.