### PR TITLE
4415: Remove unused code: PublicSectorType.Created

### DIFF
--- a/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
+++ b/GenderPayGap.Database/GpgDatabaseContext.OnModelCreating.cs
@@ -425,8 +425,6 @@ namespace GenderPayGap.Database
                     entity.Property(e => e.Description)
                         .HasMaxLength(250)
                         .IsRequired();
-
-                    entity.Property(e => e.Created).IsRequired();
                 });
 
             #endregion

--- a/GenderPayGap.Database/Migrations/20230524153611_Remove PublicSectorType.Created.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230524153611_Remove PublicSectorType.Created.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230524153611_Remove PublicSectorType.Created")]
+    partial class RemovePublicSectorTypeCreated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230524153611_Remove PublicSectorType.Created.cs
+++ b/GenderPayGap.Database/Migrations/20230524153611_Remove PublicSectorType.Created.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class RemovePublicSectorTypeCreated : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "PublicSectorTypes");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "PublicSectorTypes",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/PublicSectorType.cs
+++ b/GenderPayGap.Database/Models/PublicSectorType.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 
 namespace GenderPayGap.Database
 {
-
     [Serializable]
     [JsonObject(MemberSerialization.OptIn)]
     public class PublicSectorType
@@ -15,9 +14,6 @@ namespace GenderPayGap.Database
 
         [JsonProperty]
         public string Description { get; set; }
-
-        [JsonProperty]
-        public DateTime Created { get; set; } = VirtualDateTime.Now;
 
         public override bool Equals(object obj)
         {
@@ -32,5 +28,4 @@ namespace GenderPayGap.Database
         }
 
     }
-
 }


### PR DESCRIPTION
**What are we removing?**
The `PublicSectorType` table has a column `Created`.

**Why?**
All rows were created at the same time, so this date is not helpful.
This property is not used by any code.