### PR TITLE
4415: Remove unused code: OrganisationScope.RegisterStatus/RegisterStatusDate

### DIFF
--- a/GenderPayGap.Core/Enums.cs
+++ b/GenderPayGap.Core/Enums.cs
@@ -111,20 +111,7 @@ namespace GenderPayGap.Core
             return scopeStatus == ScopeStatuses.PresumedInScope || scopeStatus == ScopeStatuses.PresumedOutOfScope;
         }
     }
-
-    public enum RegisterStatuses
-    {
-
-        Unknown = 0,
-        RegisterSkipped = 1,
-        RegisterPending = 2,
-        RegisterComplete = 3,
-        RegisterCancelled = 4
-
-    }
-
-
-
+    
     public enum OrganisationSizes
     {
 

--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -134,8 +134,6 @@ namespace GenderPayGap.Database
 
                     entity.HasIndex(e => e.OrganisationId);
 
-                    entity.HasIndex(e => e.RegisterStatus);
-
                     entity.HasIndex(e => e.ScopeStatusDate);
 
                     entity.HasIndex(e => e.ScopeStatus);
@@ -145,7 +143,6 @@ namespace GenderPayGap.Database
                     entity.HasIndex(e => e.Status);
 
                     entity.Property(e => e.ScopeStatus).HasColumnName("ScopeStatusId");
-                    entity.Property(e => e.RegisterStatus).HasColumnName("RegisterStatusId");
                     entity.Property(e => e.Status).HasColumnName("StatusId").HasDefaultValueSql("((0))");
 
                     entity.Property(e => e.Reason).HasMaxLength(1000);

--- a/GenderPayGap.Database/Migrations/20230524120630_Remove OrganisationScope.RegisterStatus and RegisterStatusDate.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524120630_Remove OrganisationScope.RegisterStatus and RegisterStatusDate.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524120630_Remove OrganisationScope.RegisterStatus and RegisterStatusDate")]
+    partial class RemoveOrganisationScopeRegisterStatusandRegisterStatusDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524120630_Remove OrganisationScope.RegisterStatus and RegisterStatusDate.cs
+++ b/GenderPayGap.Database/Migrations/20230524120630_Remove OrganisationScope.RegisterStatus and RegisterStatusDate.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveOrganisationScopeRegisterStatusandRegisterStatusDate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OrganisationScopes_RegisterStatusId",
+                table: "OrganisationScopes");
+
+            migrationBuilder.DropColumn(
+                name: "RegisterStatusId",
+                table: "OrganisationScopes");
+
+            migrationBuilder.DropColumn(
+                name: "RegisterStatusDate",
+                table: "OrganisationScopes");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RegisterStatusId",
+                table: "OrganisationScopes",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RegisterStatusDate",
+                table: "OrganisationScopes",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganisationScopes_RegisterStatusId",
+                table: "OrganisationScopes",
+                column: "RegisterStatusId");
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/OrganisationScope.cs
+++ b/GenderPayGap.Database/Models/OrganisationScope.cs
@@ -17,11 +17,6 @@ namespace GenderPayGap.Database
         public ScopeStatuses ScopeStatus { get; set; }
         [JsonProperty]
         public DateTime ScopeStatusDate { get; set; } = VirtualDateTime.Now;
-
-        [JsonProperty]
-        public RegisterStatuses RegisterStatus { get; set; }
-        [JsonProperty]
-        public DateTime RegisterStatusDate { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
         public bool? ReadGuidance { get; set; }
         [JsonProperty]


### PR DESCRIPTION
**What are we removing?**
The `OrganisationScope` table has fields `RegisterStatus` and `RegisterStatusDate`.

**Why?**
They are never written or read in any code at all and haven't been for a long time.
There is another date on `OrganisationScope` to keep track of when the row was created.