### PR TITLE
4415: Remove unused code: OrganisationPublicSectorType.Retired

### DIFF
--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -439,8 +439,6 @@ namespace GenderPayGap.Database
 
                     entity.HasIndex(e => e.Created);
 
-                    entity.HasIndex(e => e.Retired);
-
                     entity.HasIndex(e => e.PublicSectorTypeId);
 
                     entity.HasIndex(e => e.OrganisationId);

--- a/GenderPayGap.Database/Migrations/20230524152018_Remove OrganisationPublicSectorType.Retired.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524152018_Remove OrganisationPublicSectorType.Retired.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524152018_Remove OrganisationPublicSectorType.Retired")]
+    partial class RemoveOrganisationPublicSectorTypeRetired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524152018_Remove OrganisationPublicSectorType.Retired.cs
+++ b/GenderPayGap.Database/Migrations/20230524152018_Remove OrganisationPublicSectorType.Retired.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemoveOrganisationPublicSectorTypeRetired : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OrganisationPublicSectorTypes_Retired",
+                table: "OrganisationPublicSectorTypes");
+
+            migrationBuilder.DropColumn(
+                name: "Retired",
+                table: "OrganisationPublicSectorTypes");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Retired",
+                table: "OrganisationPublicSectorTypes",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganisationPublicSectorTypes_Retired",
+                table: "OrganisationPublicSectorTypes",
+                column: "Retired");
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/OrganisationPublicSectorType.cs
+++ b/GenderPayGap.Database/Models/OrganisationPublicSectorType.cs
@@ -26,9 +26,6 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public DateTime Created { get; set; } = VirtualDateTime.Now;
 
-        [JsonProperty]
-        public DateTime? Retired { get; set; }
-
         public virtual PublicSectorType PublicSectorType { get; set; }
 
         public virtual ICollection<Organisation> Organisations { get; set; }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationSectorController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminOrganisationSectorController.cs
@@ -141,8 +141,6 @@ namespace GenderPayGap.WebUI.Controllers.Admin
 
             AuditChange(viewModel, organisation, newPublicSectorType);
 
-            RetireExistingOrganisationPublicSectorTypesForOrganisation(organisation);
-
             AddNewOrganisationPublicSectorType(organisation, viewModel.SelectedPublicSectorTypeId.Value);
 
             dataRepository.SaveChanges();
@@ -165,18 +163,6 @@ namespace GenderPayGap.WebUI.Controllers.Admin
                     viewModel.Reason
                 },
                 User);
-        }
-
-        private void RetireExistingOrganisationPublicSectorTypesForOrganisation(Organisation organisation)
-        {
-            var organisationPublicSectorTypes = dataRepository.GetAll<OrganisationPublicSectorType>()
-                .Where(opst => opst.OrganisationId == organisation.OrganisationId)
-                .ToList();
-
-            foreach (OrganisationPublicSectorType organisationPublicSectorType in organisationPublicSectorTypes)
-            {
-                organisationPublicSectorType.Retired = VirtualDateTime.Now;
-            }
         }
 
         private void AddNewOrganisationPublicSectorType(Organisation organisation, int publicSectorTypeId)


### PR DESCRIPTION
**What are we removing?**
The `OrganisationPublicSectorType` table has a field `Retired`.

**Why?**
On each `Organisation` there is a link to the latest `OrganisationPublicSectorType`.
We store a history of `OrganisationPublicSectorType` for each `Organisation`.
We store the `Created` date, so we can use this to sort the rows if needed, and the property `Organisation.LatestPublicSectorType` means it is easy to navigate directly to the active row, without needing a `Retired` property.
The `Retired` property isn't used anywhere in the code, apart from maintaining its own state.