### PR TITLE
4415: Remove unused code: Organisation.DateOfCessation

### DIFF
--- a/GenderPayGap.Database/Migrations/20230524151344_Remove Organisation.DateOfCessation.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524151344_Remove Organisation.DateOfCessation.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524151344_Remove Organisation.DateOfCessation")]
+    partial class RemoveOrganisationDateOfCessation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524151344_Remove Organisation.DateOfCessation.cs
+++ b/GenderPayGap.Database/Migrations/20230524151344_Remove Organisation.DateOfCessation.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveOrganisationDateOfCessation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DateOfCessation",
+                table: "Organisations");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateOfCessation",
+                table: "Organisations",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/Organisation.cs
+++ b/GenderPayGap.Database/Models/Organisation.cs
@@ -38,8 +38,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Created { get; set; } = VirtualDateTime.Now;
         [JsonProperty]
-        public DateTime? DateOfCessation { get; set; }
-        [JsonProperty]
         public long? LatestPublicSectorTypeId { get; set; }
 
         [JsonProperty]

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/PurgeOrganisationsJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/PurgeOrganisationsJob.cs
@@ -78,8 +78,7 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
                     org.OrganisationName,
                     org.SectorType,
                     org.Status,
-                    SicCodes = org.GetSicSectionIdsString(),
-                    org.DateOfCessation
+                    SicCodes = org.GetSicSectionIdsString()
                 });
 
             // Un-register all users for this Organisation


### PR DESCRIPTION
**What are we removing?**
The `Organisation` table has a field `DateOfCessation`.

**Why?**
It's never written or read in any code (except a single log message) and hasn't been for a long time.