### PR TITLE
4415: Remove unused code: relating to OrganisationReference

### DIFF
--- a/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationSearchViewModel.cs
+++ b/GenderPayGap.WebUI/Models/AddOrganisation/AddOrganisationSearchViewModel.cs
@@ -28,15 +28,8 @@ namespace GenderPayGap.WebUI.Models.AddOrganisation
         public long? OrganisationId { get; set; }
         public string EncryptedOrganisationId { get; set; }
         public string CompanyNumber { get; set; }
-        public List<AddOrganisationSearchResultOrganisationIdentifier> Identifiers { get; set; } = new List<AddOrganisationSearchResultOrganisationIdentifier>();
     }
 
-    public class AddOrganisationSearchResultOrganisationIdentifier
-    {
-        public string IdentifierType { get; set; }
-        public string Identifier { get; set; }
-    }
-    
     public class AddOrganisationSeparateSearchResults
     {
         public List<AddOrganisationSearchResult> SearchResultsFromOurDatabase { get; set; }

--- a/GenderPayGap.WebUI/Search/AddOrganisationSearchService.cs
+++ b/GenderPayGap.WebUI/Search/AddOrganisationSearchService.cs
@@ -283,15 +283,6 @@ namespace GenderPayGap.WebUI.Search
                             searchResult.OrganisationAddress = org.Address;
                         }
 
-                        if (!string.IsNullOrWhiteSpace(searchResult.CompanyNumber))
-                        {
-                            searchResult.Identifiers.Add(new AddOrganisationSearchResultOrganisationIdentifier
-                            {
-                                IdentifierType = "Company number",
-                                Identifier = searchResult.CompanyNumber
-                            });
-                        }
-
                         return searchResult;
                     })
                 .ToList();

--- a/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
+++ b/GenderPayGap.WebUI/Views/AddOrganisationSearch/Search.cshtml
@@ -210,12 +210,10 @@
                                 @(organisation.OrganisationAddress)
 
                                 <span class="govuk-!-font-size-16">
-                                    @foreach (AddOrganisationSearchResultOrganisationIdentifier identifier in organisation.Identifiers)
+                                    @if (!string.IsNullOrWhiteSpace(organisation.CompanyNumber))
                                     {
                                         <br />
-                                        // ":" is a special character in C# Razor
-                                        // To show an actual ":", we need to write "@::"
-                                        @(identifier.IdentifierType)@:: @(identifier.Identifier)
+                                        <span>Company number: @(organisation.CompanyNumber)</span>
                                     }
                                 </span>
                             </div>

--- a/GenderPayGap.WebUI/Views/AdminPendingRegistrations/Sections/PendingRegistrationSimilarOrganisation.cshtml
+++ b/GenderPayGap.WebUI/Views/AdminPendingRegistrations/Sections/PendingRegistrationSimilarOrganisation.cshtml
@@ -21,10 +21,10 @@
         @(Model.OrganisationAddress)
 
         <span class="govuk-!-font-size-16">
-            @foreach (AddOrganisationSearchResultOrganisationIdentifier identifier in Model.Identifiers)
+            @if (!string.IsNullOrWhiteSpace(Model.CompanyNumber))
             {
                 <br />
-                <span>@(identifier.IdentifierType): @(identifier.Identifier)</span>
+                <span>Company number: @(Model.CompanyNumber)</span>
             }
         </span>
     </div>


### PR DESCRIPTION
In an earlier PR, I removed the unused `OrganisationReference` table.
This allows us to simplify some code.

The SearchService has a class `OrganisationIdentifier` which allows multiple identifiers for each organisation.
In reality, there is is now only ever one identifier that we use in this context: CompanyNumber.
So we can simplify the code to reflect this.