### PR TITLE
4415: Remove unused code: OrganisationPublicSectorType.Organisations

### DIFF
--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -119,7 +119,7 @@ namespace GenderPayGap.Database
                     entity.Property(e => e.StatusDetails).HasMaxLength(255);
 
                     entity.HasOne(d => d.LatestPublicSectorType)
-                        .WithMany(x => x.Organisations)
+                        .WithMany()
                         .HasForeignKey(d => d.LatestPublicSectorTypeId)
                         .HasConstraintName("FK_dbo.Organisations_dbo.OrganisationPublicSectorTypes_LatestPublicSectorTypeId");
                 });

--- a/GenderPayGap.Database/Migrations/GpgDatabaseContextModelSnapshot.cs
+++ b/GenderPayGap.Database/Migrations/GpgDatabaseContextModelSnapshot.cs
@@ -1189,7 +1189,7 @@ namespace GenderPayGap.Database.Migrations
             modelBuilder.Entity("GenderPayGap.Database.Organisation", b =>
                 {
                     b.HasOne("GenderPayGap.Database.OrganisationPublicSectorType", "LatestPublicSectorType")
-                        .WithMany("Organisations")
+                        .WithMany()
                         .HasForeignKey("LatestPublicSectorTypeId")
                         .HasConstraintName("FK_dbo.Organisations_dbo.OrganisationPublicSectorTypes_LatestPublicSectorTypeId");
                 });

--- a/GenderPayGap.Database/Models/OrganisationPublicSectorType.cs
+++ b/GenderPayGap.Database/Models/OrganisationPublicSectorType.cs
@@ -28,7 +28,5 @@ namespace GenderPayGap.Database
 
         public virtual PublicSectorType PublicSectorType { get; set; }
 
-        public virtual ICollection<Organisation> Organisations { get; set; }
-
     }
 }


### PR DESCRIPTION
**What are we removing?**
The `OrganisationPublicSectorType` C# class has an Entity Framework navigation property `Organisations`.

**Why?**
This property is misleading.
Each `OrganisationPublicSectorType` only has 1 `Organisation`, not multiple.
Also, we never use this navigation property in any code.