### PR TITLE
4411: Manage admin users (part 1 of 2)

### DIFF
--- a/GenderPayGap.Core/Enums.cs
+++ b/GenderPayGap.Core/Enums.cs
@@ -14,6 +14,12 @@ namespace GenderPayGap.Core
 
     }
 
+    public enum UserRole
+    {
+        Employer = 0,
+        Admin = 1
+    }
+    
     public enum OrganisationStatuses : byte
     {
 
@@ -348,4 +354,5 @@ namespace GenderPayGap.Core
         VoluntarilyReported,
         SubmittedLate,
     }
+
 }

--- a/GenderPayGap.Database/Migrations/20230525132055_Add User.UserRole.Designer.cs
+++ b/GenderPayGap.Database/Migrations/20230525132055_Add User.UserRole.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GenderPayGap.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GenderPayGap.Database.Migrations
 {
     [DbContext(typeof(GpgDatabaseContext))]
-    partial class GpgDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20230525132055_Add User.UserRole")]
+    partial class AddUserUserRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GenderPayGap.Database/Migrations/20230525132055_Add User.UserRole.cs
+++ b/GenderPayGap.Database/Migrations/20230525132055_Add User.UserRole.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GenderPayGap.Database.Migrations
+{
+    public partial class AddUserUserRole : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "UserRole",
+                table: "Users",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserRole",
+                table: "Users");
+        }
+    }
+}

--- a/GenderPayGap.Database/Models/User.cs
+++ b/GenderPayGap.Database/Models/User.cs
@@ -41,6 +41,8 @@ namespace GenderPayGap.Database
         [JsonProperty]
         public HashingAlgorithm HashingAlgorithm { get; set; }
         [JsonProperty]
+        public UserRole UserRole { get; set; }
+        [JsonProperty]
         public string EmailVerifyHash { get; set; }
         [JsonProperty]
         public DateTime? EmailVerifySendDate { get; set; }

--- a/GenderPayGap.WebUI/Controllers/Admin/AdminManageAdminUsersController.cs
+++ b/GenderPayGap.WebUI/Controllers/Admin/AdminManageAdminUsersController.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GenderPayGap.Core;
+using GenderPayGap.Core.Interfaces;
+using GenderPayGap.Database;
+using GenderPayGap.Extensions;
+using GenderPayGap.WebUI.Helpers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GenderPayGap.WebUI.Controllers.Admin
+{
+    [Authorize(Roles = LoginRoles.GpgAdmin)]
+    [Route("admin/manage-admin-users")]
+    public class AdminManageAdminUsersController : Controller
+    {
+
+        private readonly IDataRepository dataRepository;
+
+        public AdminManageAdminUsersController(IDataRepository dataRepository)
+        {
+            this.dataRepository = dataRepository;
+        }
+
+
+        [HttpGet("migrate-admin-users")]
+        public IActionResult MigrateAdminUsers()
+        {
+            List<User> adminUsers = dataRepository.GetAll<User>()
+                .AsEnumerable()
+                .Where(u => u.EmailAddress.IsEmailAddress())
+                .Where(u => u.IsAdministrator())
+                .ToList();
+
+            foreach (User adminUser in adminUsers)
+            {
+                adminUser.UserRole = UserRole.Admin;
+            }
+            
+            dataRepository.SaveChanges();
+
+            List<string> adminEmails = adminUsers.Select(u => u.EmailAddress).ToList();
+
+            return Json(adminEmails);
+        }
+
+    }
+}


### PR DESCRIPTION
At the moment, admin users are managed via a config setting.
This PR changes that to use a database column.

This PR contains a database migration + data migration.

After this has been run, there is another PR after this which will allow admins to manage other admin users etc.