### PR TITLE
4415: Remove unused code: OrganisationAddress.CreatedByUserId

### DIFF
--- a/GenderPayGap.Database/Migrations/20230524151748_Remove OrganisationAddress.CreatedByUserId.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524151748_Remove OrganisationAddress.CreatedByUserId.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524151748_Remove OrganisationAddress.CreatedByUserId")]
+    partial class RemoveOrganisationAddressCreatedByUserId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524151748_Remove OrganisationAddress.CreatedByUserId.cs
+++ b/GenderPayGap.Database/Migrations/20230524151748_Remove OrganisationAddress.CreatedByUserId.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveOrganisationAddressCreatedByUserId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedByUserId",
+                table: "OrganisationAddresses");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "CreatedByUserId",
+                table: "OrganisationAddresses",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/OrganisationAddress.cs
+++ b/GenderPayGap.Database/Models/OrganisationAddress.cs
@@ -12,8 +12,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public long AddressId { get; set; }
         [JsonProperty]
-        public long CreatedByUserId { get; set; }
-        [JsonProperty]
         public string Address1 { get; set; }
         [JsonProperty]
         public string Address2 { get; set; }

--- a/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/PurgeOrganisationsJob.cs
+++ b/GenderPayGap.WebUI/BackgroundJobs/ScheduledJobs/PurgeOrganisationsJob.cs
@@ -61,7 +61,6 @@ namespace GenderPayGap.WebUI.BackgroundJobs.ScheduledJobs
                 // We need the AsEnumerable here because EF gets upset about method calls - so we get the list at this point and then can filter it using a method call
                 .AsEnumerable()
                 .Where(o => !o.UserOrganisations.Any(uo => uo.Method == RegistrationMethods.Manual || uo.HasBeenActivated() || uo.PINSentDate > deadline))
-                .Where(o => !o.OrganisationAddresses.Any(a => a.CreatedByUserId == -1))
                 .ToList();
         }
 

--- a/GenderPayGap.WebUI/Services/OrganisationService.cs
+++ b/GenderPayGap.WebUI/Services/OrganisationService.cs
@@ -102,7 +102,6 @@ namespace GenderPayGap.WebUI.Services
 
             AddOrganisationAddress(
                 organisation,
-                requestingUser,
                 poBox,
                 address1,
                 address2,
@@ -244,8 +243,8 @@ namespace GenderPayGap.WebUI.Services
             dataRepository.Insert(organisationAddress);
         }
 
-        private void AddOrganisationAddress(Organisation organisation,
-            User user,
+        private void AddOrganisationAddress(
+            Organisation organisation,
             string poBox,
             string address1,
             string address2,
@@ -274,8 +273,7 @@ namespace GenderPayGap.WebUI.Services
                 StatusDetails = "Manually registered",
                 StatusDate = VirtualDateTime.Now,
 
-                Organisation = organisation,
-                CreatedByUserId = user.UserId
+                Organisation = organisation
             };
 
             organisation.OrganisationAddresses.Add(organisationAddress);


### PR DESCRIPTION
**What are we removing?**
The `OrganisationAddress` table has a field `CreatedByUserId`.

**Why?**
The Address is normally now created by the system, pulling the data in from Companies House.
We don't display or use the "created by user" anywhere in the code, except one place where it's unnecessary.